### PR TITLE
Clean up custom event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ interact with the page normally, generating the equivalent test code.
 
 - Use `overwriteSource` and `overwriteLayer` instead of `map.addSource` and `map.addLayer`
 - Within a `.ts` file using classes, use `EventManager` to handle MapLibre and document event handlers. Otherwise as you edit a component, you'll keep running old versions of the callbacks!
-- Within a Svelte component, express event handlers using functions and remember to call `map.off()` within `onDestroy`. Refer to existing components.
+- Within a Svelte component, express event handlers using functions and remember to call `map.off()` and `whateverTool.removeEventListenerSuccess` within `onDestroy`. Refer to existing components.
 - When in doubt, Ctrl+Shift+R to hard refresh and get rid of any possible HMR weirdness
 
 ### Overall app state

--- a/src/lib/draw/events.ts
+++ b/src/lib/draw/events.ts
@@ -40,3 +40,14 @@ export class EventManager {
     this.documentHandlers = {};
   }
 }
+
+// Removes a callback from a list, complaining if the callback wasn't in there.
+export function mustRemoveCallback<T>(list: T[], callback: T) {
+  let len = list.length;
+  list = list.filter((x) => x != callback);
+  if (len != list.length - 1) {
+    window.alert(
+      `Bug: Tried to remove a callback that wasn't previously added`
+    );
+  }
+}

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import type { Mode } from "../types";
   import type { Point } from "geojson";
   import type { Feature } from "../../../types";
   import type { PointTool } from "./point_tool";
+  import type { FeatureWithProps } from "../../../maplibre_helpers";
   import { gjScheme, newFeatureId, formOpen } from "../../../stores";
   import PointControls from "./PointControls.svelte";
 
@@ -19,7 +21,15 @@
     pointTool.stop();
   }
 
