### PR TITLE
Update route-snapper. Users can now prevent routes from doubling back,

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.5.tgz",
-      "integrity": "sha512-LwFzvprXE2xYKDLU1DZY6qH9ci90l8zrPAaUi4sTzj6V6JqRfsHK9GZyLIH85BW1cqCk2kGE12Mp5fvM0+r8Mw=="
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.7.tgz",
+      "integrity": "sha512-VQ2iYb6m2XytmdBeK/Dg+SfxZGcNR9rP+z6CTNifzduJOX92jsJqVd/NAnvgdOWiidIkzAgi4lyN3uZrCXCAzg=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",


### PR DESCRIPTION
and new routes drawn will have a length_meters property


https://user-images.githubusercontent.com/1664407/218472870-0d2a75b0-2b1a-4075-a830-ced88b656b1a.mp4

For convenience, you can play with the new option at https://dabreegster.github.io/route_snapper/ too. Note this change also starts adding a `length_meters` property to the GeoJSON. Files people submit may or may not contain this field, since people might've used an old version of ATIP. We can easily "backfill" this on the analysis side if needed.