### PR TITLE
Switch to our own MapTiler free account. #59

### DIFF
--- a/components/Map.svelte
+++ b/components/Map.svelte
@@ -16,7 +16,7 @@
     map = new Map({
       container: mapContainer,
       style:
-        "https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL",
+        "https://api.maptiler.com/maps/streets/style.json?key=MZEJTanw3WpxRvt7qDfo",
       hash: true,
     });
     map.addControl(new ScaleControl());


### PR DESCRIPTION
I've been copying around the API key from MapLibre examples, but this morning on conference wifi, I got 403's for it. Seemingly not an issue off of conference wifi, but this is a ticking time-bomb anyway. In the short term, signing up for a free account was super easy, and the request quota should be more than enough. We can keep considering various other options for hosting long-term, but this moves us forward a bit.

As an aside, MapTiler has a v2 of the streets style. I kept the same one so far, but here's a comparison. Current:
![Screenshot from 2023-03-22 11-34-10](https://user-images.githubusercontent.com/1664407/226892424-f4e7555e-e4c4-4fe7-ab20-53a70a58b77e.png)
v2:
![Screenshot from 2023-03-22 11-33-50](https://user-images.githubusercontent.com/1664407/226892462-14f3cb5c-0f45-4135-a336-d82aaca5c18c.png)
