### PR TITLE
Add a layer to render lane details along a route

### DIFF
--- a/route_info/Cargo.lock
+++ b/route_info/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "osm2streets"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/osm2streets#6c4eb464b2c086ef7b5da9605f88a5a395da3679"
+source = "git+https://github.com/a-b-street/osm2streets#0d6f0f973b3fa8dbdc8223aa6f412a8d997252fc"
 dependencies = [
  "abstutil",
  "anyhow",

--- a/route_info/src/lib.rs
+++ b/route_info/src/lib.rs
@@ -145,6 +145,34 @@ impl RouteInfo {
         });
         Ok(abstutil::to_json(&gj))
     }
+
+    // TODO Just have one call? Return 4 GJ layers in a dictionary
+
+    /// Return a GeoJSON layer for rendering lane polygons
+    #[wasm_bindgen(js_name = renderLanePolygons)]
+    pub fn render_lane_polygons(&self) -> Result<String, JsValue> {
+        self.network.to_lane_polygons_geojson().map_err(err_to_js)
+    }
+
+    /// Return a GeoJSON layer for rendering lane markings
+    #[wasm_bindgen(js_name = renderLaneMarkings)]
+    pub fn render_lane_markings(&self) -> Result<String, JsValue> {
+        self.network.to_lane_markings_geojson().map_err(err_to_js)
+    }
+
+    /// Return a GeoJSON layer for rendering intersection polygons
+    #[wasm_bindgen(js_name = renderIntersectionPolygons)]
+    pub fn render_intersection_polygons(&self) -> Result<String, JsValue> {
+        self.network.to_geojson().map_err(err_to_js)
+    }
+
+    /// Return a GeoJSON layer for rendering intersection markings
+    #[wasm_bindgen(js_name = renderIntersectionMarkings)]
+    pub fn render_intersection_markings(&self) -> Result<String, JsValue> {
+        self.network
+            .to_intersection_markings_geojson()
+            .map_err(err_to_js)
+    }
 }
 
 fn err_to_js<E: std::fmt::Display>(err: E) -> JsValue {

--- a/route_info/src/lib.rs
+++ b/route_info/src/lib.rs
@@ -146,40 +146,10 @@ impl RouteInfo {
         Ok(abstutil::to_json(&gj))
     }
 
-    // TODO Just have one call? Return 4 GJ layers in a dictionary
-
-    /// Return a GeoJSON layer for rendering lane polygons
-    #[wasm_bindgen(js_name = renderLanePolygons)]
-    pub fn render_lane_polygons(&self) -> Result<String, JsValue> {
-        self.network
-            .to_lane_polygons_geojson(&Filter::All)
-            .map_err(err_to_js)
-    }
-
-    /// Return a GeoJSON layer for rendering lane markings
-    #[wasm_bindgen(js_name = renderLaneMarkings)]
-    pub fn render_lane_markings(&self) -> Result<String, JsValue> {
-        self.network
-            .to_lane_markings_geojson(&Filter::All)
-            .map_err(err_to_js)
-    }
-
-    /// Return a GeoJSON layer for rendering intersection polygons
-    #[wasm_bindgen(js_name = renderIntersectionPolygons)]
-    pub fn render_intersection_polygons(&self) -> Result<String, JsValue> {
-        self.network.to_geojson(&Filter::All).map_err(err_to_js)
-    }
-
-    /// Return a GeoJSON layer for rendering intersection markings
-    #[wasm_bindgen(js_name = renderIntersectionMarkings)]
-    pub fn render_intersection_markings(&self) -> Result<String, JsValue> {
-        self.network
-            .to_intersection_markings_geojson(&Filter::All)
-            .map_err(err_to_js)
-    }
-
     /// Return 4 GeoJSON layers for rendering lane details, limited to just roads along a route.
-    /// Due to encoding limitations, returns it as string JSON encoding 4 strings.
+    /// Due to encoding limitations, returns it as a JSON string containing 4 more JSON strings.
+    /// The order returned is [lane polygons, lane markings, intersection polygons, intersection
+    /// markings], and the properties of each feature isn't documented anywhere clearly yet.
     #[wasm_bindgen(js_name = renderLaneDetailsForRoute)]
     pub fn render_lane_details_for_route(&self, raw_waypoints: JsValue) -> Result<String, JsValue> {
         let raw_waypoints: Vec<RawRouteWaypoint> = serde_wasm_bindgen::from_value(raw_waypoints)?;

--- a/src/lib/forms/RouteInfoLayers.svelte
+++ b/src/lib/forms/RouteInfoLayers.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import SpeedLimits from "../layers/SpeedLimits.svelte";
+  import LaneDetails from "../layers/LaneDetails.svelte";
 
   export let id: number;
 
-  let layer: "none" | "speed limits" = "none";
+  let layer: "none" | "speed limits" | "lane details" = "none";
 </script>
 
 <label>
@@ -11,8 +12,11 @@
   <select bind:value={layer}>
     <option value="none">None</option>
     <option value="speed limits">Speed limits</option>
+    <option value="lane details">Lane details</option>
   </select>
 </label>
 {#if layer == "speed limits"}
   <SpeedLimits {id} />
+{:else if layer == "lane details"}
+  <LaneDetails {id} />
 {/if}

--- a/src/lib/layers/ContextualLayers.svelte
+++ b/src/lib/layers/ContextualLayers.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import SpeedLimits from "./SpeedLimits.svelte";
-  import LaneDetails from "./LaneDetails.svelte";
   import { formOpen } from "../../stores";
 
-  let show: "none" | "speed limits" | "lane details" = "none";
+  let show: "none" | "speed limits" = "none";
 
   // If any form is open, don't show a map-wide layer.
   $: {
@@ -18,11 +17,8 @@
   <select bind:value={show} disabled={$formOpen != null}>
     <option value="none">None</option>
     <option value="speed limits">Speed limits</option>
-    <option value="lane details">Lane details</option>
   </select>
 </label>
 {#if show == "speed limits"}
   <SpeedLimits id={undefined} />
-{:else if show == "lane details"}
-  <LaneDetails />
 {/if}

--- a/src/lib/layers/ContextualLayers.svelte
+++ b/src/lib/layers/ContextualLayers.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import SpeedLimits from "./SpeedLimits.svelte";
+  import LaneDetails from "./LaneDetails.svelte";
   import { formOpen } from "../../stores";
 
-  let show: "none" | "speed limits" = "none";
+  let show: "none" | "speed limits" | "lane details" = "none";
 
   // If any form is open, don't show a map-wide layer.
   $: {
@@ -17,8 +18,11 @@
   <select bind:value={show} disabled={$formOpen != null}>
     <option value="none">None</option>
     <option value="speed limits">Speed limits</option>
+    <option value="lane details">Lane details</option>
   </select>
 </label>
 {#if show == "speed limits"}
   <SpeedLimits id={undefined} />
+{:else if show == "lane details"}
+  <LaneDetails />
 {/if}

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -4,6 +4,9 @@
   import LanePolygons from "./lane_details/LanePolygons.svelte";
   import LaneMarkings from "./lane_details/LaneMarkings.svelte";
 
+  // Show along a route if specified, or show all otherwise
+  export let id: number | undefined;
+
   let gj1;
   let gj2;
   let gj3;
@@ -11,17 +14,25 @@
 
   onMount(async () => {
     try {
-      console.log("GIMME");
-      let raw = await $routeInfo.renderLaneDetails();
+      let raw;
+      if (id) {
+        let linestring = $gjScheme.features.find(
+          (f) => f.id == id
+        ) as Feature<LineString>;
+        raw = await $routeInfo.renderLaneDetailsForRoute(
+          linestring.properties.waypoints
+        );
+      } else {
+        raw = await $routeInfo.renderAllLaneDetails();
+      }
       gj1 = JSON.parse(raw[0]);
       gj2 = JSON.parse(raw[1]);
       //gj3 = JSON.parse(raw[2]);
       //gj4 = JSON.parse(raw[3]);
     } catch (e) {
-      window.alert(`Couldn't calculate speed limits for route: ${e}`);
+      window.alert(`Couldn't render lane details: ${e}`);
     }
   });
-
 </script>
 
 {#if gj1}

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -12,6 +12,8 @@
   // Show along a route
   export let id: number;
 
+  // renderLaneDetailsForRoute returns 4 layers in a certain order. They're
+  // labeled when used below.
   let gj1;
   let gj2;
   let gj3;

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { gjScheme, routeInfo } from "../../stores";
+  import LanePolygons from "./lane_details/LanePolygons.svelte";
+  import LaneMarkings from "./lane_details/LaneMarkings.svelte";
+
+  let gj1;
+  let gj2;
+  let gj3;
+  let gj4;
+
+  onMount(async () => {
+    try {
+      console.log("GIMME");
+      let raw = await $routeInfo.renderLaneDetails();
+      gj1 = JSON.parse(raw[0]);
+      gj2 = JSON.parse(raw[1]);
+      //gj3 = JSON.parse(raw[2]);
+      //gj4 = JSON.parse(raw[3]);
+    } catch (e) {
+      window.alert(`Couldn't calculate speed limits for route: ${e}`);
+    }
+  });
+
+</script>
+
+{#if gj1}
+  <LanePolygons gj={gj1} />
+  <LaneMarkings gj={gj2} />
+{/if}

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
+  import type { LineString } from "geojson";
+  import type { Feature } from "../../types";
   import { onMount } from "svelte";
   import { gjScheme, routeInfo } from "../../stores";
   import LanePolygons from "./lane_details/LanePolygons.svelte";
   import LaneMarkings from "./lane_details/LaneMarkings.svelte";
+  import IntersectionPolygons from "./lane_details/IntersectionPolygons.svelte";
+  import IntersectionMarkings from "./lane_details/IntersectionMarkings.svelte";
+  import HelpIcon from "../common/HelpIcon.svelte";
 
-  // Show along a route if specified, or show all otherwise
-  export let id: number | undefined;
+  // Show along a route
+  export let id: number;
 
   let gj1;
   let gj2;
@@ -14,21 +19,16 @@
 
   onMount(async () => {
     try {
-      let raw;
-      if (id) {
-        let linestring = $gjScheme.features.find(
-          (f) => f.id == id
-        ) as Feature<LineString>;
-        raw = await $routeInfo.renderLaneDetailsForRoute(
-          linestring.properties.waypoints
-        );
-      } else {
-        raw = await $routeInfo.renderAllLaneDetails();
-      }
+      let linestring = $gjScheme.features.find(
+        (f) => f.id == id
+      ) as Feature<LineString>;
+      let raw = await $routeInfo.renderLaneDetailsForRoute(
+        linestring.properties.waypoints
+      );
       gj1 = JSON.parse(raw[0]);
       gj2 = JSON.parse(raw[1]);
-      //gj3 = JSON.parse(raw[2]);
-      //gj4 = JSON.parse(raw[3]);
+      gj3 = JSON.parse(raw[2]);
+      gj4 = JSON.parse(raw[3]);
     } catch (e) {
       window.alert(`Couldn't render lane details: ${e}`);
     }
@@ -38,4 +38,10 @@
 {#if gj1}
   <LanePolygons gj={gj1} />
   <LaneMarkings gj={gj2} />
+  <IntersectionPolygons gj={gj3} />
+  <IntersectionMarkings gj={gj4} />
 {/if}
+
+<HelpIcon
+  contents="This visualizes lane data according to OpenStreetMap. There may be many errors with incorrect or missing lane data, lane width and intersection geometry, and markings. Use with caution."
+/>

--- a/src/lib/layers/lane_details/IntersectionMarkings.svelte
+++ b/src/lib/layers/lane_details/IntersectionMarkings.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Layer from "./Layer.svelte";
+  import { caseHelper } from "../../../maplibre_helpers";
+  import type { GeoJSON } from "geojson";
+
+  export let gj: GeoJSON;
+
+  let style = {
+    type: "fill",
+    paint: {
+      "fill-color": caseHelper(
+        "type",
+        {
+          "sidewalk corner": "#CCCCCC",
+        },
+        "red"
+      ),
+      "fill-opacity": 0.9,
+    },
+  };
+</script>
+
+<Layer source="intersection-markings" {gj} {style} />

--- a/src/lib/layers/lane_details/IntersectionPolygons.svelte
+++ b/src/lib/layers/lane_details/IntersectionPolygons.svelte
@@ -12,12 +12,13 @@
       "fill-color": caseHelper(
         "intersection_kind",
         {
-          Connection: "#666",
-          Intersection: "#966",
-          Terminus: "#999",
           MapEdge: "#696",
+          Terminus: "black",
+          Connection: "black",
+          Fork: "black",
+          Intersection: "black",
         },
-        "#666"
+        "red"
       ),
       "fill-opacity": 0.9,
     },

--- a/src/lib/layers/lane_details/IntersectionPolygons.svelte
+++ b/src/lib/layers/lane_details/IntersectionPolygons.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Layer from "./Layer.svelte";
+  import { caseHelper } from "../../../maplibre_helpers";
+  import type { GeoJSON } from "geojson";
+
+  export let gj: GeoJSON;
+
+  let style = {
+    type: "fill",
+    filter: ["==", ["get", "type"], "intersection"],
+    paint: {
+      "fill-color": caseHelper(
+        "intersection_kind",
+        {
+          Connection: "#666",
+          Intersection: "#966",
+          Terminus: "#999",
+          MapEdge: "#696",
+        },
+        "#666"
+      ),
+      "fill-opacity": 0.9,
+    },
+  };
+</script>
+
+<Layer source="intersection-polygons" {gj} {style} />

--- a/src/lib/layers/lane_details/LaneMarkings.svelte
+++ b/src/lib/layers/lane_details/LaneMarkings.svelte
@@ -11,7 +11,7 @@
       "fill-color": caseHelper(
         "type",
         {
-          "center line": "yellow",
+          "center line": "white",
           "lane separator": "white",
           "lane arrow": "white",
           "buffer edge": "white",

--- a/src/lib/layers/lane_details/LaneMarkings.svelte
+++ b/src/lib/layers/lane_details/LaneMarkings.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Layer from "./Layer.svelte";
+  import { caseHelper } from "../../../maplibre_helpers";
+  import type { GeoJSON } from "geojson";
+
+  export let gj: GeoJSON;
+
+  let style = {
+    type: "fill",
+    paint: {
+      "fill-color": caseHelper(
+        "type",
+        {
+          "center line": "yellow",
+          "lane separator": "white",
+          "lane arrow": "white",
+          "buffer edge": "white",
+          "buffer stripe": "white",
+          "vehicle stop line": "white",
+          "bike stop line": "green",
+        },
+        "red"
+      ),
+      "fill-opacity": 0.9,
+    },
+  };
+</script>
+
+<Layer source="lane-markings" {gj} {style} />

--- a/src/lib/layers/lane_details/LanePolygons.svelte
+++ b/src/lib/layers/lane_details/LanePolygons.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import Layer from "./Layer.svelte";
+  import { caseHelper } from "../../../maplibre_helpers";
+  import type { GeoJSON } from "geojson";
+
+  export let gj: GeoJSON;
+
+  let style = {
+    type: "fill",
+    paint: {
+      "fill-color": caseHelper(
+        "type",
+        // TODO Generate TS types from osm2streets
+        {
+          Driving: "black",
+          Parking: "#333333",
+          Sidewalk: "#CCCCCC",
+          Shoulder: "#CCCCCC",
+          Biking: "#0F7D4B",
+          Bus: "#BE4A4C",
+          SharedLeftTurn: "black",
+          Construction: "#FF6D00",
+          LightRail: "#844204",
+          Footway: "#DDDDE8",
+          SharedUse: "#E5E1BB",
+          // This is the only type used currently
+          "Buffer(Planters)": "#555555",
+        },
+        "red"
+      ),
+      "fill-opacity": 0.9,
+    },
+  };
+</script>
+
+<Layer source="lane-polygons" {gj} {style} />

--- a/src/lib/layers/lane_details/Layer.svelte
+++ b/src/lib/layers/lane_details/Layer.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import type { GeoJSON } from "geojson";
+  import { map } from "../../../stores";
+  import { overwriteSource, overwriteLayer } from "../../../maplibre_helpers";
+
+  // This component manages a source with exactly one layer. Both are torn down
+  // when this component is destroyed.
+  // TODO Move to common and use more widely?
+  export let source: string;
+  export let gj: GeoJSON;
+  export let style;
+
+  let layer = `${source}-layer`;
+
+  overwriteSource($map, source, gj);
+  overwriteLayer($map, {
+    id: layer,
+    source,
+    ...style,
+  });
+
+  onDestroy(() => {
+    if ($map.getLayer(layer)) {
+      $map.removeLayer(layer);
+    }
+    if ($map.getSource(source)) {
+      $map.removeSource(source);
+    }
+  });
+</script>

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -175,6 +175,21 @@ export function emptyGeojson(): FeatureCollection {
   };
 }
 
+// Helper for https://maplibre.org/maplibre-style-spec/expressions/#case based on one property
+export function caseHelper(
+  getKey: string,
+  map: { [name: string]: string },
+  backup: string
+): any[] {
+  let x: any[] = ["case"];
+  for (let [key, value] of Object.entries(map)) {
+    x.push(["==", ["get", getKey], key]);
+    x.push(value);
+  }
+  x.push(backup);
+  return x;
+}
+
 // Suitable for passing to map.fitBounds. Work around https://github.com/Turfjs/turf/issues/1807.
 export function bbox(gj: GeoJSON): [number, number, number, number] {
   return turfBbox(gj) as [number, number, number, number];
@@ -213,6 +228,11 @@ const layerZorder = [
   "draw-street-view",
 
   "speed-limits",
+
+  "lane-polygons-layer",
+  "intersection-polygons-layer",
+  "lane-markings-layer",
+  "intersection-markings-layer",
 
   // When editing a route, draw it over contextual layers like speed limits
   "route-points",

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -42,7 +42,8 @@ export function overwriteSource(map: Map, id: string, data: GeoJSON) {
 // This is an internal helper used by specialized functions for drawing
 // circles, lines, and polygons. The layer.id here MUST be present in
 // layerZorder.
-function overwriteLayer(
+// TODO It's exported for the LaneDetails Layer helper. Reconsider.
+export function overwriteLayer(
   map: Map,
   layer: LayerSpecification & { source: string }
 ) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -56,27 +56,6 @@ export class RouteInfo {
     return this.inner.allSpeedLimits();
   }
 
-  renderAllLaneDetails(): string[] {
-    if (!this.inner) {
-      throw new Error(
-        "Still loading route info, please retry after a few seconds"
-      );
-    }
-    console.log("do 1");
-    let gj1 = this.inner.renderLanePolygons();
-    console.log("do 2");
-    let gj2 = this.inner.renderLaneMarkings();
-    /*console.log("do 3");
-    let gj3 = this.inner.renderIntersectionPolygons();
-    console.log("do 4");
-    let gj4 = this.inner.renderIntersectionMarkings();
-    console.log("return all");
-    return [gj1, gj2, gj3, gj4];*/
-    return [gj1, gj2, "", ""];
-
-    //return [this.inner.renderLanePolygons(), this.inner.renderLaneMarkings(), this.inner.renderIntersectionPolygons(), this.inner.renderIntersectionMarkings()];
-  }
-
   renderLaneDetailsForRoute(waypoints: Waypoint[]): string[] {
     if (!this.inner) {
       throw new Error(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -55,6 +55,27 @@ export class RouteInfo {
 
     return this.inner.allSpeedLimits();
   }
+
+  renderLaneDetails(): string[] {
+    if (!this.inner) {
+      throw new Error(
+        "Still loading route info, please retry after a few seconds"
+      );
+    }
+    console.log("do 1");
+    let gj1 = this.inner.renderLanePolygons();
+    console.log("do 2");
+    let gj2 = this.inner.renderLaneMarkings();
+    /*console.log("do 3");
+    let gj3 = this.inner.renderIntersectionPolygons();
+    console.log("do 4");
+    let gj4 = this.inner.renderIntersectionMarkings();
+    console.log("return all");
+    return [gj1, gj2, gj3, gj4];*/
+    return [gj1, gj2, "", ""];
+
+    //return [this.inner.renderLanePolygons(), this.inner.renderLaneMarkings(), this.inner.renderIntersectionPolygons(), this.inner.renderIntersectionMarkings()];
+  }
 }
 
 Comlink.expose(RouteInfo);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -56,7 +56,7 @@ export class RouteInfo {
     return this.inner.allSpeedLimits();
   }
 
-  renderLaneDetails(): string[] {
+  renderAllLaneDetails(): string[] {
     if (!this.inner) {
       throw new Error(
         "Still loading route info, please retry after a few seconds"
@@ -75,6 +75,16 @@ export class RouteInfo {
     return [gj1, gj2, "", ""];
 
     //return [this.inner.renderLanePolygons(), this.inner.renderLaneMarkings(), this.inner.renderIntersectionPolygons(), this.inner.renderIntersectionMarkings()];
+  }
+
+  renderLaneDetailsForRoute(waypoints: Waypoint[]): string[] {
+    if (!this.inner) {
+      throw new Error(
+        "Still loading route info, please retry after a few seconds"
+      );
+    }
+    // Normally this code doesn't parse the results at all, but at least unpack the 4 strings
+    return JSON.parse(this.inner.renderLaneDetailsForRoute(waypoints));
   }
 }
 


### PR DESCRIPTION
Now that we have osm2streets.org hooked up to ATIP, it's relatively easy for us to attempt something kind of cool: rendering detailed lanes along a route! CC @BudgieInWA. Preview at https://acteng.github.io/atip/layer_lanes/scheme.html?authority=Derby.

https://github.com/acteng/atip/assets/1664407/dbab2d42-beeb-4093-a60b-ab475b88d568

# Design questions

First of all, there are loads of caveats with the rendering. The video above shows a few glaring problems! A big question should be how people will use this; does it solve any concrete problem right now? Is the danger of misinterpretation high and we should work towards this kind of thing eventually, but only add it once it's stabler? My motivation is partly to make osm2streets work even more visible, to drive improvements and feature requests (as a starter -- specializing the marking styles and default lane widths for the UK!).

The blue route underneath is still visible (and clickable), as with speed limits. From far away, this looks strange, and when zoomed in, it can also interfere.

It'd be cool to add a tooltip when you hover on lanes, maybe estimating the current width shown.

# Scope

Right now it only renders things along the route. (And in the example video, the snapping is a bit wrong, so it fails to match up the route -- same issue with the speed limit layer). Maybe it'd be more useful to show a bit of surrounding context, like all of the roads that connect to anything along the route?

I originally tried rendering the entire area, but even in the smallest cases, we hit major performance problems. The entire pipeline is inefficient at that scale -- rendering something in-memory to GeoJSON, serializing it as a string, possibly copying the string (I'm still not totally sure how things are transferred around by web workers), parsing it in the browser, adding it to MapLibre (which internally tiles it and converts to MVT). In A/B Street, there's none of that overhead, and still we have to lazily render details as we pan around while zoomed in. I have some ideas for how to achieve the same thing in ATIP (by lazily rendering something tile-like, or possibly by drawing directly to the OpenGL context from the web worker) but it's nothing easy to do quickly.