### PR TITLE
Experiment with a large modal form, partly generated from a JSON schema

### DIFF
--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -216,6 +216,7 @@
       const ids = drawControls.add(feature);
       feature.id = ids[0];
       feature.properties.intervention_type = "route";
+      feature.properties.details = {};
       gjScheme.update((gj) => {
         gj.features.push(feature);
         return gj;

--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -110,6 +110,7 @@
       } else {
         feature.properties.intervention_type = "other";
       }
+      feature.properties.details = {};
 
       gjScheme.update((gj) => {
         gj.features.push(feature);

--- a/components/EntireScheme.svelte
+++ b/components/EntireScheme.svelte
@@ -82,12 +82,14 @@
   }
 
   function backfill(json) {
-    // Look for any LineStrings without length_meters. Old route-snapper versions didn't fill this out.
     for (let f of json.features) {
+      // Look for any LineStrings without length_meters. Old route-snapper versions didn't fill this out.
       if (f.geometry.type == "LineString" && !f.properties.length_meters) {
         f.properties.length_meters =
           length(f.geometry, { units: "kilometers" }) * 1000.0;
       }
+      // Start empty details
+      f.properties.details ||= {};
     }
 
     return json;

--- a/components/Form.svelte
+++ b/components/Form.svelte
@@ -1,21 +1,33 @@
 <script>
   import {
+    Dropdown,
+    Modal,
     RadioButtonGroup,
     RadioButton,
     TextArea,
     TextInput,
+    NumberInput,
   } from "carbon-components-svelte";
-  import {
-    gjScheme,
-    clearCurrentlyEditing,
-    currentlyEditing,
-  } from "../stores.js";
+  import { gjScheme, clearCurrentlyEditing, currentlyEditing } from "../stores.js";
+  import areaSchema from "../schema/areas.json";
+  import crossingSchema from "../schema/crossings.json";
+  import otherSchema from "../schema/other.json";
+  import routeSchema from "../schema/routes.json";
 
   export let id;
   export let name;
   export let intervention_type;
   export let description;
   export let length_meters;
+  export let details;
+
+  let openModalForm = false;
+  let schema = {
+    area: areaSchema,
+    route: routeSchema,
+    crossing: crossingSchema,
+    other: otherSchema,
+  }[intervention_type];
 
   let bottomOfForm;
 
@@ -65,9 +77,39 @@
   <br />
 {/if}
 
-<div bind:this={bottomOfForm}>
+<div bind:this={bottomOfForm} style="display: flex; justify-content: space-between">
   <button type="button" on:click={remove}>Delete</button>
-  <button type="button" on:click={clearCurrentlyEditing} style="float: right;"
-    >Save</button
+  <button type="button" on:click={() => (openModalForm = true)}
+    >Edit details</button
   >
+  <button type="button" on:click={clearCurrentlyEditing}>Save</button>
 </div>
+
+<Modal
+  passiveModal
+  hasScrollingContent
+  modalHeading={`Edit ${intervention_type} details`}
+  bind:open={openModalForm}
+>
+  {#each Object.entries(schema.properties) as [key, value]}
+    {#if value.enum}
+      <Dropdown
+        titleText={value.description || value.title}
+        items={value.enum.map((v) => ({ id: v, text: v }))}
+        bind:selectedId={details[key]}
+      />
+      <br />
+    {/if}
+  {/each}
+
+  {#if intervention_type == "route"}
+    <NumberInput
+      step={0.1}
+      label={routeSchema.properties.width.description}
+      bind:value={details.width}
+    />
+  {/if}
+
+  <!-- TODO Hack for the Modal -->
+  <div style="height: 500px" />
+</Modal>

--- a/components/Form.svelte
+++ b/components/Form.svelte
@@ -8,7 +8,11 @@
     TextInput,
     NumberInput,
   } from "carbon-components-svelte";
-  import { gjScheme, clearCurrentlyEditing, currentlyEditing } from "../stores.js";
+  import {
+    gjScheme,
+    clearCurrentlyEditing,
+    currentlyEditing,
+  } from "../stores.js";
   import areaSchema from "../schema/areas.json";
   import crossingSchema from "../schema/crossings.json";
   import otherSchema from "../schema/other.json";
@@ -77,7 +81,10 @@
   <br />
 {/if}
 
-<div bind:this={bottomOfForm} style="display: flex; justify-content: space-between">
+<div
+  bind:this={bottomOfForm}
+  style="display: flex; justify-content: space-between"
+>
   <button type="button" on:click={remove}>Delete</button>
   <button type="button" on:click={() => (openModalForm = true)}
     >Edit details</button

--- a/components/InterventionList.svelte
+++ b/components/InterventionList.svelte
@@ -87,6 +87,7 @@
         bind:name={feature.properties.name}
         bind:intervention_type={feature.properties.intervention_type}
         bind:description={feature.properties.description}
+        bind:details={feature.properties.details}
         length_meters={feature.properties.length_meters}
       />
     </AccordionItem>

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,1 @@
+These're copied manually from <https://github.com/acteng/schema/blob/main/option3/> to test.

--- a/schema/areas.json
+++ b/schema/areas.json
@@ -1,0 +1,20 @@
+{
+  "properties": {
+    "area_type": {
+      "title": "Area type",
+      "description": "The main type of intervention in the area",
+      "type": "string",
+      "enum": [
+        "Modal filters",
+        "Traffic calming",
+        "Car free area (permanent)",
+        "Car free area (during certain times)",
+        "Car parking restrictions",
+        "20 mph zone",
+        "School streets zone",
+        "Business improvement district",
+        "Other area intervention"
+      ]
+    }
+  }
+}

--- a/schema/crossings.json
+++ b/schema/crossings.json
@@ -1,0 +1,33 @@
+{
+  "properties": {
+    "crossing_type": {
+      "title": "Crossing type",
+      "description": "The main type of active travel infrastructure along the route",
+      "type": "string",
+      "enum": [
+        "Grade separated",
+        "Signalised",
+        "Priority",
+        "Uncontrolled"
+      ]
+    },
+    "crossing_motor_traffic_flow": {
+      "title": "Motor traffic flow (PCU)",
+      "type": "string",
+      "enum": [
+        "> 8,000",
+        "3,000-8,000",
+        "< 3,000"
+      ]
+    },
+    "crossing_85th_percentile_speed": {
+      "title": "Motor traffic speed (85th percentile)",
+      "type": "string",
+      "enum": [
+        "> 30 mph",
+        "20-30 mph",
+        "< 20 mph"
+      ]
+    }
+  }
+}

--- a/schema/other.json
+++ b/schema/other.json
@@ -1,0 +1,16 @@
+{
+  "properties": {
+    "intervention_type_other": {
+      "title": "Intervention type (other)",
+      "description": "The main type of intervention",
+      "type": "string",
+      "enum": [
+        "Signage",
+        "Public transport stop",
+        "Dropped curb for wheeled access",
+        "Access ramp alongside or instead of steps",
+        "Other"
+      ]
+    }
+   }
+}

--- a/schema/routes.json
+++ b/schema/routes.json
@@ -1,0 +1,49 @@
+{
+  "properties": {
+    "separation": {
+      "title": "Separation from carriageway",
+      "description": "The main way in which the route is separated from motor traffic",
+      "type": "string",
+      "enum": [
+        "Not on road network",
+        "Full separation",
+        "Stepped",
+        "Part separation",
+        "Mandatory lane",
+        "Advisory lane",
+        "Part of carriageway (e.g. through modal filters)",
+        "Multiple Separation types",
+        "Other"
+      ]
+    },
+    "route_type": {
+      "title": "Route type",
+      "description": "Main type of active travel infrastructure along the route",
+      "type": "string",
+      "enum": [
+        "Footpath",
+        "Shared use footpath/cycleway",
+        "Cycleway",
+        "Contraflow"
+      ],
+      "default": "Footpath"
+    },
+    "reallocation": {
+      "title": "Main way space reallocated on route",
+      "description": "The main source of new space for active travel",
+      "type": "string",
+      "enum": [
+        "Reallocation of a complete vehicular lane on the carriageway",
+        "Road diet: vehicular carriageway thinned, creating new space",
+        "Pavement diet: existing pavement space reallocated",
+        "Verge or other unused space reallocated"
+      ]
+    },
+    "width": {
+      "title": "Width (m)",
+      "description": "Average width of the route in metres",
+      "type": "number",
+      "default": "2.5"
+    }
+  }
+}


### PR DESCRIPTION
This isn't intended to merge, just a quick way to experiment with using JSON schemas from https://github.com/acteng/schema/ in ATIP:

https://user-images.githubusercontent.com/1664407/227908327-530f23fe-4f25-4eb5-8bfc-aac7891da765.mp4

# Notes on libraries

I tried a few NPM packages for autogenerating a form from a JSON schema, but didn't have any luck finding one that works well out-of-box. I don't think it's too important to invest in this, because

1) the JSON schema format is just a convenient way for us to iterate on the schema right now; it may not be the final thing we choose to use in the frontend, for any DB schema, etc
2) in ATIP, we will probably always want custom form / controls. As you select a crossing type, we could show some example images inline, have a cost estimate, link to design manuals, etc. Maybe once you specify the "The main source of new space for active travel" for routes, you get a new sub-form with something Streetmix-like, etc.

But anyway, here's what I tried for reference:

- https://github.com/xpluscal/svelte-schemaform: somehow breaks CSS button styling, can't handle empty input to start
- https://github.com/restspace/svelte-schema-form: Requires Saas dependency and the installation somehow breaks
- https://github.com/pyoner/svelte-form: Old, installation breaks