### PR TITLE
Split routes

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -6,6 +6,7 @@ export const colors = {
   other: "#984ea3",
 
   hovering: "black",
+  lineEndpointColor: "black",
 };
 
 // For points

--- a/components/draw/InterventionLayer.svelte
+++ b/components/draw/InterventionLayer.svelte
@@ -12,6 +12,10 @@
   import { colors, circleRadius, lineWidth } from "../../colors.js";
   import { gjScheme, map } from "../../stores.js";
 
+  // TODO Document here the z-ordering between all the layers defined
+  // everywhere. Or maybe even pass a list to overwriteLayer and have it figure
+  // things out!
+
   let source = "interventions";
 
   overwriteSource($map, source, {
@@ -73,12 +77,19 @@
     // TODO Outline?
   });
 
-  overwriteLayer($map, {
-    id: "interventions-lines",
-    source,
-    filter: ["all", isLine, hideWhileEditing],
-    ...drawLine(colorByInterventionType, lineWidth),
-  });
+  // Draw underneath the route tool
+  // TODO Also want this to be beneath route-points, but we can only specify one
+  // TODO Also draw beneath draw-split-route
+  overwriteLayer(
+    $map,
+    {
+      id: "interventions-lines",
+      source,
+      filter: ["all", isLine, hideWhileEditing],
+      ...drawLine(colorByInterventionType, lineWidth),
+    },
+    "route-lines"
+  );
   // Draw endpoints to emphasize where two LineStrings meet
   overwriteLayer($map, {
     id: "interventions-lines-endpoints",

--- a/components/draw/SplitRouteMode.svelte
+++ b/components/draw/SplitRouteMode.svelte
@@ -71,7 +71,10 @@
       return;
     }
 
-    if (snappedIndex != null) {
+    if (snappedIndex == null) {
+      // We clicked the map, stop the tool
+      changeMode("edit-attribute");
+    } else {
       let result = lineSplit($gjScheme.features[snappedIndex], cursor);
       if (result.features.length == 2) {
         let piece1 = result.features[0];
@@ -97,9 +100,10 @@
           return gj;
         });
       }
+
+      // Stay in this mode, but reset state
+      stop();
     }
-    // TODO Edit one of the pieces?
-    changeMode("edit-attribute");
   });
 
   // Rendering

--- a/components/draw/SplitRouteMode.svelte
+++ b/components/draw/SplitRouteMode.svelte
@@ -156,6 +156,8 @@
 
     let splitDist = distanceAlongLine(original, splitPt);
     let firstPiece = true;
+    // TODO Can we iterate over an array's contents and get the index at the same time?
+    let i = 0;
     for (let waypt of original.properties.waypoints) {
       let wayptDist = distanceAlongLine(
         original,
@@ -165,28 +167,45 @@
         if (wayptDist < splitDist) {
           piece1.properties.waypoints.push(waypt);
         } else {
-          // We found where the split occurs. Fix piece1
+          // We found where the split occurs. We'll insert a new waypoint
+          // representing the split at the end of piece1 and the beginning of
+          // piece2. Should that new waypoint be snapped or freehand? There are
+          // 4 cases for where the split (|) happens with regards to a
+          // (s)napped and (f)reehand point:
+          //
+          // 1) s | s
+          // 2) s | f
+          // 3) f | s
+          // 4) f | f
+          //
+          // Only in case 1 should the new waypoint introduced at (|) be
+          // snapped.
+          // TODO Problem: in case 1, what if we split in the middle of a road,
+          // far from an intersection?
+
+          // Note i > 0; splitDist can't be before the first waypoint (distance 0)
+          // TODO Edge case: somebody manages to exactly click a waypoint
+          let snapped =
+            waypt.snapped && original.properties.waypoints[i - 1].snapped;
+
           piece1.properties.waypoints.push({
             lon: splitPt.geometry.coordinates[0],
             lat: splitPt.geometry.coordinates[1],
-            // TODO Problem: even if we're sandwiched between two snapped
-            // waypoints, what if we split in the middle of a road, far from an
-            // intersection?
-            snapped: true,
+            snapped,
           });
 
-          // Fix piece2
           firstPiece = false;
           piece2.properties.waypoints.push({
             lon: splitPt.geometry.coordinates[0],
             lat: splitPt.geometry.coordinates[1],
-            snapped: true,
+            snapped,
           });
           piece2.properties.waypoints.push(waypt);
         }
       } else {
         piece2.properties.waypoints.push(waypt);
       }
+      i++;
     }
   }
 

