### PR TITLE
Make hovering more consistent

### DIFF
--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -21,6 +21,7 @@
     clearCurrentlyEditing,
     openFromSidebar,
     map,
+    currentlyEditing,
   } from "../stores.js";
 
   const circleRadius = 7;
@@ -150,18 +151,22 @@
 
     // Highlight something in the sidebar when we hover on a feature in the map
     $map.on("mousemove", (e) => {
-      var newHoverEntry = null;
-      if (routeSnapper && !routeSnapper.isActive()) {
-        // TODO This whines about a layer missing, and I can't suppress with try/catch
-        const ids = drawControls.getFeatureIdsAt(e.point);
-        if (ids.length > 0) {
-          newHoverEntry = ids[0];
+      if ($currentlyEditing == null) {
+        var newHoverEntry = null;
+        if (routeSnapper && !routeSnapper.isActive()) {
+          // TODO This whines about a layer missing, and I can't suppress with try/catch
+          const ids = drawControls.getFeatureIdsAt(e.point);
+          if (ids.length > 0) {
+            newHoverEntry = ids[0];
+          }
+          currentHover.set(newHoverEntry);
         }
-        currentHover.set(newHoverEntry);
       }
     });
     $map.on("mouseout", () => {
-      currentHover.set(null);
+      if ($currentlyEditing == null) {
+        currentHover.set(null);
+      }
     });
 
     openFromSidebar.subscribe((id) => {

--- a/components/DrawControls.svelte
+++ b/components/DrawControls.svelte
@@ -16,7 +16,7 @@
 
   import {
     gjScheme,
-    currentMapHover,
+    currentHover,
     setCurrentlyEditing,
     clearCurrentlyEditing,
     openFromSidebar,
@@ -157,11 +157,11 @@
         if (ids.length > 0) {
           newHoverEntry = ids[0];
         }
-        currentMapHover.set(newHoverEntry);
+        currentHover.set(newHoverEntry);
       }
     });
     $map.on("mouseout", () => {
-      currentMapHover.set(null);
+      currentHover.set(null);
     });
 
     openFromSidebar.subscribe((id) => {

--- a/components/HoverLayer.svelte
+++ b/components/HoverLayer.svelte
@@ -12,7 +12,7 @@
   } from "../maplibre_helpers.js";
   import { colors } from "../colors.js";
   import { emptyGeojson } from "../stores.js";
-  import { gjScheme, currentSidebarHover, map } from "../stores.js";
+  import { gjScheme, currentHover, map } from "../stores.js";
 
   // TODO Does this need to be a store?
   const dontHover = derived(gjScheme, ($gj) =>
@@ -50,7 +50,7 @@
   });
   overwriteLayer($map, {
     id: "hover-points",
-    source: source,
+    source,
     filter: isPoint,
     ...drawCircle(colors.hovering, 1.5 * circleRadius, 1.0),
   });
@@ -58,11 +58,11 @@
   // Don't show hover whenever we're editing something
   dontHover.subscribe((x) => {
     if (x) {
-      currentSidebarHover.set(null);
+      currentHover.set(null);
     }
   });
 
-  currentSidebarHover.subscribe((id) => {
+  currentHover.subscribe((id) => {
     if (id && !$dontHover) {
       $map
         .getSource(source)

--- a/components/HoverLayer.svelte
+++ b/components/HoverLayer.svelte
@@ -14,11 +14,6 @@
   import { emptyGeojson } from "../stores.js";
   import { gjScheme, currentHover, map } from "../stores.js";
 
-  // TODO Does this need to be a store?
-  const dontHover = derived(gjScheme, ($gj) =>
-    $gj.features.some((f) => f.properties.editing)
-  );
-
   let source = "hover";
   let lineWidth = 10;
   let circleRadius = 7;
@@ -55,15 +50,8 @@
     ...drawCircle(colors.hovering, 1.5 * circleRadius, 1.0),
   });
 
-  // Don't show hover whenever we're editing something
-  dontHover.subscribe((x) => {
-    if (x) {
-      currentHover.set(null);
-    }
-  });
-
   currentHover.subscribe((id) => {
-    if (id && !$dontHover) {
+    if (id) {
       $map
         .getSource(source)
         .setData($gjScheme.features.find((f) => f.id == id));

--- a/components/InterventionList.svelte
+++ b/components/InterventionList.svelte
@@ -3,8 +3,7 @@
   import Form from "./Form.svelte";
   import {
     gjScheme,
-    currentSidebarHover,
-    currentMapHover,
+    currentHover,
     currentlyEditing,
     openFromSidebar,
   } from "../stores.js";
@@ -28,7 +27,7 @@
 
   // TODO Not sure why we can't inline this one below
   function reset() {
-    currentSidebarHover.set(null);
+    currentHover.set(null);
   }
 
   function startEditing(id) {
@@ -72,11 +71,11 @@
     <AccordionItem
       bind:open={feature.properties.editing}
       on:click={startEditing(feature.id)}
-      on:mouseenter={currentSidebarHover.set(feature.id)}
+      on:mouseenter={currentHover.set(feature.id)}
       on:mouseleave={reset}
     >
       <svelte:fragment slot="title">
-        {#if feature.id == $currentMapHover}
+        {#if feature.id == $currentHover}
           <strong>{i + 1}) {interventionName(feature)}</strong>
         {:else}
           {i + 1}) {interventionName(feature)}

--- a/components/InterventionList.svelte
+++ b/components/InterventionList.svelte
@@ -25,9 +25,10 @@
     return `Untitled ${noun}`;
   }
 
-  // TODO Not sure why we can't inline this one below
-  function reset() {
-    currentHover.set(null);
+  function sidebarHover(id) {
+    if ($currentlyEditing == null) {
+      currentHover.set(id);
+    }
   }
 
   function startEditing(id) {
@@ -71,8 +72,8 @@
     <AccordionItem
       bind:open={feature.properties.editing}
       on:click={startEditing(feature.id)}
-      on:mouseenter={currentHover.set(feature.id)}
-      on:mouseleave={reset}
+      on:mouseenter={sidebarHover(feature.id)}
+      on:mouseleave={sidebarHover(null)}
     >
       <svelte:fragment slot="title">
         {#if feature.id == $currentHover}

--- a/stores.js
+++ b/stores.js
@@ -4,7 +4,8 @@ import { writable, derived } from "svelte/store";
 export const map = writable(null);
 
 export const gjScheme = writable(emptyGeojson());
-// The optional ID of a feature currently hovered from the sidebar or map.
+// The optional ID of a feature currently hovered from the sidebar or map. When
+// an intervention is open and being edited, hovering is fixed to it.
 export const currentHover = writable(null);
 
 // These act as event dispatchers, but are easier to plumb around. They will
@@ -45,6 +46,8 @@ export function setCurrentlyEditing(id) {
     }
     return gj;
   });
+  // While we're editing, hover is pinned to this
+  currentHover.set(id);
 }
 export function clearCurrentlyEditing() {
   gjScheme.update((gj) => {
@@ -53,6 +56,7 @@ export function clearCurrentlyEditing() {
     });
     return gj;
   });
+  currentHover.set(null);
 }
 
 /* Thinking through the flow of state...

--- a/stores.js
+++ b/stores.js
@@ -4,8 +4,8 @@ import { writable, derived } from "svelte/store";
 export const map = writable(null);
 
 export const gjScheme = writable(emptyGeojson());
-export const currentSidebarHover = writable(null);
-export const currentMapHover = writable(null);
+// The optional ID of a feature currently hovered from the sidebar or map.
+export const currentHover = writable(null);
 
 // These act as event dispatchers, but are easier to plumb around. They will
 // either have a feature ID or null.


### PR DESCRIPTION
As part of #58, I've been trying to detangle all the state we have and determine valid interactions during different drawing/editing modes. This is a smaller refactoring that changes behavior. I believe it makes it nicer and more consistent, but please evaluate the UX of it.

Before, we draw an outline for stuff on the map when you hover in the sidebar, but not when you hover on the map. And when something is being edited, you can partly change the hover state independently:

https://user-images.githubusercontent.com/1664407/229165708-e1037a25-770a-4e19-89d4-0aa48c9bded6.mp4

With this PR, I'm merging the concept of "currently hovered object" to be just one thing -- whether it's from the sidebar or the map. And when something is being edited, you can't change the hover state.

https://user-images.githubusercontent.com/1664407/229165832-fc4432b2-af68-4ba3-808c-f1854423ffbb.mp4

