### PR TITLE
Specialized planning mode form, toggled by a URL query param

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,6 +29,7 @@
   // TODO Add validation and some kind of error page
   let authorityName: string = params.get("authority")!;
   let style: string = params.get("style") || "streets";
+  let planningMode = params.has("planning");
 
   // TODO Slight hack. These files are stored in an S3 bucket, which only has
   // an HTTP interface. When deployed to Github pages over HTTPS, we can't mix
@@ -75,16 +76,16 @@
   </div>
   <div slot="sidebar">
     <h1>{authorityName} <ZoomOutMap {boundaryGeojson} /></h1>
-    <EntireScheme {authorityName} />
+    <EntireScheme {authorityName} {planningMode} />
     <br />
-    <InterventionList />
+    <InterventionList {planningMode} />
   </div>
   <div slot="main">
     <Map {style}>
       <BoundaryLayer {boundaryGeojson} />
       <InterventionLayer />
       <HoverLayer />
-      <Toolbox {routeUrl} />
+      <Toolbox {routeUrl} {planningMode} />
       <BaselayerSwitcher {style} />
       <Legend />
     </Map>

--- a/src/lib/EntireScheme.svelte
+++ b/src/lib/EntireScheme.svelte
@@ -4,9 +4,15 @@
   import type { Scheme } from "../types";
 
   export let authorityName: string;
+  export let planningMode: boolean;
+
+  let baseFilename = authorityName;
+  if (planningMode) {
+    baseFilename += "_planning";
+  }
 
   // Set up local storage sync
