### PR TITLE
random port assignment for tests using port 0

### DIFF
--- a/tests/atip-map-interact.spec.js
+++ b/tests/atip-map-interact.spec.js
@@ -2,7 +2,6 @@ import { afterAll, beforeAll, describe, test } from "vitest";
 import { preview } from "vite";
 import { chromium } from "playwright";
 import { expect } from "@playwright/test";
-import { getRandomIntInclusive } from './test-utils';
 
 // unstable in Windows, TODO: investigate
 describe.runIf(process.platform !== "win32")("basic", async () => {
@@ -11,7 +10,7 @@ describe.runIf(process.platform !== "win32")("basic", async () => {
   let page;
 
   beforeAll(async () => {
-    server = await preview({ preview: { port: getRandomIntInclusive(4000, 5000) } });
+    server = await preview({ preview: { port: 0 } });
     browser = await chromium.launch();
     page = await browser.newPage();
   });

--- a/tests/hello-atip.spec.js
+++ b/tests/hello-atip.spec.js
@@ -2,7 +2,6 @@ import { afterAll, beforeAll, describe, test } from "vitest";
 import { preview } from "vite";
 import { chromium } from "playwright";
 import { expect } from "@playwright/test";
-import { getRandomIntInclusive } from './test-utils';
 
 // unstable in Windows, TODO: investigate
 describe.runIf(process.platform !== "win32")("basic", async () => {
@@ -11,7 +10,7 @@ describe.runIf(process.platform !== "win32")("basic", async () => {
   let page;
 
   beforeAll(async () => {
-    server = await preview({ preview: { port: getRandomIntInclusive(4000, 5000) } });
+    server = await preview({ preview: { port: 0 } });
     browser = await chromium.launch();
     page = await browser.newPage();
   });

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,7 +1,0 @@
-export function getRandomIntInclusive(min, max) {
-    // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min + 1) + min); // The maximum is inclusive and the minimum is inclusive
-}
-


### PR DESCRIPTION
This PR improves upon the previous PR introducing playwright.

In that PR we randomly allocated a port number for tests using a utility function. A nicer way to set random port numbers is to specify port 0 and allow the OS to randomly assign from an available port for each test.