### PR TITLE
Less clunky developer experience, part 1

### DIFF
--- a/components/BoundaryLayer.svelte
+++ b/components/BoundaryLayer.svelte
@@ -1,30 +1,32 @@
 <script>
   import geojsonExtent from "@mapbox/geojson-extent";
   import mask from "@turf/mask";
-  import { drawPolygon } from "../maplibre_helpers.js";
-  import { onMount, getContext } from "svelte";
+  import {
+    drawPolygon,
+    overwriteSource,
+    overwriteLayer,
+  } from "../maplibre_helpers.js";
+  import { getContext } from "svelte";
   import { map } from "../stores.js";
 
   export let boundaryGeojson;
 
   const setCamera = getContext("setCamera");
 
-  onMount(() => {
-    if (setCamera) {
-      $map.fitBounds(geojsonExtent(boundaryGeojson), {
-        padding: 20,
-        animate: false,
-      });
-    }
+  if (setCamera) {
+    $map.fitBounds(geojsonExtent(boundaryGeojson), {
+      padding: 20,
+      animate: false,
+    });
+  }
 
-    $map.addSource("boundary", {
-      type: "geojson",
-      data: mask(boundaryGeojson),
-    });
-    $map.addLayer({
-      id: "boundary",
-      source: "boundary",
-      ...drawPolygon("black", 0.5),
-    });
+  overwriteSource($map, "boundary", {
+    type: "geojson",
+    data: mask(boundaryGeojson),
+  });
+  overwriteLayer($map, {
+    id: "boundary",
+    source: "boundary",
+    ...drawPolygon("black", 0.5),
   });
 </script>

--- a/components/BoundaryLayer.svelte
+++ b/components/BoundaryLayer.svelte
@@ -1,7 +1,7 @@
 <script>
   import geojsonExtent from "@mapbox/geojson-extent";
   import mask from "@turf/mask";
-  import { drawPolygon } from "../style.js";
+  import { drawPolygon } from "../maplibre_helpers.js";
   import { onMount, getContext } from "svelte";
   import { map } from "../stores.js";
 

--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -7,7 +7,7 @@
     drawLine,
     isPolygon,
     drawPolygon,
-  } from "../style.js";
+  } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { onMount, onDestroy } from "svelte";
   import { init, RouteSnapper, fetchWithProgress } from "route-snapper/lib.js";

--- a/components/EditingLayer.svelte
+++ b/components/EditingLayer.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from "svelte";
   import geojsonExtent from "@mapbox/geojson-extent";
   import {
     drawLine,
@@ -8,6 +7,8 @@
     isLine,
     drawCircle,
     drawPolygon,
+    overwriteSource,
+    overwriteLayer,
   } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { emptyGeojson } from "../stores.js";
@@ -17,47 +18,43 @@
   let lineWidth = 10;
   let circleRadius = 7;
 
