### PR TITLE
When we expand a form, scroll to ensure it's visible in the sidebar

### DIFF
--- a/components/Form.svelte
+++ b/components/Form.svelte
@@ -5,13 +5,28 @@
     TextArea,
     TextInput,
   } from "carbon-components-svelte";
-  import { gjScheme, clearCurrentlyEditing } from "../stores.js";
+  import {
+    gjScheme,
+    clearCurrentlyEditing,
+    currentlyEditing,
+  } from "../stores.js";
 
   export let id;
   export let name;
   export let intervention_type;
   export let description;
   export let length_meters;
+
+  let bottomOfForm;
+
+  currentlyEditing.subscribe((openedId) => {
+    if (id == openedId) {
+      // Wait 1ms before doing this, because it appears the accordion doesn't
+      // expand instantly. This is flaky when clicking the accordion instead of
+      // the map.
+      setTimeout(() => bottomOfForm?.scrollIntoView({ behavior: "smooth" }), 1);
+    }
+  });
 
   function remove() {
     gjScheme.update((gj) => {
@@ -50,7 +65,7 @@
   <br />
 {/if}
 
-<div>
+<div bind:this={bottomOfForm}>
   <button type="button" on:click={remove}>Delete</button>
   <button type="button" on:click={clearCurrentlyEditing} style="float: right;"
     >Save</button

--- a/stores.js
+++ b/stores.js
@@ -7,6 +7,8 @@ export const gjScheme = writable(emptyGeojson());
 export const currentSidebarHover = writable(null);
 export const currentMapHover = writable(null);
 
+// These act as event dispatchers, but are easier to plumb around. They will
+// either have a feature ID or null.
 export const openFromSidebar = writable(null);
 
 // TODO Should we store a map from ID to feature?


### PR DESCRIPTION
This is a small tweak that makes navigation/editing easier. If someone picks an intervention, they probably want to actually see the entire form.

Before:

https://user-images.githubusercontent.com/1664407/228212695-c4638fc0-3b63-486a-b7ee-b6450bfce2c4.mp4

After:

https://user-images.githubusercontent.com/1664407/228212718-85059976-8b7d-42b2-9232-24884957f3e4.mp4

