### PR TITLE
Remove Input validation against foreign members

### DIFF
--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -66,31 +66,13 @@
     document.body.removeChild(element);
   }
 
-  function checkOrigin(geojson) {
-    if (geojson.hasOwnProperty("origin")) {
-      let origin = geojson.origin;
-      return origin.startsWith("atip-");
-    } else {
-      return geojson.hasOwnProperty("authority");
-    }
-  }
-
   function loadFile(e) {
     const reader = new FileReader();
     // TODO No await? :(
     // TODO Should we prompt before deleting the current scheme?
     reader.onload = (e) => {
       try {
-        let result = JSON.parse(e.target.result);
-
-        // check for origin or authority foreign member to confirm atip generated
-        if (checkOrigin(result)) {
-          gjScheme.set(result);
-        } else {
-          window.alert(
-            `Non-ATIP based geojson uploaded. Please try again with an ATIP generated file.`
-          );
-        }
+        gjScheme.set(JSON.parse(e.target.result));
       } catch (err) {
         window.alert(`Couldn't load scheme from a file: ${err}`);
       }

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -16,13 +16,6 @@
     window.localStorage.setItem(authorityName, JSON.stringify(geojsonToSave()))
   );
 
-  gjScheme.update((gj) => {
-    gj.authority = authorityName;
-    // we could probably be more sophisticated here and set version more centrally
-    gj.origin = "atip-v1";
-    return gj;
-  });
-
   function clearAll() {
     if (
       confirm(
@@ -50,6 +43,9 @@
   function exportToGeojson() {
     let geojson = geojsonToSave();
     var filename = authorityName;
+    geojson.authority = authorityName;
+    // we could probably be more sophisticated here and set version more centrally
+    geojson.origin = "atip-v1";
     // Include the scheme name if it's set
     if (geojson["scheme_name"]) {
       filename += "_" + geojson["scheme_name"];


### PR DESCRIPTION
This PR removes checkOrigin based input validation and moves foreign member creation ("authority" and "origin") to the exportGeojson function.

It aims to address issues described in #78 and #72 

Tested instances:
✅ Current prod geojson - [Warwickshire-all-fields.txt](https://github.com/acteng/atip/files/10742576/Warwickshire-all-fields.txt)
✅ Only scheme_name (generated from a cleared map and redraw) - [Warwickshire_A47.Hinckley.Road-just-scheme-name.txt](https://github.com/acteng/atip/files/10742578/Warwickshire_A47.Hinckley.Road-just-scheme-name.txt)
✅ No foreign members - [Warwickshire-no-foreign-members.txt](https://github.com/acteng/atip/files/10742575/Warwickshire-no-foreign-members.txt)
