### PR TITLE
Refactor code to create layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@turf/nearest-point-on-line": "^6.5.0",
         "@types/geojson": "^7946.0.10",
         "comlink": "^4.4.1",
+        "just-flush": "^2.3.0",
         "maplibre-gl": "^2.4.0",
         "route-snapper": "^0.1.13",
         "svelte": "^3.54.0"
@@ -1460,6 +1461,11 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/just-flush": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/just-flush/-/just-flush-2.3.0.tgz",
+      "integrity": "sha512-fBuxQ1gJ61BurmhwKS5LYTzhkbrT5j/2U7ax+UbLm9aRvCTh2h6AfzLteOckE4KKomqOf0Y3zIG3Xu57sRsKUg=="
     },
     "node_modules/kdbush": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@turf/nearest-point-on-line": "^6.5.0",
     "@types/geojson": "^7946.0.10",
     "comlink": "^4.4.1",
+    "just-flush": "^2.3.0",
     "maplibre-gl": "^2.4.0",
     "route-snapper": "^0.1.13",
     "svelte": "^3.54.0"

--- a/src/lib/BoundaryLayer.svelte
+++ b/src/lib/BoundaryLayer.svelte
@@ -2,9 +2,8 @@
   import type { FeatureCollection, Polygon } from "geojson";
   import mask from "@turf/mask";
   import {
-    drawPolygon,
     overwriteSource,
-    overwriteLayer,
+    overwritePolygonLayer,
     bbox,
   } from "../maplibre_helpers";
   import { getContext } from "svelte";
@@ -22,9 +21,10 @@
   }
 
   overwriteSource($map, "boundary", mask(boundaryGeojson));
