### PR TITLE
Consistent controls to stop drawing

### DIFF
--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -177,7 +177,7 @@
   {#if currentlyEditingControls == "point"}
     <PointControls {pointTool} editingExisting={true} />
   {:else if currentlyEditingControls == "polygon"}
-    <PolygonControls />
+    <PolygonControls {polygonTool} />
   {:else if currentlyEditingControls == "route"}
     <RouteControls {routeTool} />
   {:else}

--- a/src/lib/draw/KeyHandler.svelte
+++ b/src/lib/draw/KeyHandler.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  interface Cancelable {
+    cancel(): void;
+  }
+
+  export let tool: Cancelable;
+
+  // The escape key isn't registered at all for keypress, so use keydown
+  // TODO And this callback doesn't seem to work at all until clicking
+  // somewhere after this component is mounted
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key == "Escape") {
+      tool.cancel();
+      e.preventDefault();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeyDown} />

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { PointTool } from "./point_tool";
+
+  export let pointTool: PointTool;
   export let editingExisting: boolean;
 </script>
 
@@ -7,3 +10,5 @@
 {:else}
   <p>Click to add a new point</p>
 {/if}
+
+<button type="button" on:click={() => pointTool.cancel()}>Cancel</button>

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { PointTool } from "./point_tool";
+  import KeyHandler from "../KeyHandler.svelte";
 
   export let pointTool: PointTool;
   export let editingExisting: boolean;
@@ -10,5 +11,7 @@
 {:else}
   <p>Click to add a new point</p>
 {/if}
+<p>Press <b>Escape</b> to cancel</p>
 
 <button type="button" on:click={() => pointTool.cancel()}>Cancel</button>
+<KeyHandler tool={pointTool} />

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -19,7 +19,7 @@
     pointTool.stop();
   }
 
-  pointTool.addEventListener((feature) => {
+  pointTool.addEventListenerSuccess((feature) => {
     if (mode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
@@ -32,8 +32,13 @@
       formOpen.set(feature.id as number);
     }
   });
+  pointTool.addEventListenerFailure(() => {
+    if (mode == thisMode) {
+      changeMode("edit-attribute");
+    }
+  });
 </script>
 
 {#if mode == thisMode}
-  <PointControls editingExisting={false} />
+  <PointControls {pointTool} editingExisting={false} />
 {/if}

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { PolygonTool } from "./polygon_tool";
+  import KeyHandler from "../KeyHandler.svelte";
 
   export let polygonTool: PolygonTool;
 </script>
@@ -9,9 +10,11 @@
   <li><b>Click</b> a vertex to delete it</li>
   <li><b>Drag</b> a vertex or the polygon to move it</li>
   <li>Press <b>Enter</b> to finish</li>
+  <li>Press <b>Escape</b> to cancel</li>
 </ul>
 
 <div style="display: flex; justify-content: space-between">
   <button type="button" on:click={() => polygonTool.finish()}>Finish</button>
   <button type="button" on:click={() => polygonTool.cancel()}>Cancel</button>
 </div>
+<KeyHandler tool={polygonTool} />

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,6 +1,17 @@
+<script lang="ts">
+  import { PolygonTool } from "./polygon_tool";
+
+  export let polygonTool: PolygonTool;
+</script>
+
 <ul>
   <li><b>Click</b> the map to add a vertex</li>
   <li><b>Click</b> a vertex to delete it</li>
   <li><b>Drag</b> a vertex or the polygon to move it</li>
   <li>Press <b>Enter</b> to finish</li>
 </ul>
+
+<div style="display: flex; justify-content: space-between">
+  <button type="button" on:click={() => polygonTool.finish()}>Finish</button>
+  <button type="button" on:click={() => polygonTool.cancel()}>Cancel</button>
+</div>

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -19,7 +19,7 @@
     polygonTool.stop();
   }
 
-  polygonTool.addEventListener((feature) => {
+  polygonTool.addEventListenerSuccess((feature) => {
     if (mode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
@@ -32,8 +32,13 @@
       formOpen.set(feature.id as number);
     }
   });
+  polygonTool.addEventListenerFailure(() => {
+    if (mode == thisMode) {
+      changeMode("edit-attribute");
+    }
+  });
 </script>
 
 {#if mode == thisMode}
-  <PolygonControls />
+  <PolygonControls {polygonTool} />
 {/if}

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { RouteTool } from "./route_tool";
+  import KeyHandler from "../KeyHandler.svelte";
 
   export let routeTool: RouteTool;
 
@@ -21,6 +22,7 @@
   <li><b>Click and drag</b> any point to move it</li>
   <li><b>Click</b> a red waypoint to delete it</li>
   <li>Press <b>Enter</b> to finish route</li>
+  <li>Press <b>Escape</b> to cancel</li>
 </ul>
 
 <label>
@@ -32,3 +34,4 @@
   <button type="button" on:click={() => routeTool.finish()}>Finish</button>
   <button type="button" on:click={() => routeTool.cancel()}>Cancel</button>
 </div>
+<KeyHandler tool={routeTool} />

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -260,8 +260,21 @@
     let sliced = lineSlice(start, point, line);
     return length(sliced, { units: "kilometers" }) * 1000.0;
   }
+
+  // The escape key isn't registered at all for keypress, so use keydown
+  function onKeyDown(e: KeyboardEvent) {
+    if (mode == thisMode && e.key == "Escape") {
+      changeMode("edit-attribute");
+      e.preventDefault();
+    }
+  }
 </script>
 
 {#if mode == thisMode}
-  <p>Click near a route to split it, or click on the map to cancel</p>
+  <ul>
+    <li><b>Click</b> near a route to split it</li>
+    <li><b>Click</b> on the map or press <b>Escape</b> to cancel</li>
+  </ul>
 {/if}
+
+<svelte:window on:keydown={onKeyDown} />

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -216,8 +216,7 @@ export class RouteTool {
     this.redraw();
   }
 
-  // Destroy resources attached to the map. Warning, this doesn't yet handle
-  // event listeners!
+  // Destroy resources attached to the map.
   tearDown() {
     // TODO Will these throw if they're not there?
     this.map.removeLayer("route-points");
@@ -252,7 +251,7 @@ export class RouteTool {
     this.stop();
   }
 
-  // This stops the control and fires a failure event
+  // This stops the tool and fires a failure event
   cancel() {
     this.inner.clearState();
     this.finish();


### PR DESCRIPTION
This adds a clickable cancel button to all modes, and lets pressing the escape key also work. #124 

Weird caveat: listening for the escape key only works after clicking on the page. Not sure why.