### PR TITLE
Update mapbox-gl-draw, fixing the active styling on the controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mapbox/geojson-extent": "^1.0.1",
-        "@mapbox/mapbox-gl-draw": "^1.3.0",
+        "@mapbox/mapbox-gl-draw": "^1.4.0",
         "@turf/mask": "^6.5.0",
         "carbon-components-svelte": "^0.70.13",
         "maplibre-gl": "^2.4.0",
@@ -505,12 +505,12 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-draw": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.3.0.tgz",
-      "integrity": "sha512-B+KWK+dAgzLHMNyKVuuMRfjeSlQ77MhNLdfpQQpbp3pkhnrdmydDe3ixto1Ua78hktNut0WTrAaD8gYu4PVcjA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.0.tgz",
+      "integrity": "sha512-eFhdmW44ZKJt+9iDc5TBP0+hc88VjTrp8Ui1cUjrwElziSk3IerSs0WdkQvdyy9YFn1HODL65zfau/QfMy3Bbw==",
       "dependencies": {
         "@mapbox/geojson-area": "^0.2.2",
-        "@mapbox/geojson-extent": "^1.0.0",
+        "@mapbox/geojson-extent": "^1.0.1",
         "@mapbox/geojson-normalize": "^0.0.1",
         "@mapbox/point-geometry": "^0.1.0",
         "hat": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@mapbox/geojson-extent": "^1.0.1",
-    "@mapbox/mapbox-gl-draw": "^1.3.0",
+    "@mapbox/mapbox-gl-draw": "^1.4.0",
     "@turf/mask": "^6.5.0",
     "carbon-components-svelte": "^0.70.13",
     "maplibre-gl": "^2.4.0",


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/1664407/216993545-361ffb16-237a-4559-b761-432574e33654.mp4

After:

https://user-images.githubusercontent.com/1664407/216993568-aa367f9b-2af1-489e-93f7-c9893b861679.mp4

Note the polygon tool is shaded when active on the 2nd. The other changes in https://github.com/mapbox/mapbox-gl-draw/blob/main/CHANGELOG.md don't affect us.