-  onMount(() => {
-    $map.addSource(source, {
-      type: "geojson",
-      data: emptyGeojson(),
-    });
+  overwriteSource($map, source, {
+    type: "geojson",
+    data: emptyGeojson(),
+  });
 
-    // Don't symbolize polygons or linestrings being edited. They'll have
-    // draggable points rendered, making it clear anyway.
-    $map.addLayer({
-      id: "editing-points",
-      source,
-      filter: isPoint,
-      // Use the same style as hovering; it's clear enough what the user is doing
-      ...drawCircle(colors.hovering, 1.5 * circleRadius),
-    });
+  // Don't symbolize polygons or linestrings being edited. They'll have
+  // draggable points rendered, making it clear anyway.
+  overwriteLayer($map, {
+    id: "editing-points",
+    source,
+    filter: isPoint,
+    // Use the same style as hovering; it's clear enough what the user is doing
+    ...drawCircle(colors.hovering, 1.5 * circleRadius),
+  });
 
-    gjScheme.subscribe((gj) => {
-      $map
-        .getSource(source)
-        .setData(
-          gj.features.find((f) => f.properties.editing) || emptyGeojson()
-        );
-    });
+  gjScheme.subscribe((gj) => {
+    $map
+      .getSource(source)
+      .setData(gj.features.find((f) => f.properties.editing) || emptyGeojson());
+  });
 
-    // When the user starts editing something from the sidebar, warp to what's
-    // being edited. (Don't do this when clicking the object on the map.)
-    openFromSidebar.subscribe((id) => {
-      if (id) {
-        let feature = $gjScheme.features.find((f) => f.id == id);
+  // When the user starts editing something from the sidebar, warp to what's
+  // being edited. (Don't do this when clicking the object on the map.)
+  openFromSidebar.subscribe((id) => {
+    if (id) {
+      let feature = $gjScheme.features.find((f) => f.id == id);
 
-        // Extent of points is defined in a weird way, special-case it
-        if (feature.geometry.type == "Point") {
-          $map.flyTo({ center: feature.geometry.coordinates });
-        } else {
-          $map.fitBounds(geojsonExtent(feature), {
-            padding: 200,
-            animate: true,
-            duration: 500,
-          });
-        }
+      // Extent of points is defined in a weird way, special-case it
+      if (feature.geometry.type == "Point") {
+        $map.flyTo({ center: feature.geometry.coordinates });
+      } else {
+        $map.fitBounds(geojsonExtent(feature), {
+          padding: 200,
+          animate: true,
+          duration: 500,
+        });
       }
-    });
+    }
   });
 </script>

--- a/components/EditingLayer.svelte
+++ b/components/EditingLayer.svelte
@@ -8,7 +8,7 @@
     isLine,
     drawCircle,
     drawPolygon,
-  } from "../style.js";
+  } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { emptyGeojson } from "../stores.js";
   import { gjScheme, openFromSidebar, map } from "../stores.js";

--- a/components/HoverLayer.svelte
+++ b/components/HoverLayer.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from "svelte";
   import { derived } from "svelte/store";
   import {
     drawLine,
@@ -8,6 +7,8 @@
     isLine,
     drawCircle,
     drawPolygon,
+    overwriteSource,
+    overwriteLayer,
   } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { emptyGeojson } from "../stores.js";
@@ -22,55 +23,52 @@
   let lineWidth = 10;
   let circleRadius = 7;
 
-  onMount(() => {
-    // Use a layer that only ever has zero or one features for hovering. I
-    // think https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/ should
-    // be an easier way to do this, but I can't make it work with the draw
-    // plugin.
-    $map.addSource(source, {
-      type: "geojson",
-      data: emptyGeojson(),
-    });
+  // Use a layer that only ever has zero or one features for hovering. I think
+  // https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/ should be an
+  // easier way to do this, but I can't make it work with the draw plugin.
+  overwriteSource($map, source, {
+    type: "geojson",
+    data: emptyGeojson(),
+  });
 
-    $map.addLayer({
-      id: "hover-polygons",
-      source: source,
-      filter: isPolygon,
-      // Outline around the polygons
-      // TODO Because this is underneath the draw controls, half the outline is
-      // covered by the 50% opaque color
-      ...drawLine(colors.hovering, lineWidth, 1.0),
-    });
-    $map.addLayer({
-      id: "hover-lines",
-      source: source,
-      filter: isLine,
-      // By "accident", this layer is underneath the draw controls. Draw a
-      // thick line underneath, making it look like an outline.
-      ...drawLine(colors.hovering, 1.5 * lineWidth, 1.0),
-    });
-    $map.addLayer({
-      id: "hover-points",
-      source: source,
-      filter: isPoint,
-      ...drawCircle(colors.hovering, 1.5 * circleRadius, 1.0),
-    });
+  overwriteLayer($map, {
+    id: "hover-polygons",
+    source: source,
+    filter: isPolygon,
+    // Outline around the polygons
+    // TODO Because this is underneath the draw controls, half the outline is
+    // covered by the 50% opaque color
+    ...drawLine(colors.hovering, lineWidth, 1.0),
+  });
+  overwriteLayer($map, {
+    id: "hover-lines",
+    source: source,
+    filter: isLine,
+    // By "accident", this layer is underneath the draw controls. Draw a
+    // thick line underneath, making it look like an outline.
+    ...drawLine(colors.hovering, 1.5 * lineWidth, 1.0),
+  });
+  overwriteLayer($map, {
+    id: "hover-points",
+    source: source,
+    filter: isPoint,
+    ...drawCircle(colors.hovering, 1.5 * circleRadius, 1.0),
+  });
 
-    // Don't show hover whenever we're editing something
-    dontHover.subscribe((x) => {
-      if (x) {
-        currentSidebarHover.set(null);
-      }
-    });
+  // Don't show hover whenever we're editing something
+  dontHover.subscribe((x) => {
+    if (x) {
+      currentSidebarHover.set(null);
+    }
+  });
 
-    currentSidebarHover.subscribe((id) => {
-      if (id && !$dontHover) {
-        $map
-          .getSource(source)
-          .setData($gjScheme.features.find((f) => f.id == id));
-      } else {
-        $map.getSource(source).setData(emptyGeojson());
-      }
-    });
+  currentSidebarHover.subscribe((id) => {
+    if (id && !$dontHover) {
+      $map
+        .getSource(source)
+        .setData($gjScheme.features.find((f) => f.id == id));
+    } else {
+      $map.getSource(source).setData(emptyGeojson());
+    }
   });
 </script>

--- a/components/HoverLayer.svelte
+++ b/components/HoverLayer.svelte
@@ -8,7 +8,7 @@
     isLine,
     drawCircle,
     drawPolygon,
-  } from "../style.js";
+  } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { emptyGeojson } from "../stores.js";
   import { gjScheme, currentSidebarHover, map } from "../stores.js";

--- a/maplibre_helpers.js
+++ b/maplibre_helpers.js
@@ -1,5 +1,4 @@
-// https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/EXAMPLES.md as
-// reference
+// Helpers for https://maplibre.org/maplibre-gl-js-docs/style-spec/
 
 const roundedLine = {
   "line-cap": "round",

--- a/maplibre_helpers.js
+++ b/maplibre_helpers.js
@@ -41,3 +41,32 @@ export function drawCircle(color, radius, opacity = 1.0) {
     },
   };
 }
