### PR TITLE
Let people reset 3D camera

### DIFF
--- a/components/Map.svelte
+++ b/components/Map.svelte
@@ -20,7 +20,10 @@
       hash: true,
     });
     map.addControl(new ScaleControl());
-    map.addControl(new NavigationControl(), "bottom-right");
+    map.addControl(
+      new NavigationControl({ visualizePitch: true }),
+      "bottom-right"
+    );
 
     map.on("load", () => {
       loaded = true;


### PR DESCRIPTION
Small but annoying thing: on the current site, hold control and click around to make the camera 3D. It's hard to reset to top-down. The compass control we already have in the corner will fix rotation, but not pitch. This fixes that to always reset to neutral.

https://user-images.githubusercontent.com/1664407/227202181-5ecee96d-1157-44dd-8aef-fc843bc283bc.mp4