-  overwriteLayer($map, {
-    id: "boundary",
+  overwritePolygonLayer($map, {
     source: "boundary",
-    ...drawPolygon("black", 0.5),
+    layer: "boundary",
+    color: "black",
+    opacity: 0.5,
   });
 </script>

--- a/src/lib/BoundaryLayer.svelte
+++ b/src/lib/BoundaryLayer.svelte
@@ -22,8 +22,8 @@
 
   overwriteSource($map, "boundary", mask(boundaryGeojson));
   overwritePolygonLayer($map, {
+    id: "boundary",
     source: "boundary",
-    layer: "boundary",
     color: "black",
     opacity: 0.5,
   });

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { GeoJSONSource } from "maplibre-gl";
   import {
-    drawLine,
+    overwriteLineLayer,
     isPolygon,
     isPoint,
     isLine,
@@ -26,18 +26,20 @@
   // easier way to do this, but I can't make it work with the draw plugin.
   overwriteSource($map, source, emptyGeojson());
 
-  overwriteLayer($map, {
+  overwriteLineLayer($map, {
     id: "hover-polygons",
     source,
     filter: isPolygon,
     // Outline around the polygons
-    ...drawLine(colors.hovering, 0.5 * lineWidth, 1.0),
+    color: colors.hovering,
+    width: 0.5 * lineWidth,
   });
-  overwriteLayer($map, {
+  overwriteLineLayer($map, {
     id: "hover-lines",
     source,
     filter: isLine,
-    ...drawLine(colors.hovering, 1.5 * lineWidth, 1.0),
+    color: colors.hovering,
+    width: 1.5 * lineWidth,
   });
   overwriteCircleLayer($map, {
     id: "hover-points",

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -7,7 +7,6 @@
     isLine,
     overwriteCircleLayer,
     overwriteSource,
-    overwriteLayer,
     emptyGeojson,
   } from "../../maplibre_helpers";
   import { colors, lineWidth, circleRadius } from "../../colors";

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -5,7 +5,7 @@
     isPolygon,
     isPoint,
     isLine,
-    drawCircle,
+    overwriteCircleLayer,
     overwriteSource,
     overwriteLayer,
     emptyGeojson,
@@ -39,11 +39,12 @@
     filter: isLine,
     ...drawLine(colors.hovering, 1.5 * lineWidth, 1.0),
   });
-  overwriteLayer($map, {
+  overwriteCircleLayer($map, {
     id: "hover-points",
     source,
     filter: isPoint,
-    ...drawCircle(colors.hovering, 1.5 * circleRadius, 1.0),
+    color: colors.hovering,
+    radius: 1.5 * circleRadius,
   });
 
   // When a form is open, ignore regular map and sidebar interactions

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -12,7 +12,6 @@
     overwritePolygonLayer,
     overwriteLineLayer,
     overwriteSource,
-    overwriteLayer,
   } from "../../maplibre_helpers";
   import { colors, circleRadius, lineWidth } from "../../colors";
   import { gjScheme, map } from "../../stores";
@@ -111,17 +110,14 @@
     width: lineWidth,
   });
   // Draw endpoints to emphasize where two LineStrings meet
-  overwriteLayer($map, {
+  overwriteCircleLayer($map, {
     id: "interventions-lines-endpoints",
     source,
     filter: ["==", "endpoint", true],
-    type: "circle",
-    paint: {
-      "circle-radius": 0.5 * lineWidth,
-      "circle-opacity": 0.0,
-      "circle-stroke-color": colors.lineEndpointColor,
-      "circle-stroke-width": 2.0,
-    },
+    radius: 0.5 * lineWidth,
+    opacity: 0.0,
+    strokeColor: colors.lineEndpointColor,
+    strokeWidth: 2.0,
   });
 
   overwritePolygonLayer($map, {

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -9,7 +9,7 @@
     isPolygon,
     isPoint,
     isLine,
-    drawCircle,
+    overwriteCircleLayer,
     overwritePolygonLayer,
     overwriteSource,
     overwriteLayer,
@@ -89,11 +89,12 @@
   ];
   const notEndpoint: FilterSpecification = ["!=", "endpoint", true];
 
-  overwriteLayer($map, {
+  overwriteCircleLayer($map, {
     id: "interventions-points",
     source,
-    filter: ["all", isPoint, hideWhileEditing, notEndpoint],
-    ...drawCircle(colorByInterventionType, circleRadius),
+    filter: ["all", isPoint, hideWhileEditing, notEndpoint] as FilterSpecification,
+    color: colorByInterventionType,
+    radius: circleRadius,
     // TODO Outline?
   });
 
@@ -118,8 +119,8 @@
   });
 
   overwritePolygonLayer($map, {
+    id: "interventions-polygons",
     source,
-    layer: "interventions-polygons",
     filter: ["all", isPolygon, hideWhileEditing] as FilterSpecification,
     color:
       schema == "planning" ? colorByReferenceType : colorByInterventionType,

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -5,12 +5,12 @@
     FilterSpecification,
   } from "maplibre-gl";
   import {
-    drawLine,
     isPolygon,
     isPoint,
     isLine,
     overwriteCircleLayer,
     overwritePolygonLayer,
+    overwriteLineLayer,
     overwriteSource,
     overwriteLayer,
   } from "../../maplibre_helpers";
@@ -92,17 +92,23 @@
   overwriteCircleLayer($map, {
     id: "interventions-points",
     source,
-    filter: ["all", isPoint, hideWhileEditing, notEndpoint] as FilterSpecification,
+    filter: [
+      "all",
+      isPoint,
+      hideWhileEditing,
+      notEndpoint,
+    ] as FilterSpecification,
     color: colorByInterventionType,
     radius: circleRadius,
     // TODO Outline?
   });
 
-  overwriteLayer($map, {
+  overwriteLineLayer($map, {
     id: "interventions-lines",
     source,
-    filter: ["all", isLine, hideWhileEditing],
-    ...drawLine(colorByInterventionType, lineWidth),
+    filter: ["all", isLine, hideWhileEditing] as FilterSpecification,
+    color: colorByInterventionType,
+    width: lineWidth,
   });
   // Draw endpoints to emphasize where two LineStrings meet
   overwriteLayer($map, {

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -2,6 +2,7 @@
   import type {
     GeoJSONSource,
     DataDrivenPropertyValueSpecification,
+    FilterSpecification,
   } from "maplibre-gl";
   import {
     drawLine,
@@ -9,7 +10,7 @@
     isPoint,
     isLine,
     drawCircle,
-    drawPolygon,
+    overwritePolygonLayer,
     overwriteSource,
     overwriteLayer,
   } from "../../maplibre_helpers";
@@ -81,8 +82,12 @@
     "white",
   ];
 
-  const hideWhileEditing = ["!=", "hide_while_editing", true];
-  const notEndpoint = ["!=", "endpoint", true];
+  const hideWhileEditing: FilterSpecification = [
+    "!=",
+    "hide_while_editing",
+    true,
+  ];
+  const notEndpoint: FilterSpecification = ["!=", "endpoint", true];
 
   overwriteLayer($map, {
     id: "interventions-points",
@@ -112,14 +117,13 @@
     },
   });
 
-  overwriteLayer($map, {
-    id: "interventions-polygons",
+  overwritePolygonLayer($map, {
     source,
-    filter: ["all", isPolygon, hideWhileEditing],
-    ...drawPolygon(
+    layer: "interventions-polygons",
+    filter: ["all", isPolygon, hideWhileEditing] as FilterSpecification,
+    color:
       schema == "planning" ? colorByReferenceType : colorByInterventionType,
-      0.5
-    ),
+    opacity: 0.5,
     // TODO Outline too?
   });
 </script>

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -3,8 +3,7 @@ import type { Map, GeoJSONSource, MapMouseEvent } from "maplibre-gl";
 import {
   emptyGeojson,
   overwriteSource,
-  overwriteLayer,
-  drawCircle,
+  overwriteCircleLayer,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { colors, circleRadius } from "../../../colors";
@@ -36,10 +35,11 @@ export class PointTool {
 
     // Render
     overwriteSource(map, source, emptyGeojson());
-    overwriteLayer(map, {
+    overwriteCircleLayer(map, {
       id: "edit-point-mode",
       source,
-      ...drawCircle(colors.hovering, circleRadius, 1.0),
+      color: colors.hovering,
+      radius: circleRadius,
     });
   }
 

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -9,7 +9,6 @@ import nearestPointOnLine from "@turf/nearest-point-on-line";
 import {
   emptyGeojson,
   overwriteSource,
-  overwriteLayer,
   overwriteCircleLayer,
   overwritePolygonLayer,
   overwriteLineLayer,

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -11,7 +11,7 @@ import {
   overwriteSource,
   overwriteLayer,
   drawCircle,
-  drawPolygon,
+  overwritePolygonLayer,
   drawLine,
   isPoint,
   isPolygon,
@@ -62,16 +62,12 @@ export class PolygonTool {
     // Render
     overwriteSource(map, source, emptyGeojson());
 
-    overwriteLayer(map, {
-      id: "edit-polygon-fill",
+    overwritePolygonLayer(map, {
       source,
+      layer: "edit-polygon-fill",
       filter: isPolygon,
-      ...drawPolygon("red", [
-        "case",
-        ["boolean", ["get", "hover"], "false"],
-        1.0,
-        0.5,
-      ]),
+      color: "red",
+      opacity: ["case", ["boolean", ["get", "hover"], "false"], 1.0, 0.5],
     });
     overwriteLayer(map, {
       id: "edit-polygon-lines",

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -10,7 +10,7 @@ import {
   emptyGeojson,
   overwriteSource,
   overwriteLayer,
-  drawCircle,
+  overwriteCircleLayer,
   overwritePolygonLayer,
   drawLine,
   isPoint,
@@ -63,8 +63,8 @@ export class PolygonTool {
     overwriteSource(map, source, emptyGeojson());
 
     overwritePolygonLayer(map, {
+      id: "edit-polygon-fill",
       source,
-      layer: "edit-polygon-fill",
       filter: isPolygon,
       color: "red",
       opacity: ["case", ["boolean", ["get", "hover"], "false"], 1.0, 0.5],
@@ -76,16 +76,13 @@ export class PolygonTool {
       // TODO Dashed
       ...drawLine("black", 8, 0.5),
     });
-    overwriteLayer(map, {
+    overwriteCircleLayer(map, {
       id: "edit-polygon-vertices",
       source,
       filter: isPoint,
-      ...drawCircle(colors.hovering, circleRadius, [
-        "case",
-        ["boolean", ["get", "hover"], "false"],
-        1.0,
-        0.5,
-      ]),
+      color: colors.hovering,
+      radius: circleRadius,
+      opacity: ["case", ["boolean", ["get", "hover"], "false"], 1.0, 0.5],
     });
   }
 

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -12,7 +12,7 @@ import {
   overwriteLayer,
   overwriteCircleLayer,
   overwritePolygonLayer,
-  drawLine,
+  overwriteLineLayer,
   isPoint,
   isPolygon,
   isLine,
@@ -69,12 +69,14 @@ export class PolygonTool {
       color: "red",
       opacity: ["case", ["boolean", ["get", "hover"], "false"], 1.0, 0.5],
     });
-    overwriteLayer(map, {
+    overwriteLineLayer(map, {
       id: "edit-polygon-lines",
       source,
       filter: isLine,
       // TODO Dashed
-      ...drawLine("black", 8, 0.5),
+      color: "black",
+      width: 8,
+      opacity: 0.5,
     });
     overwriteCircleLayer(map, {
       id: "edit-polygon-vertices",

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -14,8 +14,7 @@
   import {
     emptyGeojson,
     overwriteSource,
-    overwriteLayer,
-    drawCircle,
+    overwriteCircleLayer,
   } from "../../../maplibre_helpers";
 
   const thisMode = "split-route";
@@ -48,15 +47,12 @@
   let source = "split-route";
   overwriteSource($map, source, emptyGeojson());
   // TODO Scissors icon?
-  overwriteLayer($map, {
+  overwriteCircleLayer($map, {
     id: "draw-split-route",
     source,
-    ...drawCircle("black", circleRadiusPixels, [
-      "case",
-      ["==", ["get", "snapped"], true],
-      1.0,
-      0.5,
-    ]),
+    color: "black",
+    radius: circleRadiusPixels,
+    opacity: ["case", ["==", ["get", "snapped"], true], 1.0, 0.5],
   });
 
   $: {

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -8,7 +8,7 @@ import {
   isPolygon,
   overwriteSource,
   overwriteLayer,
-  drawCircle,
+  overwriteCircleLayer,
   drawLine,
   overwritePolygonLayer,
   type FeatureWithProps,
@@ -42,30 +42,28 @@ export class RouteTool {
 
     // Rendering
     overwriteSource(map, source, emptyGeojson());
-    overwriteLayer(map, {
+    overwriteCircleLayer(map, {
       id: "route-points",
       source,
       filter: isPoint,
-      ...drawCircle(
-        [
-          "match",
-          ["get", "type"],
-          "hovered",
-          "green",
-          "important",
-          "red",
-          // other
-          "black",
-        ],
-        [
-          "match",
-          ["get", "type"],
-          "unimportant",
-          circleRadiusPixels / 2.0,
-          // other
-          circleRadiusPixels,
-        ]
-      ),
+      color: [
+        "match",
+        ["get", "type"],
+        "hovered",
+        "green",
+        "important",
+        "red",
+        // other
+        "black",
+      ],
+      radius: [
+        "match",
+        ["get", "type"],
+        "unimportant",
+        circleRadiusPixels / 2.0,
+        // other
+        circleRadiusPixels,
+      ],
     });
     overwriteLayer(map, {
       id: "route-lines",
@@ -74,8 +72,8 @@ export class RouteTool {
       ...drawLine("black", 2.5),
     });
     overwritePolygonLayer(map, {
+      id: "route-polygons",
       source,
-      layer: "route-polygons",
       filter: isPolygon,
       color: "black",
       opacity: 0.5,

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -10,7 +10,7 @@ import {
   overwriteLayer,
   drawCircle,
   drawLine,
-  drawPolygon,
+  overwritePolygonLayer,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { EventManager } from "../events";
@@ -73,11 +73,12 @@ export class RouteTool {
       filter: isLine,
       ...drawLine("black", 2.5),
     });
-    overwriteLayer(map, {
-      id: "route-polygons",
+    overwritePolygonLayer(map, {
       source,
+      layer: "route-polygons",
       filter: isPolygon,
-      ...drawPolygon("black", 0.5),
+      color: "black",
+      opacity: 0.5,
     });
 
     // Set up interactions

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -9,7 +9,7 @@ import {
   overwriteSource,
   overwriteLayer,
   overwriteCircleLayer,
-  drawLine,
+  overwriteLineLayer,
   overwritePolygonLayer,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
@@ -65,11 +65,12 @@ export class RouteTool {
         circleRadiusPixels,
       ],
     });
-    overwriteLayer(map, {
+    overwriteLineLayer(map, {
       id: "route-lines",
       source,
       filter: isLine,
-      ...drawLine("black", 2.5),
+      color: "black",
+      width: 2.5,
     });
     overwritePolygonLayer(map, {
       id: "route-polygons",

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -7,7 +7,6 @@ import {
   isLine,
   isPolygon,
   overwriteSource,
-  overwriteLayer,
   overwriteCircleLayer,
   overwriteLineLayer,
   overwritePolygonLayer,

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -3,7 +3,6 @@
   import {
     emptyGeojson,
     overwriteSource,
-    overwriteLayer,
     overwriteLineLayer,
   } from "../../maplibre_helpers";
   import type { LineString } from "geojson";

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -4,7 +4,7 @@
     emptyGeojson,
     overwriteSource,
     overwriteLayer,
-    drawLine,
+    overwriteLineLayer,
   } from "../../maplibre_helpers";
   import type { LineString } from "geojson";
   import type {
@@ -63,10 +63,12 @@
   // (and the source and layer) will get destroyed frequently, but even if not,
   // overwriting should be safe.
   overwriteSource($map, source, emptyGeojson());
-  overwriteLayer($map, {
+  overwriteLineLayer($map, {
     id: layer,
     source,
-    ...drawLine(color, lineWidth, opacity),
+    color,
+    width: lineWidth,
+    opacity,
   });
 
   onMount(async () => {

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -1,11 +1,15 @@
 // Helpers for https://maplibre.org/maplibre-gl-js-docs/style-spec/
-import type { Map, DataDrivenPropertyValueSpecification } from "maplibre-gl";
+import type {
+  Map,
+  DataDrivenPropertyValueSpecification,
+  FilterSpecification,
+} from "maplibre-gl";
 import type { GeoJSON, FeatureCollection, Feature, Geometry } from "geojson";
 import turfBbox from "@turf/bbox";
 
-export const isPolygon = ["==", "$type", "Polygon"];
-export const isLine = ["==", "$type", "LineString"];
-export const isPoint = ["==", "$type", "Point"];
+export const isPolygon: FilterSpecification = ["==", "$type", "Polygon"];
+export const isLine: FilterSpecification = ["==", "$type", "LineString"];
+export const isPoint: FilterSpecification = ["==", "$type", "Point"];
 
 export function drawLine(
   color: DataDrivenPropertyValueSpecification<string>,
@@ -22,19 +26,6 @@ export function drawLine(
       "line-color": color,
       "line-width": width,
       "line-opacity": opacity,
-    },
-  };
-}
-
-export function drawPolygon(
-  color: DataDrivenPropertyValueSpecification<string>,
-  opacity: DataDrivenPropertyValueSpecification<number>
-) {
-  return {
-    type: "fill",
-    paint: {
-      "fill-color": color,
-      "fill-opacity": opacity,
     },
   };
 }
@@ -114,6 +105,28 @@ export function overwriteLayer(map: Map, layer) {
   // If beforeId isn't set, we'll add the layer on top of everything else.
 
   map.addLayer(layer, beforeId);
+}
+
+export function overwritePolygonLayer(
+  map: Map,
+  params: {
+    source: string;
+    layer: string;
+    filter?: FilterSpecification;
+    color: DataDrivenPropertyValueSpecification<string>;
+    opacity: DataDrivenPropertyValueSpecification<number>;
+  }
+) {
+  overwriteLayer(map, {
+    id: params.layer,
+    source: params.source,
+    filter: params.filter,
+    type: "fill",
+    paint: {
+      "fill-color": params.color,
+      "fill-opacity": params.opacity,
+    },
+  });
 }
 
 export function emptyGeojson(): FeatureCollection {

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -30,21 +30,6 @@ export function drawLine(
   };
 }
 
-export function drawCircle(
-  color: DataDrivenPropertyValueSpecification<string>,
-  radius: DataDrivenPropertyValueSpecification<number>,
-  opacity: DataDrivenPropertyValueSpecification<number> = 1.0
-) {
-  return {
-    type: "circle",
-    paint: {
-      "circle-radius": radius,
-      "circle-color": color,
-      "circle-opacity": opacity,
-    },
-  };
-}
-
 // This sets up a GeoJSON source. MapLibre's API isn't idempotent; you can't
 // overwrite an existing source or layer. This complicates Vite's hot-reload
 // feature, unless every component correctly tears down all sources and layers.
@@ -110,21 +95,45 @@ export function overwriteLayer(map: Map, layer) {
 export function overwritePolygonLayer(
   map: Map,
   params: {
+    id: string;
     source: string;
-    layer: string;
     filter?: FilterSpecification;
     color: DataDrivenPropertyValueSpecification<string>;
     opacity: DataDrivenPropertyValueSpecification<number>;
   }
 ) {
   overwriteLayer(map, {
-    id: params.layer,
+    id: params.id,
     source: params.source,
     filter: params.filter,
     type: "fill",
     paint: {
       "fill-color": params.color,
       "fill-opacity": params.opacity,
+    },
+  });
+}
+
+export function overwriteCircleLayer(
+  map: Map,
+  params: {
+    id: string;
+    source: string;
+    filter?: FilterSpecification;
+    color: DataDrivenPropertyValueSpecification<string>;
+    radius: DataDrivenPropertyValueSpecification<number>;
+    opacity?: DataDrivenPropertyValueSpecification<number>;
+  }
+) {
+  overwriteLayer(map, {
+    id: params.id,
+    source: params.source,
+    filter: params.filter,
+    type: "circle",
+    paint: {
+      "circle-radius": params.radius,
+      "circle-color": params.color,
+      "circle-opacity": params.opacity || 1.0,
     },
   });
 }

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -11,25 +11,6 @@ export const isPolygon: FilterSpecification = ["==", "$type", "Polygon"];
 export const isLine: FilterSpecification = ["==", "$type", "LineString"];
 export const isPoint: FilterSpecification = ["==", "$type", "Point"];
 
-export function drawLine(
-  color: DataDrivenPropertyValueSpecification<string>,
-  width: DataDrivenPropertyValueSpecification<number>,
-  opacity: DataDrivenPropertyValueSpecification<number> = 1.0
-) {
-  return {
-    type: "line",
-    layout: {
-      "line-cap": "round",
-      "line-join": "round",
-    },
-    paint: {
-      "line-color": color,
-      "line-width": width,
-      "line-opacity": opacity,
-    },
-  };
-}
-
 // This sets up a GeoJSON source. MapLibre's API isn't idempotent; you can't
 // overwrite an existing source or layer. This complicates Vite's hot-reload
 // feature, unless every component correctly tears down all sources and layers.
@@ -134,6 +115,34 @@ export function overwriteCircleLayer(
       "circle-radius": params.radius,
       "circle-color": params.color,
       "circle-opacity": params.opacity || 1.0,
+    },
+  });
+}
+
+export function overwriteLineLayer(
+  map: Map,
+  params: {
+    id: string;
+    source: string;
+    filter?: FilterSpecification;
+    color: DataDrivenPropertyValueSpecification<string>;
+    width: DataDrivenPropertyValueSpecification<number>;
+    opacity?: DataDrivenPropertyValueSpecification<number>;
+  }
+) {
+  overwriteLayer(map, {
+    id: params.id,
+    source: params.source,
+    filter: params.filter,
+    type: "line",
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+    },
+    paint: {
+      "line-color": params.color,
+      "line-width": params.width,
+      "line-opacity": params.opacity || 1.0,
     },
   });
 }


### PR DESCRIPTION
Part of #89. Previously, we used one big `overwriteLayer` call, but couldn't specify `LayerSpecification` on one of the parameters without getting some bizarre TS errors. After fighting this for a while, I decided it's more clear to split the function into 3 smaller ones specifically for circles, polygons, and lines. That makes the parameters easier to specify, anyway.

This should be a pure refactoring PR, no behavioral change (that I've spotted!)