### PR TITLE
Only zoom to an intervention when clicking it in the sidebar, not fro…

### DIFF
--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -18,7 +18,7 @@
     currentMapHover,
     setCurrentlyEditing,
     clearCurrentlyEditing,
-    currentlyEditing,
+    openFromSidebar,
     map,
   } from "../stores.js";
 
@@ -143,7 +143,7 @@
       currentMapHover.set(null);
     });
 
-    currentlyEditing.subscribe((id) => {
+    openFromSidebar.subscribe((id) => {
       if (id) {
         let feature = $gjScheme.features.find((f) => f.id == id);
         // Act like we've selected the object. (This is irrelevant for points.)

--- a/components/EditingLayer.svelte
+++ b/components/EditingLayer.svelte
@@ -10,7 +10,7 @@
     drawPolygon,
   } from "../style.js";
   import { emptyGeojson } from "../stores.js";
-  import { gjScheme, currentlyEditing, map } from "../stores.js";
+  import { gjScheme, openFromSidebar, map } from "../stores.js";
 
   let source = "editing";
   let color = "red";
@@ -50,16 +50,13 @@
         );
     });
 
-    // Warp to what's being edited
-    // TODO This is a bit annoying when clicking on the map. Can we limit to just the sidebar?
-    currentlyEditing.subscribe((id) => {
+    // When the user starts editing something from the sidebar, warp to what's
+    // being edited. (Don't do this when clicking the object on the map.)
+    openFromSidebar.subscribe((id) => {
       if (id) {
-        // currentlyEditing only changes when the ID changes, not
-        // properties/geometry, so that this behavior isn't triggered
-        // constantly
         let feature = $gjScheme.features.find((f) => f.id == id);
 
-        // Points are weird
+        // Extent of points is defined in a weird way, special-case it
         if (feature.geometry.type == "Point") {
           $map.flyTo({ center: feature.geometry.coordinates });
         } else {

--- a/components/InterventionList.svelte
+++ b/components/InterventionList.svelte
@@ -6,6 +6,7 @@
     currentSidebarHover,
     currentMapHover,
     currentlyEditing,
+    openFromSidebar,
   } from "../stores.js";
 
   function interventionName(feature) {
@@ -30,7 +31,14 @@
     currentSidebarHover.set(null);
   }
 
-  function closeOtherForms(id) {
+  function startEditing(id) {
+    // Always set this to null first, to force subscribers to see the update.
+    // It's possible to open something from the sidebar, close it (by clicking
+    // on the map or using the sidebar), then reopen the same thing.
+    openFromSidebar.set(null);
+    openFromSidebar.set(id);
+
+    // Remove the editing property from everything else, so that the Accordion is hidden
     for (let f of $gjScheme.features) {
       if (f.properties.editing && f.id != id) {
         delete f.properties.editing;
@@ -63,7 +71,7 @@
   {#each $gjScheme.features as feature, i}
     <AccordionItem
       bind:open={feature.properties.editing}
-      on:click={closeOtherForms(feature.id)}
+      on:click={startEditing(feature.id)}
       on:mouseenter={currentSidebarHover.set(feature.id)}
       on:mouseleave={reset}
     >

--- a/stores.js
+++ b/stores.js
@@ -7,6 +7,8 @@ export const gjScheme = writable(emptyGeojson());
 export const currentSidebarHover = writable(null);
 export const currentMapHover = writable(null);
 
+export const openFromSidebar = writable(null);
+
 // TODO Should we store a map from ID to feature?
 // TODO DrawControls will partly own state. Do we have to listen for every geometry change?
 // TODO Should we attempt to keep properties in DrawControls or not?


### PR DESCRIPTION
…m the map. Closes #64

Before:

https://user-images.githubusercontent.com/1664407/227789897-8d555438-6540-4b42-8e38-c7dd01a16fee.mp4

After:

https://user-images.githubusercontent.com/1664407/227789906-55965c38-1da7-4a3a-b9f2-af783e851f88.mp4

I've found it very annoying (personally -- this is a design choice we could poll users about if we needed to?) to reset the camera when clicking an object on the map. So this PR makes us only zoom to something if clicked in the sidebar