### PR TITLE
Fade out everything outside of the boundary

### DIFF
--- a/components/BoundaryLayer.svelte
+++ b/components/BoundaryLayer.svelte
@@ -1,7 +1,8 @@
 <script>
   import authoritiesUrl from "../authorities.geojson?url";
   import geojsonExtent from "@mapbox/geojson-extent";
-  import { drawLine } from "../style.js";
+  import mask from "@turf/mask";
+  import { drawPolygon } from "../style.js";
   import { onMount, getContext } from "svelte";
 
   export let authorityName;
@@ -22,12 +23,12 @@
 
     map.addSource("boundary", {
       type: "geojson",
-      data: boundaryGeojson,
+      data: mask(boundaryGeojson),
     });
     map.addLayer({
       id: "boundary",
       source: "boundary",
-      ...drawLine("black", 3, 0.5),
+      ...drawPolygon("black", 0.5),
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mapbox/geojson-extent": "^1.0.1",
         "@mapbox/mapbox-gl-draw": "^1.3.0",
+        "@turf/mask": "^6.5.0",
         "carbon-components-svelte": "^0.70.13",
         "maplibre-gl": "^2.4.0",
         "route-snapper": "^0.1.0",
@@ -605,6 +606,26 @@
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-6.5.0.tgz",
+      "integrity": "sha512-RQha4aU8LpBrmrkH8CPaaoAfk0Egj5OuXtv6HuCQnHeGNOQt3TQVibTA3Sh4iduq4EPxnZfDjgsOeKtrCA19lg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "polygon-clipping": "^0.15.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/geojson": {
@@ -1807,6 +1828,14 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/polygon-clipping": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.3.tgz",
+      "integrity": "sha512-ho0Xx5DLkgxRx/+n4O74XyJ67DcyN3Tu9bGYKsnTukGAW6ssnuak6Mwcyb1wHy9MZc9xsUWqIoiazkZB5weECg==",
+      "dependencies": {
+        "splaytree": "^3.1.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.20",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
@@ -2085,6 +2114,11 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
+    },
+    "node_modules/splaytree": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.1.tgz",
+      "integrity": "sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww=="
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@mapbox/geojson-extent": "^1.0.1",
     "@mapbox/mapbox-gl-draw": "^1.3.0",
+    "@turf/mask": "^6.5.0",
     "carbon-components-svelte": "^0.70.13",
     "maplibre-gl": "^2.4.0",
     "route-snapper": "^0.1.0",


### PR DESCRIPTION
![Screenshot from 2023-01-09 10-50-48](https://user-images.githubusercontent.com/1664407/211291434-05e04158-e665-4487-bfa0-1ffd0775545b.png)
![Screenshot from 2023-01-09 10-50-40](https://user-images.githubusercontent.com/1664407/211291440-24a20412-0775-40e0-a8ea-e4c5d4420e91.png)

Previously:
![Screenshot from 2023-01-09 10-51-30](https://user-images.githubusercontent.com/1664407/211291574-7545de28-8de3-4688-a27f-0e79cccdf3b0.png)


This makes it much easier to distinguish the inside and outside of the study area, and should make it clear why the route tool stops at the boundary. But it might discourage schemes that cross boundaries, especially because the mask color is so dark. Should we do this or not?