### PR TITLE
Make the route snapper be able to draw free-form segments too

### DIFF
--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -13,7 +13,6 @@ export class RouteSnapper {
     console.timeEnd("Deserialize and setup JsRouteSnapper");
     console.log("JsRouteSnapper ready, waiting for idle event");
     this.active = false;
-    this.snapMode = true;
 
     // on(load) is a bad trigger, because downloading the RouteSnapper input can race. Just wait for the map to be usable.
     this.map.once("idle", () => {
@@ -35,7 +34,7 @@ export class RouteSnapper {
             "match",
             ["get", "type"],
             "hovered",
-            "yellow",
+            "green",
             "important",
             "red",
             "unimportant",
@@ -80,13 +79,13 @@ export class RouteSnapper {
           .unproject(e.point)
           .distanceTo(this.map.unproject(nearbyPoint));
         if (
-          this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters, this.snapMode)
+          this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters)
         ) {
           this.#redraw();
         }
       });
 
-      this.map.on("click", () => {
+      this.map.on("click", (e) => {
         if (!this.active) {
           return;
         }
@@ -119,6 +118,27 @@ export class RouteSnapper {
         if (e.key == "Enter") {
           e.preventDefault();
           this.#finishSnapping();
+        }
+      });
+
+      document.addEventListener("keydown", (e) => {
+        if (!this.active) {
+          return;
+        }
+        if (e.key == "Shift") {
+          e.preventDefault();
+          this.inner.setSnapMode(false);
+          this.#redraw();
+        }
+      });
+      document.addEventListener("keyup", (e) => {
+        if (!this.active) {
+          return;
+        }
+        if (e.key == "Shift") {
+          e.preventDefault();
+          this.inner.setSnapMode(true);
+          this.#redraw();
         }
       });
 

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -13,6 +13,7 @@ export class RouteSnapper {
     console.timeEnd("Deserialize and setup JsRouteSnapper");
     console.log("JsRouteSnapper ready, waiting for idle event");
     this.active = false;
+    this.snapMode = true;
 
     // on(load) is a bad trigger, because downloading the RouteSnapper input can race. Just wait for the map to be usable.
     this.map.once("idle", () => {
@@ -79,7 +80,7 @@ export class RouteSnapper {
           .unproject(e.point)
           .distanceTo(this.map.unproject(nearbyPoint));
         if (
-          this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters)
+          this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters, this.snapMode)
         ) {
           this.#redraw();
         }

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -85,7 +85,7 @@ export class RouteSnapper {
         }
       });
 
-      this.map.on("click", (e) => {
+      this.map.on("click", () => {
         if (!this.active) {
           return;
         }


### PR DESCRIPTION
#43 
Hold down shift to draw freehand.

https://user-images.githubusercontent.com/1664407/205376229-d28465dd-0047-4e06-bbfb-36ee800b1e99.mp4



The interaction needs more work, but a solid step forward. Biggest next things to figure out:

1) Drag freehand points too
2) Maybe auto-snap after ending a freehand segment. Right now you have to add an extra point that snaps to an intersection before you can continue the route
3) Display context-sensitive instructions saying things like "hold shift"