-  pointTool.addEventListenerSuccess((feature) => {
+  pointTool.addEventListenerSuccess(onSuccess);
+  pointTool.addEventListenerFailure(onFailure);
+
+  onDestroy(() => {
+    pointTool.removeEventListenerSuccess(onSuccess);
+    pointTool.removeEventListenerFailure(onFailure);
+  });
+
+  function onSuccess(feature: FeatureWithProps<Point>) {
     if (mode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
@@ -31,12 +41,13 @@
       changeMode("edit-attribute");
       formOpen.set(feature.id as number);
     }
-  });
-  pointTool.addEventListenerFailure(() => {
+  }
+
+  function onFailure() {
     if (mode == thisMode) {
       changeMode("edit-attribute");
     }
-  });
+  }
 </script>
 
 {#if mode == thisMode}

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -8,7 +8,7 @@ import {
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { colors, circleRadius } from "../../../colors";
-import { EventManager } from "../events";
+import { EventManager, mustRemoveCallback } from "../events";
 
 const source = "edit-point-mode";
 
@@ -76,6 +76,12 @@ export class PointTool {
   }
   addEventListenerFailure(callback: () => void) {
     this.eventListenersFailure.push(callback);
+  }
+  removeEventListenerSuccess(callback: (f: FeatureWithProps<Point>) => void) {
+    mustRemoveCallback(this.eventListenersSuccess, callback);
+  }
+  removeEventListenerFailure(callback: () => void) {
+    mustRemoveCallback(this.eventListenersFailure, callback);
   }
 
   tearDown() {

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import type { Mode } from "../types";
   import type { Polygon } from "geojson";
   import type { Feature } from "../../../types";
   import type { PolygonTool } from "./polygon_tool";
+  import type { FeatureWithProps } from "../../../maplibre_helpers";
   import { gjScheme, newFeatureId, formOpen } from "../../../stores";
   import PolygonControls from "./PolygonControls.svelte";
 
@@ -19,7 +21,15 @@
     polygonTool.stop();
   }
 
-  polygonTool.addEventListenerSuccess((feature) => {
+  polygonTool.addEventListenerSuccess(onSuccess);
+  polygonTool.addEventListenerFailure(onFailure);
+
+  onDestroy(() => {
+    polygonTool.removeEventListenerSuccess(onSuccess);
+    polygonTool.removeEventListenerFailure(onFailure);
+  });
+
+  function onSuccess(feature: FeatureWithProps<Polygon>) {
     if (mode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
@@ -31,12 +41,13 @@
       changeMode("edit-attribute");
       formOpen.set(feature.id as number);
     }
-  });
-  polygonTool.addEventListenerFailure(() => {
+  }
+
+  function onFailure() {
     if (mode == thisMode) {
       changeMode("edit-attribute");
     }
-  });
+  }
 </script>
 
 {#if mode == thisMode}

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -19,7 +19,7 @@ import {
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { colors, circleRadius } from "../../../colors";
-import { EventManager } from "../events";
+import { EventManager, mustRemoveCallback } from "../events";
 
 const source = "edit-polygon-mode";
 
@@ -199,6 +199,12 @@ export class PolygonTool {
   }
   addEventListenerFailure(callback: () => void) {
     this.eventListenersFailure.push(callback);
+  }
+  removeEventListenerSuccess(callback: (f: FeatureWithProps<Polygon>) => void) {
+    mustRemoveCallback(this.eventListenersSuccess, callback);
+  }
+  removeEventListenerFailure(callback: () => void) {
+    mustRemoveCallback(this.eventListenersFailure, callback);
   }
 
   tearDown() {

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -13,7 +13,7 @@ import {
   drawPolygon,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
-import { EventManager } from "../events";
+import { EventManager, mustRemoveCallback } from "../events";
 
 const source = "route-snapper";
 
@@ -279,6 +279,19 @@ export class RouteTool {
   }
   addEventListenerFailure(callback: () => void) {
     this.eventListenersFailure.push(callback);
+  }
+  removeEventListenerSuccessRoute(
+    callback: (f: FeatureWithProps<LineString>) => void
+  ) {
+    mustRemoveCallback(this.eventListenersSuccessRoute, callback);
+  }
+  removeEventListenerSuccessArea(
+    callback: (f: FeatureWithProps<Polygon>) => void
+  ) {
+    mustRemoveCallback(this.eventListenersSuccessArea, callback);
+  }
+  removeEventListenerFailure(callback: () => void) {
+    mustRemoveCallback(this.eventListenersFailure, callback);
   }
 
   isActive(): boolean {

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import type { Mode } from "../types";
   import type { Polygon } from "geojson";
   import type { Feature } from "../../../types";
   import type { RouteTool } from "../route/route_tool";
   import { gjScheme, newFeatureId, formOpen } from "../../../stores";
+  import type { FeatureWithProps } from "../../../maplibre_helpers";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";
 
   const thisMode = "snap-polygon";
@@ -19,7 +21,15 @@
     routeTool.stop();
   }
 
-  routeTool.addEventListenerSuccessArea((feature) => {
+  routeTool.addEventListenerSuccessArea(onSuccess);
+  routeTool.addEventListenerFailure(onFailure);
+
+  onDestroy(() => {
+    routeTool.removeEventListenerSuccessArea(onSuccess);
+    routeTool.removeEventListenerFailure(onFailure);
+  });
+
+  function onSuccess(feature: FeatureWithProps<Polygon>) {
     if (mode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
@@ -31,12 +41,13 @@
       changeMode("edit-attribute");
       formOpen.set(feature.id as number);
     }
-  });
-  routeTool.addEventListenerFailure(() => {
+  }
+
+  function onFailure() {
     if (mode == thisMode) {
       changeMode("edit-attribute");
     }
-  });
+  }
 </script>
 
 {#if mode == thisMode}


### PR DESCRIPTION
This is the final round of fixing our code to properly teardown event listeners in Svelte components. When editing components locally with HMR, these callbacks were previously being duplicated from past loads.

To verify this works, I added logging statements in PointMode's callbacks, edited the component repeatedly, and watched the console when clicking. Before this PR, multiple log statements would stack up. With this change, we just have one, as expected.

CC @yongrenjie, who may hit similar problems in a new Svelte app. Any callback created by a Svelte component has to get cleaned up correctly, or local edits will get confusing.