### PR TITLE
Defining origin of generated geojson files

### DIFF
--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -77,15 +77,11 @@
         if (result["origin"] || result.hasOwnProperty("authority")) {
           gjScheme.set(result);
         } else {
-          console.log(
-            `Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`
-          );
           window.alert(
             `Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`
           );
         }
       } catch (err) {
-        console.log(`Couldn't load from a file: ${err}`);
         window.alert(`Couldn't load scheme from a file: ${err}`);
       }
     };

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -69,13 +69,9 @@
     if (geojson.hasOwnProperty("origin")) {
       let origin = geojson.origin;
       return origin.startsWith("atip-");
-    } else if (
-      geojson.hasOwnProperty("authority") &&
-      !geojson.hasOwnProperty("origin")
-    ) {
-      return true;
     } else {
-      return false;
+      return geojson.hasOwnProperty("authority");
+    }
     }
   }
 

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -73,9 +73,8 @@
       try {
         let result = JSON.parse(e.target.result);
 
-        // test if origin field is set
-        // if not then file is not from atip
-        if (result["origin"]) {
+        // check for origin or authority foreign member to confirm atip generated
+        if (result["origin"] || result.hasOwnProperty("authority")) {
           gjScheme.set(result);
         } else {
           console.log(

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -71,7 +71,17 @@
     // TODO Should we prompt before deleting the current scheme?
     reader.onload = (e) => {
       try {
-        gjScheme.set(JSON.parse(e.target.result));
+
+        let result = JSON.parse(e.target.result);
+
+        // test if origin field is set
+        // if not then file is not from atip
+        if(result['origin']) {
+          gjScheme.set(result);
+        } else {
+          console.log(`Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`);
+          window.alert(`Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`);
+        }
       } catch (err) {
         console.log(`Couldn't load from a file: ${err}`);
         window.alert(`Couldn't load scheme from a file: ${err}`);

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -65,6 +65,20 @@
     document.body.removeChild(element);
   }
 
+  function checkOrigin(geojson) {
+    if (geojson.hasOwnProperty("origin")) {
+      let origin = geojson.origin;
+      return origin.startsWith("atip-");
+    } else if (
+      geojson.hasOwnProperty("authority") &&
+      !geojson.hasOwnProperty("origin")
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   function loadFile(e) {
     const reader = new FileReader();
     // TODO No await? :(
@@ -74,10 +88,7 @@
         let result = JSON.parse(e.target.result);
 
         // check for origin or authority foreign member to confirm atip generated
-        if (
-          result.hasOwnProperty("origin") ||
-          result.hasOwnProperty("authority")
-        ) {
+        if (checkOrigin(result)) {
           gjScheme.set(result);
         } else {
           window.alert(

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -19,7 +19,7 @@
   gjScheme.update((gj) => {
     gj.authority = authorityName;
     // we could probably be more sophisticated here and set version more centrally
-    gj.origin = "atip-v1"
+    gj.origin = "atip-v1";
     return gj;
   });
 
@@ -71,16 +71,19 @@
     // TODO Should we prompt before deleting the current scheme?
     reader.onload = (e) => {
       try {
-
         let result = JSON.parse(e.target.result);
 
         // test if origin field is set
         // if not then file is not from atip
-        if(result['origin']) {
+        if (result["origin"]) {
           gjScheme.set(result);
         } else {
-          console.log(`Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`);
-          window.alert(`Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`);
+          console.log(
+            `Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`
+          );
+          window.alert(
+            `Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`
+          );
         }
       } catch (err) {
         console.log(`Couldn't load from a file: ${err}`);

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -18,6 +18,8 @@
 
   gjScheme.update((gj) => {
     gj.authority = authorityName;
+    // we could probably be more sophisticated here and set version more centrally
+    gj.origin = "atip-v1"
     return gj;
   });
 

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -74,7 +74,10 @@
         let result = JSON.parse(e.target.result);
 
         // check for origin or authority foreign member to confirm atip generated
-        if (result["origin"] || result.hasOwnProperty("authority")) {
+        if (
+          result.hasOwnProperty("origin") ||
+          result.hasOwnProperty("authority")
+        ) {
           gjScheme.set(result);
         } else {
           window.alert(

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -72,7 +72,6 @@
     } else {
       return geojson.hasOwnProperty("authority");
     }
-    }
   }
 
   function loadFile(e) {


### PR DESCRIPTION
This PR attempts to start to address #65 

In particular including some validation to check an uploaded geojson is one that was generated from the ATIP platform.

Summary of changes:
- Adding an origin field to generated geojson that specifies `atip-v1`
- Adding a validation step in `loadFile` that checks for this origin field

Outstanding tasks:
- [ ] Make backwards compatible