### PR TITLE
Let long drawing control instructions be hidden. #134

### DIFF
--- a/src/lib/draw/CollapsibleCard.svelte
+++ b/src/lib/draw/CollapsibleCard.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  // TODO Lots of overlap with AccordionItem
+  import { slide } from "svelte/transition";
+
+  export let label: string;
+
+  let open = false;
+</script>
+
+<button on:click={() => (open = !open)} aria-expanded={open}
+  ><svg
+    style="tran"
+    width="20"
+    height="20"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    stroke="currentColor"><path d="M9 5l7 7-7 7" /></svg
+  >
+  {label}
+</button>
+{#if open}
+  <div transition:slide={{ duration: 100 }}>
+    <slot />
+  </div>
+{/if}
+
+<style>
+  button {
+    border: none;
+    background: none;
+    display: block;
+    font-size: 20px;
+    cursor: pointer;
+    margin: 0;
+    padding-bottom: 0.5em;
+    padding-top: 0.5em;
+    text-align: left;
+  }
+
+  button:hover {
+    text-decoration: underline;
+  }
+
+  svg {
+    transition: transform 0.2s ease-in;
+  }
+
+  [aria-expanded="true"] svg {
+    transform: rotate(0.25turn);
+  }
+</style>

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -6,12 +6,14 @@
   export let editingExisting: boolean;
 </script>
 
-{#if editingExisting}
-  <p>Click to move the point here</p>
-{:else}
-  <p>Click to add a new point</p>
-{/if}
-<p>Press <b>Escape</b> to cancel</p>
+<ul>
+  {#if editingExisting}
+    <li>Click to move the point here</li>
+  {:else}
+    <li>Click to add a new point</li>
+  {/if}
+  <li>Press <b>Escape</b> to cancel</li>
+</ul>
 
 <button type="button" on:click={() => pointTool.cancel()}>Cancel</button>
 <KeyHandler tool={pointTool} />

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
   import { PolygonTool } from "./polygon_tool";
   import KeyHandler from "../KeyHandler.svelte";
+  import CollapsibleCard from "../CollapsibleCard.svelte";
 
   export let polygonTool: PolygonTool;
 </script>
 
-<ul>
-  <li><b>Click</b> the map to add a vertex</li>
-  <li><b>Click</b> a vertex to delete it</li>
-  <li><b>Drag</b> a vertex or the polygon to move it</li>
-  <li>Press <b>Enter</b> to finish</li>
-  <li>Press <b>Escape</b> to cancel</li>
-</ul>
+<CollapsibleCard label="Help">
+  <ul>
+    <li><b>Click</b> the map to add a vertex</li>
+    <li><b>Click</b> a vertex to delete it</li>
+    <li><b>Drag</b> a vertex or the polygon to move it</li>
+    <li>Press <b>Enter</b> to finish</li>
+    <li>Press <b>Escape</b> to cancel</li>
+  </ul>
+</CollapsibleCard>
 
 <div style="display: flex; justify-content: space-between">
   <button type="button" on:click={() => polygonTool.finish()}>Finish</button>

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { RouteTool } from "./route_tool";
   import KeyHandler from "../KeyHandler.svelte";
+  import CollapsibleCard from "../CollapsibleCard.svelte";
 
   export let routeTool: RouteTool;
 
@@ -14,16 +15,18 @@
   // TODO Disable finish when the route is invalid
 </script>
 
-<ul>
-  <li>
-    <b>Click</b> green points on the transport network to create snapped routes
-  </li>
-  <li>Hold <b>Shift</b> to draw a point anywhere</li>
-  <li><b>Click and drag</b> any point to move it</li>
-  <li><b>Click</b> a red waypoint to delete it</li>
-  <li>Press <b>Enter</b> to finish route</li>
-  <li>Press <b>Escape</b> to cancel</li>
-</ul>
+<CollapsibleCard label="Help">
+  <ul>
+    <li>
+      <b>Click</b> green points on the transport network to create snapped routes
+    </li>
+    <li>Hold <b>Shift</b> to draw a point anywhere</li>
+    <li><b>Click and drag</b> any point to move it</li>
+    <li><b>Click</b> a red waypoint to delete it</li>
+    <li>Press <b>Enter</b> to finish route</li>
+    <li>Press <b>Escape</b> to cancel</li>
+  </ul>
+</CollapsibleCard>
 
 <label>
   <input type="checkbox" bind:checked={avoidDoublingBack} />

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
   import { RouteTool } from "../route/route_tool";
   import KeyHandler from "../KeyHandler.svelte";
+  import CollapsibleCard from "../CollapsibleCard.svelte";
 
   export let routeTool: RouteTool;
 
   // TODO Disable finish when the route is invalid
 </script>
 
-<ul>
-  <li>
-    <b>Click</b> green points on the transport network to create snapped routes
-  </li>
-  <li><b>Click and drag</b> any point to move it</li>
-  <li><b>Click</b> a red waypoint to delete it</li>
-  <li>Press <b>Enter</b> to finish area</li>
-  <li>Press <b>Escape</b> to cancel</li>
-</ul>
+<CollapsibleCard label="Help">
+  <ul>
+    <li>
+      <b>Click</b> green points on the transport network to create snapped routes
+    </li>
+    <li><b>Click and drag</b> any point to move it</li>
+    <li><b>Click</b> a red waypoint to delete it</li>
+    <li>Press <b>Enter</b> to finish area</li>
+    <li>Press <b>Escape</b> to cancel</li>
+  </ul>
+</CollapsibleCard>
 
 <div style="display: flex; justify-content: space-between">
   <button type="button" on:click={() => routeTool.finish()}>Finish</button>


### PR DESCRIPTION

https://user-images.githubusercontent.com/1664407/236215962-b81e0f49-40e3-481d-a6fd-cde5f385a350.mp4

This is a small improvement to the very long instructions eating up all the toolbox space. Plenty of room for improvement. Maybe whether the instructions are shown should be remembered globally or per control?