### PR TITLE
Make the legend collapsible

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <title>Active Travel Intervention Platform v1</title>
+    <title>Active Travel Infrastructure Platform v1</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/lib/About.svelte
+++ b/src/lib/About.svelte
@@ -5,7 +5,7 @@
   export let open: boolean;
 </script>
 
-<Modal title="About the Active Travel Intervention Platform" bind:open>
+<Modal title="About the Active Travel Infrastructure Platform" bind:open>
   <p>
     ATIP v1 is an
     <ExternalLink href="https://github.com/acteng/atip"

--- a/src/lib/CollapsibleCard.svelte
+++ b/src/lib/CollapsibleCard.svelte
@@ -3,8 +3,7 @@
   import { slide } from "svelte/transition";
 
   export let label: string;
-
-  let open = false;
+  export let open = false;
 </script>
 
 <button on:click={() => (open = !open)} aria-expanded={open}

--- a/src/lib/Legend.svelte
+++ b/src/lib/Legend.svelte
@@ -1,27 +1,29 @@
 <script lang="ts">
   import { colors } from "../colors";
   import type { Schema, Scheme } from "../types";
+  import CollapsibleCard from "./CollapsibleCard.svelte";
 
   export let schema: Schema;
 </script>
 
 <div>
-  <h1>Interventions</h1>
-  <ul>
-    {#if schema == "planning"}
-      <li><span style:background={colors.preapp} />Preapp</li>
-      <li><span style:background={colors.outline} />Outline</li>
-      <li>
-        <span style:background={colors["reserved matters"]} />Reserved matters
-      </li>
-      <li><span style:background={colors["local plan"]} />Local plan</li>
-    {:else}
-      <li><span style:background={colors.area} />Areas</li>
-      <li><span style:background={colors.route} />Routes</li>
-      <li><span style:background={colors.crossing} />Crossings</li>
-      <li><span style:background={colors.other} />Other</li>
-    {/if}
-  </ul>
+  <CollapsibleCard label="Interventions" open>
+    <ul>
+      {#if schema == "planning"}
+        <li><span style:background={colors.preapp} />Preapp</li>
+        <li><span style:background={colors.outline} />Outline</li>
+        <li>
+          <span style:background={colors["reserved matters"]} />Reserved matters
+        </li>
+        <li><span style:background={colors["local plan"]} />Local plan</li>
+      {:else}
+        <li><span style:background={colors.area} />Areas</li>
+        <li><span style:background={colors.route} />Routes</li>
+        <li><span style:background={colors.crossing} />Crossings</li>
+        <li><span style:background={colors.other} />Other</li>
+      {/if}
+    </ul>
+  </CollapsibleCard>
 </div>
 
 <style>
@@ -31,10 +33,6 @@
     top: 60px;
     background-color: white;
     padding: 16px;
-  }
-
-  h1 {
-    font-size: 2em;
   }
 
   span {

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { PolygonTool } from "./polygon_tool";
   import KeyHandler from "../KeyHandler.svelte";
-  import CollapsibleCard from "../CollapsibleCard.svelte";
+  import CollapsibleCard from "../../CollapsibleCard.svelte";
 
   export let polygonTool: PolygonTool;
 </script>

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { RouteTool } from "./route_tool";
   import KeyHandler from "../KeyHandler.svelte";
-  import CollapsibleCard from "../CollapsibleCard.svelte";
+  import CollapsibleCard from "../../CollapsibleCard.svelte";
 
   export let routeTool: RouteTool;
 

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { RouteTool } from "../route/route_tool";
   import KeyHandler from "../KeyHandler.svelte";
-  import CollapsibleCard from "../CollapsibleCard.svelte";
+  import CollapsibleCard from "../../CollapsibleCard.svelte";
 
   export let routeTool: RouteTool;
 


### PR DESCRIPTION
During in-person UX testing with Robin last week, we decided the current legend should be de-emphasized. It'll probably change even more once we work on contextual layers, but for now, I've made it collapsible, starting open by default:

https://github.com/acteng/atip/assets/1664407/c6d2c33c-0ea4-4a16-aa2c-e90119195c75