+
+// MapLibre's API isn't idempotent; you can't overwrite an existing source or
+// layer. This complicates Vite's hot-reload feature, unless every component
+// correctly tears down all sources and layers. These methods workaround that
+// lifetime management hassle by overwriting if necessary.
+export function overwriteSource(map, id, source) {
+  if (map.getSource(id)) {
+    // First remove all layers using this source
+    let layers = [];
+    for (let layer of map.getStyle().layers) {
+      if (layer.source == id) {
+        layers.push(layer.id);
+      }
+    }
+    for (let layer of layers) {
+      map.removeLayer(layer);
+    }
+
+    map.removeSource(id);
+  }
+  map.addSource(id, source);
+}
+
+export function overwriteLayer(map, layer) {
+  if (map.getLayer(layer.id)) {
+    map.removeLayer(layer.id);
+  }
+  map.addLayer(layer);
+}


### PR DESCRIPTION
Vite does hot-module reloading (HMR), meaning when you edit code, just the necessary Svelte components get reloaded without the whole page refreshing. It's incredibly handy to tune CSS or map drawing styles things and instantly see feedback. But today, if you edit the code in many ATIP components, the page breaks completely.

This PR fixes most of the cases involving sources and layers on the map. MapLibre doesn't let you add a source or layer with a duplicate ID. We could solve this in a few ways:

- Writing an `onDestroy` for all relevant components, and carefully removing things in the correct order. (Layers have to be removed before their source). Boilerplatey, and really easy to get wrong.
- Using Svelte components that wrap Sources and Layers and do the lifetime management properly. This is the approach in https://github.com/dimfeld/svelte-maplibre/. I like it, but it's a bigger change for us to either switch to this library or to mimic this style.
- Use helper methods that first remove sources/layers before adding them, if needed. This is the approach in this PR. Maybe not ideal, but simple.

In the next PR, I want to fix more remaining problems. Everytime we do `someStore.subscribe`, that component can't be reloaded properly; the old callback dangles and so logic will run a bunch of times, or we hold onto stale objects. Svelte auto-subscriptions will help here, but it's not super easy to get right, so I'll save it for the next step.

Going to ASAP merge this because it dramatically makes my editing workflow better, but very happy to address feedback later