### PR TITLE
Manage callbacks better

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ interact with the page normally, generating the equivalent test code.
 [Hot module replacement](https://vitejs.dev/guide/features.html#hot-module-replacement) means you can edit source code and have just that Svelte component live-reload in the browser, without needing to do anything. It's incredibly useful for rapid iteration, especially for simple things like styling. There are some gotchas to keep it working:
 
 - Use `overwriteSource` and `overwriteLayer` instead of `map.addSource` and `map.addLayer`
-- Most event listeners (on `document` and `map`) aren't yet correctly torn down, so as hot-reloading happens, you might wind up firing the same (or older versions) handler many times
+- Within a `.ts` file using classes, use `EventManager` to handle MapLibre and document event handlers. Otherwise as you edit a component, you'll keep running old versions of the callbacks!
+- Within a Svelte component, express event handlers using functions and remember to call `map.off()` within `onDestroy`. Refer to existing components.
 - When in doubt, Ctrl+Shift+R to hard refresh and get rid of any possible HMR weirdness
 
 ### Overall app state

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
+  import { type MapMouseEvent } from "maplibre-gl";
   import type { LineString, Polygon } from "geojson";
   import type { PointTool } from "./point/point_tool";
   import type { PolygonTool } from "./polygon/polygon_tool";

--- a/src/lib/draw/events.ts
+++ b/src/lib/draw/events.ts
@@ -1,0 +1,42 @@
+import type { Map } from "maplibre-gl";
+
+// Use this to create and destroy event handlers on the map and document. When
+// the handlers are object methods, it's tedious to specify exactly the same
+// value for on() and off().
+export class EventManager {
+  owner: any;
+  map: Map;
+  // TODO We could try to store better callback types?
+  mapHandlers: { [name: string]: any } = {};
+  documentHandlers: { [name: string]: any } = {};
+
+  constructor(owner: any, map: Map) {
+    this.owner = owner;
+    this.map = map;
+    this.mapHandlers = {};
+    this.documentHandlers = {};
+  }
+
+  mapHandler(name: string, handler: any) {
+    let bound = handler.bind(this.owner);
+    this.mapHandlers[name] = bound;
+    this.map.on(name, bound);
+  }
+
+  documentHandler(name: string, handler: any) {
+    let bound = handler.bind(this.owner);
+    this.documentHandlers[name] = bound;
+    document.addEventListener(name, bound);
+  }
+
+  tearDown() {
+    for (let [name, bound] of Object.entries(this.mapHandlers)) {
+      this.map.off(name, bound);
+    }
+    this.mapHandlers = {};
+    for (let [name, bound] of Object.entries(this.documentHandlers)) {
+      document.removeEventListener(name, bound);
+    }
+    this.documentHandlers = {};
+  }
+}

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -50,7 +50,7 @@ export class PointTool {
   private onMouseMove(e: MapMouseEvent) {
     if (this.active) {
       this.cursor = pointFeature(e.lngLat.toArray());
-      this.#redraw();
+      this.redraw();
     }
   }
 
@@ -85,10 +85,10 @@ export class PointTool {
   stop() {
     this.cursor = null;
     this.active = false;
-    this.#redraw();
+    this.redraw();
   }
 
-  #redraw() {
+  private redraw() {
     let gj = emptyGeojson();
     if (this.cursor) {
       gj.features.push(this.cursor);

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -100,7 +100,7 @@ export class PolygonTool {
 
   private onMouseMove(e: MapMouseEvent) {
     if (this.active && !this.dragFrom) {
-      this.#recalculateHovering(e);
+      this.recalculateHovering(e);
     } else if (this.active && this.dragFrom) {
       if (this.hover == "polygon") {
         // Move entire polygon
@@ -114,7 +114,7 @@ export class PolygonTool {
         this.points[this.hover as number] = e.lngLat.toArray();
       }
       this.dragFrom = e.lngLat.toArray();
-      this.#redraw();
+      this.redraw();
     }
   }
 
@@ -138,14 +138,14 @@ export class PolygonTool {
         this.points.push(this.cursor.geometry.coordinates);
         this.hover = this.points.length - 1;
       }
-      this.#redraw();
+      this.redraw();
     } else if (this.active && typeof this.hover === "number") {
       this.points.splice(this.hover, 1);
       this.hover = null;
-      this.#redraw();
+      this.redraw();
       // TODO Doesn't seem to work; you still have to move the mouse to hover
       // on the polygon
-      this.#recalculateHovering(e);
+      this.recalculateHovering(e);
     }
   }
 
@@ -169,7 +169,7 @@ export class PolygonTool {
     }
     if (e.key == "Enter") {
       e.preventDefault();
-      let polygon = this.#polygonFeature();
+      let polygon = this.polygonFeature();
       if (polygon) {
         for (let cb of this.eventListeners) {
           cb(polygon);
@@ -199,8 +199,8 @@ export class PolygonTool {
     this.active = true;
     this.points = feature.geometry.coordinates[0];
     this.points.pop();
-    this.#redraw();
-    // TODO #recalculateHovering, but we need to know where the mouse is
+    this.redraw();
+    // TODO recalculateHovering, but we need to know where the mouse is
   }
 
   stop() {
@@ -209,10 +209,10 @@ export class PolygonTool {
     this.active = false;
     this.hover = null;
     this.dragFrom = null;
-    this.#redraw();
+    this.redraw();
   }
 
-  #redraw() {
+  private redraw() {
     let gj = emptyGeojson();
 
     this.points.forEach((pt, idx) => {
@@ -227,7 +227,7 @@ export class PolygonTool {
 
     gj.features = gj.features.concat(pointsToLineSegments(this.points));
 
-    let polygon = this.#polygonFeature();
+    let polygon = this.polygonFeature();
     if (polygon) {
       polygon.properties!.hover = this.hover == "polygon";
       gj.features.push(polygon);
@@ -236,7 +236,7 @@ export class PolygonTool {
     (this.map.getSource(source) as GeoJSONSource).setData(gj);
   }
 
-  #recalculateHovering(e: MapLayerMouseEvent) {
+  private recalculateHovering(e: MapLayerMouseEvent) {
     this.cursor = null;
     this.hover = null;
 
@@ -259,11 +259,11 @@ export class PolygonTool {
       this.cursor = pointFeature(e.lngLat.toArray());
     }
 
-    this.#redraw();
+    this.redraw();
   }
 
   // TODO Force the proper winding order that geojson requires
-  #polygonFeature(): FeatureWithProps<Polygon> | null {
+  polygonFeature(): FeatureWithProps<Polygon> | null {
     if (this.points.length < 3) {
       return null;
     }

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -98,7 +98,7 @@ export class RouteTool {
     if (
       this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters)
     ) {
-      this.#redraw();
+      this.redraw();
     }
   }
 
@@ -107,7 +107,7 @@ export class RouteTool {
       return;
     }
     this.inner.onClick();
-    this.#redraw();
+    this.redraw();
   }
 
   private onDragStart() {
@@ -145,7 +145,7 @@ export class RouteTool {
     if (e.key == "Shift") {
       e.preventDefault();
       this.inner.setSnapMode(false);
-      this.#redraw();
+      this.redraw();
     }
   }
 
@@ -156,7 +156,7 @@ export class RouteTool {
     if (e.key == "Shift") {
       e.preventDefault();
       this.inner.setSnapMode(true);
-      this.#redraw();
+      this.redraw();
     }
   }
 
@@ -177,7 +177,7 @@ export class RouteTool {
   stop() {
     this.active = false;
     this.inner.clearState();
-    this.#redraw();
+    this.redraw();
     this.map["boxZoom"].enable();
   }
 
@@ -213,7 +213,7 @@ export class RouteTool {
 
     this.start();
     this.inner.editExisting(feature.properties.waypoints);
-    this.#redraw();
+    this.redraw();
   }
 
   // Destroy resources attached to the map. Warning, this doesn't yet handle
@@ -260,10 +260,10 @@ export class RouteTool {
 
   setConfig(config: { avoid_doubling_back: boolean }) {
     this.inner.setConfig(config);
-    this.#redraw();
+    this.redraw();
   }
 
-  #redraw() {
+  private redraw() {
     (this.map.getSource(source) as GeoJSONSource).setData(
       JSON.parse(this.inner.renderGeojson())
     );


### PR DESCRIPTION
As the edits near `README` describe, we have to be a bit careful about unregistering any document/map/etc event handlers when a Svelte component gets torn down. Otherwise as you edit a component, every previous version of the callback keeps running! This PR fixes most remaining problems; see comments below for the strategy.

The last big remaining problem is the custom observable pattern used in all the `*tool.ts` classes with `addEventListener`. We need to clean those up too.