-  let loadLocal = window.localStorage.getItem(authorityName);
+  let loadLocal = window.localStorage.getItem(baseFilename);
   if (loadLocal) {
     try {
       gjScheme.set(backfill(JSON.parse(loadLocal)));
@@ -19,7 +25,7 @@
     if ($gjScheme) {
       console.log(`GJ changed, saving to local storage`);
       window.localStorage.setItem(
-        authorityName,
+        baseFilename,
         JSON.stringify(geojsonToSave())
       );
     }
@@ -51,7 +57,7 @@
 
   function exportToGeojson() {
     let geojson = geojsonToSave();
-    var filename = authorityName;
+    var filename = baseFilename;
     geojson.authority = authorityName;
     // we could probably be more sophisticated here and set version more centrally
     geojson.origin = "atip-v1";

--- a/src/lib/InterventionList.svelte
+++ b/src/lib/InterventionList.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import type { FeatureUnion } from "../types";
   import Form from "./Form.svelte";
+  import PlanningForm from "./PlanningForm.svelte";
   import AccordionItem from "./AccordionItem.svelte";
   import { gjScheme, formOpen, deleteIntervention } from "../stores";
+
+  export let planningMode: boolean;
 
   function interventionName(feature: FeatureUnion): string {
     if (feature.properties.name) {
@@ -45,12 +48,16 @@
     id={feature.id}
     label={i + 1 + ") " + interventionName(feature)}
   >
-    <Form
-      id={feature.id}
-      bind:name={feature.properties.name}
-      bind:intervention_type={feature.properties.intervention_type}
-      bind:description={feature.properties.description}
-      length_meters={feature.properties.length_meters}
-    />
+    {#if planningMode}
+      <PlanningForm id={feature.id} bind:allProperties={feature.properties} />
+    {:else}
+      <Form
+        id={feature.id}
+        bind:name={feature.properties.name}
+        bind:intervention_type={feature.properties.intervention_type}
+        bind:description={feature.properties.description}
+        length_meters={feature.properties.length_meters}
+      />
+    {/if}
   </AccordionItem>
 {/each}

--- a/src/lib/PlanningForm.svelte
+++ b/src/lib/PlanningForm.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { gjScheme, deleteIntervention, formOpen } from "../stores";
+  import type { InterventionProps, PlanningProps } from "../types";
+
+  export let id: number;
+  export let allProperties: InterventionProps;
+
+  // TODO Should we start with these defaults, or make everything optional?
+  allProperties.planning ||= {
+    name: "",
+    notes: "",
+    reference_type: "preapp",
+    size: 0,
+    size_units: "number of units",
+    triage: "No Comment",
+    recommendation: "No Comment",
+  };
+  let props: PlanningProps = allProperties.planning!;
+
+  const referenceTypes = [
+    "preapp",
+    "outline",
+    "reserved matters",
+    "local plan",
+  ];
+  const sizeUnits = [
+    "number of units",
+    "floorspace (Gross Floor Area)",
+    "area (Hectare)",
+  ];
+  const triages = ["No Comment", "Standing Advice", "Toolkit Assessment"];
+  const recommendations = [
+    "No Comment",
+    "No Objection",
+    "Standing Advice",
+    "Deferral",
+    "Approve subject to conditions and/or obligations",
+    "Refusal",
+  ];
+</script>
+
+<label
+  >Name:<br />
+  <input type="text" bind:value={props.name} style="width: 100%" />
+</label>
+
+<br />
+<br />
+
+<label>
+  Reference type:
+  <select bind:value={props.reference_type}>
+    {#each referenceTypes as x}
+      <option value={x}>{x}</option>
+    {/each}
+  </select>
+</label>
+
+<br />
+<br />
+
+<label>
+  Notes:<br />
+  <textarea bind:value={props.notes} style="width: 100%" rows="5" />
+</label>
+
+<br />
+<br />
+
+<label>
+  Size:
+  <input type="number" bind:value={props.size} min="0" max="1000" />
+  <select bind:value={props.size_units}>
+    {#each sizeUnits as x}
+      <option value={x}>{x}</option>
+    {/each}
+  </select>
+</label>
+
+<br />
+<br />
+
+<label>
+  ATE Triage:
+  <select bind:value={props.triage}>
+    {#each triages as x}
+      <option value={x}>{x}</option>
+    {/each}
+  </select>
+</label>
+
+<br />
+<br />
+
+<label>
+  ATE Recommendation:
+  <select bind:value={props.recommendation}>
+    {#each recommendations as x}
+      <option value={x}>{x}</option>
+    {/each}
+  </select>
+</label>
+
+<br />
+<br />
+
+<div style="display: flex; justify-content: space-between">
+  <button type="button" on:click={() => deleteIntervention(id)}>Delete</button>
+  <button type="button" on:click={() => formOpen.set(null)}>Save</button>
+</div>
+
+<style>
+  textarea {
+    resize: none;
+  }
+</style>

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -14,6 +14,7 @@
   import SplitRouteMode from "./route/SplitRouteMode.svelte";
 
   export let routeUrl: string;
+  export let planningMode: boolean;
   // Plumbed up from RouteMode, so we can pass it down to GeometryMode
   // TODO Reconsider
   let routeTool: RouteTool;
@@ -85,11 +86,13 @@
     {/if}
   </div>
   <div>
-    <button
-      type="button"
-      on:click={() => changeMode("point")}
-      disabled={mode == "point"}>New point</button
-    >
+    {#if !planningMode}
+      <button
+        type="button"
+        on:click={() => changeMode("point")}
+        disabled={mode == "point"}>New point</button
+      >
+    {/if}
     <PointMode bind:this={pointMode} {mode} {changeMode} {pointTool} />
   </div>
   <div>
@@ -101,11 +104,13 @@
     <PolygonMode bind:this={polygonMode} {mode} {changeMode} {polygonTool} />
   </div>
   <div>
-    <button
-      type="button"
-      on:click={() => changeMode("route")}
-      disabled={mode == "route"}>New route</button
-    >
+    {#if !planningMode}
+      <button
+        type="button"
+        on:click={() => changeMode("route")}
+        disabled={mode == "route"}>New route</button
+      >
+    {/if}
     <RouteMode
       bind:this={routeMode}
       {mode}
@@ -115,11 +120,13 @@
     />
   </div>
   <div>
-    <button
-      type="button"
-      on:click={() => changeMode("split-route")}
-      disabled={mode == "split-route"}>Split route</button
-    >
+    {#if !planningMode}
+      <button
+        type="button"
+        on:click={() => changeMode("split-route")}
+        disabled={mode == "split-route"}>Split route</button
+      >
+    {/if}
     <SplitRouteMode bind:this={splitRouteMode} {mode} {changeMode} />
   </div>
 </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,8 +37,27 @@ export interface InterventionProps {
   length_meters?: number;
   waypoints?: Waypoint[];
 
+  // TODO Hack. If these're filled out, ignore the schema above.
+  planning?: PlanningProps;
+
   // Temporary state, not meant to be serialized
   hide_while_editing?: boolean;
+}
+
+export interface PlanningProps {
+  name: string;
+  notes: string;
+  reference_type: "preapp" | "outline" | "reserved matters" | "local plan";
+  size: number;
+  size_units: "number of units" | "floorspace" | "area";
+  triage: "No Comment" | "Standing Advice" | "Toolkit Assessment";
+  recommendation:
+    | "No Comment"
+    | "No Objection"
+    | "Standing Advice"
+    | "Deferral"
+    | "Approve subject to conditions and/or obligations"
+    | "Refusal";
 }
 
 export interface Waypoint {


### PR DESCRIPTION
For #136. It's just normal ATIP, but with a different form, and only a polygon tool.

https://user-images.githubusercontent.com/1664407/234032078-f7ab007f-6eef-44a5-8181-8e92eb3a0104.mp4

UX thoughts:
- Should we have buttons to switch between regular ATIP mode and planning mode, or should planning folks know to go to a special URL? We should probably loudly change the style or label the page as planning mode, regardless.
- The about & instructions popups maybe need to change
- Is the form easy to use? Is it too small cramped in the sidebar; should we have a bigger modal pop up?

Implementation / code maintenance thoughts:
- The current approach is to introduce a `?planning` URL query param and toggle a bunch of behavior based on that. This was the easiest way to make this change, but is it the most maintainable?
- Should we instead make a separate `.html` with its own specialized copy of `App`? The immediate problem is that most components are the same; only a few need to specialize right now. Maybe we revisit as both ATIP modes evolve?
- Alternatively, do we bite the bullet and make everything in ATIP much more generic? Do we want to support multiple schemas or data entry forms?