### PR TITLE
Add a schema for critical issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fmt": "npx prettier --write *.html tests/* src/*",
     "test": "npx playwright test",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "generate-schema-ts": "npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/v2.json > src/schemas/v2.ts && npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/planning.json > src/schemas/planning.ts"
+    "generate-schema-ts": "for x in v2 planning criticals; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done"
   },
   "devDependencies": {
     "@playwright/test": "1.31.2",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -92,6 +92,7 @@
         <option value="v1">v1</option>
         <option value="v2">v2</option>
         <option value="planning">Housing developments</option>
+        <option value="criticals">Critical issues</option>
       </select>
     </label>
   </div>

--- a/src/lib/InterventionList.svelte
+++ b/src/lib/InterventionList.svelte
@@ -3,6 +3,7 @@
   import FormV1 from "./forms/FormV1.svelte";
   import FormV2 from "./forms/FormV2.svelte";
   import PlanningForm from "./forms/PlanningForm.svelte";
+  import CriticalsForm from "./forms/CriticalsForm.svelte";
   import AccordionItem from "./AccordionItem.svelte";
   import { gjScheme, formOpen, deleteIntervention } from "../stores";
 
@@ -71,6 +72,8 @@
       <FormV2 bind:props={feature.properties} />
     {:else if schema == "planning"}
       <PlanningForm bind:props={feature.properties} />
+    {:else if schema == "criticals"}
+      <CriticalsForm bind:props={feature.properties} />
     {/if}
 
     <br />

--- a/src/lib/forms/CriticalsForm.svelte
+++ b/src/lib/forms/CriticalsForm.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import schemaJson from "../../schemas/criticals.json";
+  import AutogenerateForm from "./AutogenerateForm.svelte";
+  import type { Field } from "./types";
+  import type { InterventionProps } from "../../types";
+
+  export let props: InterventionProps;
+
+  props.criticals ||= {};
+
+  let x: Field = schemaJson;
+</script>
+
+<AutogenerateForm spec={x} bind:value={props.criticals} />

--- a/src/schemas/criticals.json
+++ b/src/schemas/criticals.json
@@ -1,0 +1,78 @@
+{
+  "name": "CriticalIssue",
+  "members": [
+    {
+      "name": "Type",
+      "oneOf": [
+        {
+          "value": "Conflict with motor traffic at side roads / priority junctions",
+          "description": ">2500vpd cut across main cycling or walking streams"
+        },
+        {
+          "value": "Conflict with motor traffic at signal controlled junctions and roundabouts",
+          "description": ">2500vpd cut across main cycling or walking streams"
+        },
+        {
+          "value": "Collision alongside or from behind",
+          "description": "Cyclists are not protected in traffic lanes between 3.25 and 3.9m wide."
+        },
+        {
+          "value": "Trip hazard",
+          "description": "There are level differences of greater than 20mm with no colour contrast to help identify them."
+        },
+        {
+          "value": "Conflict with kerbside activity (parking, loading, risk of 'dooring') ",
+          "description": "Cycle facility next to parking/loading with no buffer."
+        },
+        {
+          "value": "Kerbside activity or risk of crossing conflict",
+          "description": "On busy roads (>8000vpd) formal crossings are more than 400m apart. On quieter roads (<8000vpd), desire lines are blocked by parking and loading."
+        },
+        {
+          "value": "Standard of crossing facility",
+          "description": "On busy roads (>8000vpd), there are uncontrolled crossings of two or more lanes with no gaps in traffic. At signal junctions there are arms with no green man for pedestrians."
+        },
+        {
+          "value": "Speed of traffic (where cyclists are not separated or pedestrians crossing uncontrolled)",
+          "description": "85th percentile > 37mph (60kph)"
+        },
+        {
+          "value": "Total volume of traffic (where cyclists are not separated or pedestrians cross uncontrolled)",
+          "description": ">10000 vpd. >5% of traffic is HGVs."
+        },
+        {
+          "value": "Required crossing speed (risk of pedestrians coming into conflict with traffic)",
+          "description": "Pedestrians must cross at a speed of over 1.2m/s to get across the crossing in time."
+        },
+        {
+          "value": "Clear walking spaces free of obstructions and furniture, reducing risk of pedestrians walking in the carriageway.",
+          "description": "<1.5m clear footway width. Or, 1.5m-2m clear footway width and pedestrian comfort is poor (PCL of D-E)."
+        },
+        {
+          "value": "Effective width next to tram line on a straight run",
+          "description": "<2.4m from tramline edge to kerb."
+        },
+        {
+          "value": "Crossing angle (between cyclist desire line and tram tracks)",
+          "description": "Crossing angle less than 60 degrees."
+        },
+        {
+          "value": "Defects: non cycle friendly ironworks, raised/ sunken covers/gullies",
+          "description": "Major defects"
+        },
+        {
+          "value": "Defects: non flush tables, misleading tactile information, cracked paving, slip-risks present from covers, steep slopes",
+          "description": "Major defects"
+        }
+      ]
+    },
+    {
+      "name": "comment",
+      "type": "textbox"
+    },
+    {
+      "name": "photographed",
+      "type": "checkbox"
+    }
+  ]
+}

--- a/src/schemas/criticals.ts
+++ b/src/schemas/criticals.ts
@@ -1,0 +1,24 @@
+// This file is auto-generated; do not manually edit
+
+export interface CriticalIssue {
+  Type?: Type;
+  comment?: string;
+  photographed?: boolean;
+}
+
+export type Type =
+  | "Conflict with motor traffic at side roads / priority junctions"
+  | "Conflict with motor traffic at signal controlled junctions and roundabouts"
+  | "Collision alongside or from behind"
+  | "Trip hazard"
+  | "Conflict with kerbside activity (parking, loading, risk of 'dooring') "
+  | "Kerbside activity or risk of crossing conflict"
+  | "Standard of crossing facility"
+  | "Speed of traffic (where cyclists are not separated or pedestrians crossing uncontrolled)"
+  | "Total volume of traffic (where cyclists are not separated or pedestrians cross uncontrolled)"
+  | "Required crossing speed (risk of pedestrians coming into conflict with traffic)"
+  | "Clear walking spaces free of obstructions and furniture, reducing risk of pedestrians walking in the carriageway."
+  | "Effective width next to tram line on a straight run"
+  | "Crossing angle (between cyclist desire line and tram tracks)"
+  | "Defects: non cycle friendly ironworks, raised/ sunken covers/gullies"
+  | "Defects: non flush tables, misleading tactile information, cracked paving, slip-risks present from covers, steep slopes";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 import type { Point, LineString, Polygon } from "geojson";
 import type { Intervention } from "./schemas/v2";
 import type { Planning } from "./schemas/planning";
+import type { CriticalIssue } from "./schemas/criticals";
 
-export type Schema = "v1" | "v2" | "planning";
+export type Schema = "v1" | "v2" | "planning" | "criticals";
 
 // This describes the full structure of the GeoJSON we manage. We constrain the
 // default GeoJSON types and specify feature properties.
@@ -45,6 +46,7 @@ export interface InterventionProps {
   // TODO Hack. If these're filled out, ignore the schema above.
   planning?: Planning;
   v2?: Intervention;
+  criticals?: CriticalIssue;
 
   // Temporary state, not meant to be serialized
   hide_while_editing?: boolean;


### PR DESCRIPTION
This is based on v2.0 of the ATE inspection spreadsheet

Related to https://github.com/acteng/overview/issues/27 -- this isn't a way to automatically discover critical issues, but a schema and UI in ATIP to collect/display the problems.

The UX of a radio button with 15 options and long descriptions is awful:
![Screenshot from 2023-05-04 13-27-42](https://user-images.githubusercontent.com/1664407/236204185-ba2445e3-459e-44a2-ae83-8a8b80aaafa3.png)
![Screenshot from 2023-05-04 13-27-35](https://user-images.githubusercontent.com/1664407/236204189-7fea509d-6d19-47ec-9dcc-69cb4264f92f.png)

But I'll merge this and iterate on other designs. Suggestions very welcome.