--- a/components/draw/SplitRouteMode.svelte
+++ b/components/draw/SplitRouteMode.svelte
@@ -1,0 +1,143 @@
+<script>
+  import nearestPointOnLine from "@turf/nearest-point-on-line";
+  import lineSplit from "@turf/line-split";
+  import { gjScheme, map, emptyGeojson, newFeatureId } from "../../stores.js";
+  import {
+    overwriteSource,
+    overwriteLayer,
+    drawCircle,
+  } from "../../maplibre_helpers.js";
+
+  const thisMode = "split-route";
+
+  const circleRadiusPixels = 10;
+  const snapDistancePixels = 30;
+
+  export let mode;
+  export let changeMode;
+
+  export function start() {}
+  export function stop() {
+    cursor = null;
+    snappedIndex = null;
+  }
+
+  // An optional Feature<Point>
+  let cursor = null;
+  // Index into gjScheme of what we're snapped to
+  let snappedIndex = null;
+
+  $map.on("mousemove", (e) => {
+    if (mode != thisMode) {
+      return;
+    }
+
+    cursor = cursorFeature(e.lngLat.toArray(), false);
+    snappedIndex = null;
+
+    const nearbyPoint = { x: e.point.x - snapDistancePixels, y: e.point.y };
+    const thresholdKm =
+      $map.unproject(e.point).distanceTo($map.unproject(nearbyPoint)) / 1000.0;
+
+    // Are we snapped to anything?
+    let candidates = [];
+    for (let [index, f] of $gjScheme.features.entries()) {
+      if (f.geometry.type == "LineString") {
+        let snapped = nearestPointOnLine(f.geometry, cursor, {
+          units: "kilometers",
+        });
+        if (snapped.properties.dist <= thresholdKm) {
+          candidates.push([
+            index,
+            snapped.geometry.coordinates,
+            snapped.properties.dist,
+          ]);
+        }
+      }
+    }
+    candidates.sort((a, b) => a[2] - b[2]);
+
+    if (candidates.length > 0) {
+      cursor = cursorFeature(candidates[0][1], true);
+      snappedIndex = candidates[0][0];
+    }
+  });
+
+  $map.on("click", (e) => {
+    if (mode != thisMode) {
+      return;
+    }
+
+    if (snappedIndex != null) {
+      let result = lineSplit($gjScheme.features[snappedIndex], cursor);
+      if (result.features.length == 2) {
+        let piece1 = result.features[0];
+        let piece2 = result.features[1];
+
+        gjScheme.update((gj) => {
+          // Keep the old ID for one, assign a new ID to the other
+          piece1.id = gj.features[snappedIndex].id;
+          piece2.id = newFeatureId(gj);
+
+          // The properties get lost. Copy everything to both
+          piece1.properties = gj.features[snappedIndex].properties;
+          // "Deep clone"
+          piece2.properties = JSON.parse(JSON.stringify(piece1.properties));
+
+          // TODO Need to fix length_meters and waypoints!
+
+          // Replace the one LineString we snapped to with the two new pieces
+          gj.features.splice(snappedIndex, 1, piece1, piece2);
+
+          return gj;
+        });
+      }
+    }
+    // TODO Edit one of the pieces?
+    changeMode("edit-attribute");
+  });
+
+  // Rendering
+  let source = "split-route";
+  overwriteSource($map, source, {
+    type: "geojson",
+    data: emptyGeojson(),
+  });
+  // TODO Scissors icon?
+  // TODO Z-ordering wrong?
+  overwriteLayer($map, {
+    id: "draw-split-route",
+    source,
+    ...drawCircle("black", circleRadiusPixels, [
+      "case",
+      ["==", ["get", "snapped"], true],
+      1.0,
+      0.5,
+    ]),
+  });
+
+  $: {
+    let gj = emptyGeojson();
+    if (cursor) {
+      gj.features.push(cursor);
+    }
+    $map.getSource(source).setData(gj);
+  }
+
+  function cursorFeature(pt, snapped) {
+    return {
+      type: "Feature",
+      properties: {
+        snapped,
+      },
+      geometry: {
+        type: "Point",
+        coordinates: pt,
+      },
+    };
+  }
+</script>
+
+{#if mode == thisMode}
+  <p>Click near a route to split it, or click on the map to cancel</p>
+{/if}

--- a/components/draw/Toolbox.svelte
+++ b/components/draw/Toolbox.svelte
@@ -9,6 +9,7 @@
   import RouteMode from "./RouteMode.svelte";
   import PointMode from "./PointMode.svelte";
   import PolygonMode from "./PolygonMode.svelte";
+  import SplitRouteMode from "./SplitRouteMode.svelte";
 
   export let routeUrl;
   // Plumbed up from RouteMode, so we can pass it down to GeometryMode
@@ -26,6 +27,7 @@
   let routeMode;
   let pointMode;
   let polygonMode;
+  let splitRouteMode;
 
   // This must be used; don't manually change mode
   function changeMode(newMode) {
@@ -35,6 +37,7 @@
       route: routeMode,
       point: pointMode,
       polygon: polygonMode,
+      "split-route": splitRouteMode,
     };
 
     if (mode == newMode) {
@@ -105,6 +108,14 @@
       bind:routeSnapper
       bind:snapTool
     />
+  </div>
+  <div>
+    <button
+      type="button"
+      on:click={() => changeMode("split-route")}
+      disabled={mode == "split-route"}>Split route</button
+    >
+    <SplitRouteMode bind:this={splitRouteMode} {mode} {changeMode} />
   </div>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@mapbox/geojson-extent": "^1.0.1",
         "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
         "@turf/length": "^6.5.0",
+        "@turf/line-slice": "^6.5.0",
         "@turf/line-split": "^6.5.0",
         "@turf/mask": "^6.5.0",
         "@turf/nearest-point-on-line": "^6.5.0",
@@ -727,6 +729,19 @@
         "@turf/helpers": "^6.5.0",
         "@turf/invariant": "^6.5.0",
         "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-6.5.0.tgz",
+      "integrity": "sha512-vDqJxve9tBHhOaVVFXqVjF5qDzGtKWviyjbyi2QnSnxyFAmLlLnBfMX8TLQCAf2GxHibB95RO5FBE6I2KVPRuw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/nearest-point-on-line": "^6.5.0"
       },
       "funding": {
         "url": "https://opencollective.com/turf"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mapbox/geojson-extent": "^1.0.1",
         "@turf/boolean-point-in-polygon": "^6.5.0",
         "@turf/length": "^6.5.0",
+        "@turf/line-split": "^6.5.0",
         "@turf/mask": "^6.5.0",
         "@turf/nearest-point-on-line": "^6.5.0",
         "carbon-components-svelte": "^0.70.13",
@@ -731,6 +732,26 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/line-split": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-6.5.0.tgz",
+      "integrity": "sha512-/rwUMVr9OI2ccJjw7/6eTN53URtGThNSD5I0GgxyFXMtxWiloRJ9MTff8jBbtPWrRka/Sh2GkwucVRAEakx9Sw==",
+      "dependencies": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "@turf/line-segment": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "@turf/nearest-point-on-line": "^6.5.0",
+        "@turf/square": "^6.5.0",
+        "@turf/truncate": "^6.5.0",
+        "geojson-rbush": "3.x"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/mask": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-6.5.0.tgz",
@@ -765,6 +786,30 @@
         "@turf/helpers": "^6.5.0",
         "@turf/invariant": "^6.5.0",
         "@turf/line-intersect": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-6.5.0.tgz",
+      "integrity": "sha512-BM2UyWDmiuHCadVhHXKIx5CQQbNCpOxB6S/aCNOCLbhCeypKX5Q0Aosc5YcmCJgkwO5BERCC6Ee7NMbNB2vHmQ==",
+      "dependencies": {
+        "@turf/distance": "^6.5.0",
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-6.5.0.tgz",
+      "integrity": "sha512-pFxg71pLk+eJj134Z9yUoRhIi8vqnnKvCYwdT4x/DQl/19RVdq1tV3yqOT3gcTQNfniteylL5qV1uTBDV5sgrg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mapbox/geojson-extent": "^1.0.1",
     "@turf/boolean-point-in-polygon": "^6.5.0",
     "@turf/length": "^6.5.0",
+    "@turf/line-split": "^6.5.0",
     "@turf/mask": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.5.0",
     "carbon-components-svelte": "^0.70.13",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "dependencies": {
     "@mapbox/geojson-extent": "^1.0.1",
     "@turf/boolean-point-in-polygon": "^6.5.0",
+    "@turf/helpers": "^6.5.0",
     "@turf/length": "^6.5.0",
+    "@turf/line-slice": "^6.5.0",
     "@turf/line-split": "^6.5.0",
     "@turf/mask": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.5.0",

--- a/stores.js
+++ b/stores.js
@@ -64,6 +64,10 @@ export function setCurrentlyEditing(id) {
 // Although this implementation may appear to ID features in order (1, 2, 3,
 // etc), this is NOT an invariant. Do not assume this; it will not be true as
 // soon as a user deletes or reorders an intervention.
+//
+// NOTE! If you call this twice in a row in a `gjScheme.update` transaction
+// without adding one of the new features, then this'll return the same ID
+// twice!
 export function newFeatureId(gj) {
   let ids = new Set();
   for (let f of gj.features) {


### PR DESCRIPTION

https://user-images.githubusercontent.com/1664407/231227440-89f0468e-7b08-485a-b500-d372046ce3b6.mp4

Here's a new mode to split routes. The intended flow is that users will first sketch the overall route they want, then later optionally fill in more info about different sections of the route. The specific interventions will likely vary based on available width and other factors. This tool helps them refine a long route into shorter ones.

There's one big task left before this PR is ready: when we split a route, we need to update the route-snapper's stored waypoints, so that we can then edit each piece individually.

Some inspiration for other line splitting tools in the mapbox-gl-draw ecosystem: https://github.com/ReyhaneMasumi/mapbox-gl-draw-split-line-mode, https://github.com/BrunoSalerno/mapbox-gl-draw-cut-line-mode, https://github.com/mhsattarian/mapbox-gl-draw-snap-mode