### PR TITLE
Adding some tests for adding route intervention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,10 @@
         "svelte": "^3.54.0"
       },
       "devDependencies": {
-        "@playwright/test": "1.31.2",
+        "@playwright/test": "^1.33.0",
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@tsconfig/svelte": "^4.0.1",
-        "playwright": "1.31.2",
+        "playwright": "^1.33.0",
         "prettier": "2.8.2",
         "prettier-plugin-svelte": "^2.9.0",
         "svelte-check": "^3.2.0",
@@ -527,13 +527,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.33.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1721,13 +1721,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.2.tgz",
-      "integrity": "sha512-jpC47n2PKQNtzB7clmBuWh6ftBRS/Bt5EGLigJ9k2QAKcNeYXZkEaDH5gmvb6+AbcE0DO6GnXdbl9ogG6Eh+og==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.33.0.tgz",
+      "integrity": "sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.33.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1737,9 +1737,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "generate-schema-ts": "for x in v2 planning criticals; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done"
   },
   "devDependencies": {
-    "@playwright/test": "1.31.2",
+    "@playwright/test": "^1.33.0",
     "@sveltejs/vite-plugin-svelte": "^2.0.0",
     "@tsconfig/svelte": "^4.0.1",
-    "playwright": "1.31.2",
+    "playwright": "^1.33.0",
     "prettier": "2.8.2",
     "prettier-plugin-svelte": "^2.9.0",
     "svelte-check": "^3.2.0",

--- a/tests/add-delete-add.spec.ts
+++ b/tests/add-delete-add.spec.ts
@@ -5,7 +5,7 @@ test('testing adding interventions, then deleting one, then adding another', asy
     test.fixme();
     await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
     // wait for the map to load and interventions panel to appear
-    await page.getByText('Edit attributes Click an intervention to fill out its attributes Edit geometry N').waitFor();
+await page.getByText('Click an intervention to fill out its attributes').waitFor();
     // wait for router snapper to load so we can use route tool
     await page.getByText('Route tool loading...').waitFor({ 'state': 'hidden' });
 

--- a/tests/add-delete-add.spec.ts
+++ b/tests/add-delete-add.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test('testing adding interventions, then deleting one, then adding another', async ({ page }) => {
+    await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
+    await page.getByRole('region', { name: 'Map' }).waitFor();
+    await page.getByRole('button', { name: 'New route' }).click();
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 522,
+            y: 468
+        }
+    });
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 192,
+            y: 513
+        }
+    });
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: '1) Untitled route' }).click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'New route' }).click();
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 196,
+            y: 375
+        }
+    });
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 481,
+            y: 399
+        }
+    });
+    await page.getByRole('button', { name: 'Finish' }).click();
+
+    await expect(page.getByRole('button', { name: '1) Untitled point' }).isVisible())
+});

--- a/tests/add-delete-add.spec.ts
+++ b/tests/add-delete-add.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@playwright/test';
 
 test('testing adding interventions, then deleting one, then adding another', async ({ page }) => {
     await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
+    // wait for the map to load and interventions panel to appear
+    await page.getByText('Edit attributes Click an intervention to fill out its attributes Edit geometry N').waitFor();
+    // wait for router snapper to load so we can use route tool
+    await page.getByText('Route tool loading...').waitFor({ 'state': 'hidden' });
+
     await page.getByRole('region', { name: 'Map' }).waitFor();
     await page.getByRole('button', { name: 'New route' }).click();
     await page.getByRole('region', { name: 'Map' }).click({

--- a/tests/add-delete-add.spec.ts
+++ b/tests/add-delete-add.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 test('testing adding interventions, then deleting one, then adding another', async ({ page }) => {
+    // mark this test to fail
+    test.fixme();
     await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
     // wait for the map to load and interventions panel to appear
     await page.getByText('Edit attributes Click an intervention to fill out its attributes Edit geometry N').waitFor();

--- a/tests/add-route.spec.ts
+++ b/tests/add-route.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('testing add a route and save it', async ({ page }) => {
+    await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
+    await page.getByRole('region', { name: 'Map' }).waitFor();
+    await page.getByRole('button', { name: 'New route' }).click();
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 522,
+            y: 468
+        }
+    });
+    await page.getByRole('region', { name: 'Map' }).click({
+        position: {
+            x: 192,
+            y: 513
+        }
+    });
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByRole('button', { name: '1) Untitled route' })).toBeVisible()
+});

--- a/tests/add-route.spec.ts
+++ b/tests/add-route.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('testing add a route and save it', async ({ page }) => {
     await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
     // wait for the map to load and interventions panel to appear
-    await page.getByText('Edit attributes Click an intervention to fill out its attributes Edit geometry N').waitFor();
+    await page.getByText('Click an intervention to fill out its attributes').waitFor();
     // wait for router snapper to load so we can use route tool
     await page.getByText('Route tool loading...').waitFor({ 'state': 'hidden' });
 

--- a/tests/add-route.spec.ts
+++ b/tests/add-route.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '@playwright/test';
 
 test('testing add a route and save it', async ({ page }) => {
     await page.goto('/scheme.html?authority=Derby#16.84/52.906457/-1.504519');
-    await page.getByRole('region', { name: 'Map' }).waitFor();
+    // wait for the map to load and interventions panel to appear
+    await page.getByText('Edit attributes Click an intervention to fill out its attributes Edit geometry N').waitFor();
+    // wait for router snapper to load so we can use route tool
+    await page.getByText('Route tool loading...').waitFor({ 'state': 'hidden' });
+
     await page.getByRole('button', { name: 'New route' }).click();
     await page.getByRole('region', { name: 'Map' }).click({
         position: {
@@ -17,6 +21,8 @@ test('testing add a route and save it', async ({ page }) => {
         }
     });
     await page.getByRole('button', { name: 'Finish' }).click();
+    // wait to make sure intervention attributes appear
+    await page.getByRole('button', { name: 'Save' }).waitFor();
     await page.getByRole('button', { name: 'Save' }).click();
 
     await expect(page.getByRole('button', { name: '1) Untitled route' })).toBeVisible()


### PR DESCRIPTION
This PR adds some tests for adding route interventions and updated playwright version to get access to [`--ui`](https://playwright.dev/docs/test-ui-mode) mode.

These tests include one test that aims to capture the bug described in #162 and so I expect it to fail checks.

Test code was produced using codegen which is pretty nice. 