### PR TITLE
Use 'object' instead of 'intervention' some places in the user-visibl…

### DIFF
--- a/src/lib/EntireScheme.svelte
+++ b/src/lib/EntireScheme.svelte
@@ -159,7 +159,7 @@
 <br />
 
 <div>
-  <span>{$gjScheme.features.length} interventions</span>
+  <span>{$gjScheme.features.length} objects</span>
   <button
     type="button"
     class="align-right"

--- a/src/lib/Legend.svelte
+++ b/src/lib/Legend.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div>
-  <CollapsibleCard label="Interventions" open>
+  <CollapsibleCard label="Objects" open>
     <ul>
       {#if schema == "planning"}
         <li><span style:background={colors.preapp} />Preapp</li>

--- a/src/lib/draw/AttributeMode.svelte
+++ b/src/lib/draw/AttributeMode.svelte
@@ -99,8 +99,8 @@
 
 {#if mode == thisMode}
   {#if $formOpen}
-    <p>Edit attributes to the left, or click another intervention</p>
+    <p>Edit attributes to the left, or click another object</p>
   {:else}
-    <p>Click an intervention to fill out its attributes</p>
+    <p>Click an object to fill out its attributes</p>
   {/if}
 {/if}

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -212,6 +212,6 @@
   {:else if currentlyEditingControls == "route"}
     <RouteControls {routeTool} />
   {:else}
-    <p>Click an intervention to edit its geometry</p>
+    <p>Click an object to edit its geometry</p>
   {/if}
 {/if}

--- a/tests/add-delete-add.spec.ts
+++ b/tests/add-delete-add.spec.ts
@@ -5,9 +5,7 @@ test("testing adding interventions, then deleting one, then adding another", asy
 }) => {
   await page.goto("/scheme.html?authority=Derby#16.84/52.906457/-1.504519");
   // wait for the map to load and interventions panel to appear
-  await page
-    .getByText("Click an intervention to fill out its attributes")
-    .waitFor();
+  await page.getByText("Click an object to fill out its attributes").waitFor();
   // wait for router snapper to load so we can use route tool
   await page.getByText("Route tool loading...").waitFor({ state: "hidden" });
 

--- a/tests/add-route.spec.ts
+++ b/tests/add-route.spec.ts
@@ -3,9 +3,7 @@ import { test, expect } from "@playwright/test";
 test("testing add a route and save it", async ({ page }) => {
   await page.goto("/scheme.html?authority=Derby#16.84/52.906457/-1.504519");
   // wait for the map to load and interventions panel to appear
-  await page
-    .getByText("Click an intervention to fill out its attributes")
-    .waitFor();
+  await page.getByText("Click an object to fill out its attributes").waitFor();
   // wait for router snapper to load so we can use route tool
   await page.getByText("Route tool loading...").waitFor({ state: "hidden" });
 

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -14,6 +14,6 @@ test("clearing all while a feature is open works", async ({ page }) => {
   await page.getByRole("button", { name: "Clear all" }).click();
   // Make sure AttributeMode resets to nothing being selected
   await expect(
-    page.getByText("Click an intervention to fill out its attributes")
+    page.getByText("Click an object to fill out its attributes")
   ).toBeVisible();
 });


### PR DESCRIPTION
…e text. #160

See #160 for context. We still use "intervention" many places in the code -- ideally we'd be consistent about the terminology everywhere. "Object" feels a bit generic, and "object on the map" is too verbose. If there are ideas for what to do, we can adjust here, otherwise this PR will just adjust a bit of the user-visible text.