### PR TITLE
adjust validation criteria

### DIFF
--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -75,7 +75,10 @@
       let origin = geojson.origin;
       return origin.startsWith("atip-");
     } else {
-      return geojson.hasOwnProperty("authority");
+      return (
+        geojson.hasOwnProperty("authority") ||
+        geojson.hasOwnProperty("scheme_name")
+      );
     }
   }
 

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -16,13 +16,6 @@
     window.localStorage.setItem(authorityName, JSON.stringify(geojsonToSave()))
   );
 
-  gjScheme.update((gj) => {
-    gj.authority = authorityName;
-    // we could probably be more sophisticated here and set version more centrally
-    gj.origin = "atip-v1";
-    return gj;
-  });
-
   function clearAll() {
     if (
       confirm(
@@ -50,6 +43,9 @@
   function exportToGeojson() {
     let geojson = geojsonToSave();
     var filename = authorityName;
+    geojson.authority = authorityName;
+    // we could probably be more sophisticated here and set version more centrally
+    geojson.origin = "atip-v1";
     // Include the scheme name if it's set
     if (geojson["scheme_name"]) {
       filename += "_" + geojson["scheme_name"];


### PR DESCRIPTION
This PR attempts to resolve issues as seen in #78 where previously downloaded files where schemes were cleared removed foreign members used for validation (origin and authority).

It introduces:
- Validation on either "authority" or "scheme_name"
- migrates the creation of validation foreign members to exportToGeoJson (this is to ensure if you upload an old file where these foreign members ("authority","origin") don't exist they are added)

Tested instances:

✅ Current exported geojson from prod ATIP
✅ Exported geojson from #78 where validation foreign members were cleared
❌ If you exported a .txt when foreign members were cleared and didn't add a scheme name this does not work (but this also doesn't work currently either)