### PR TITLE
Small UX tweaks

### DIFF
--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -268,7 +268,7 @@
 
 {#if mode == thisMode}
   <ul>
-    <li><b>Click</b> near a route to split it</li>
+    <li><b>Click</b> on a route to split it</li>
     <li><b>Click</b> on the map or press <b>Escape</b> to cancel</li>
   </ul>
 {/if}

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -17,7 +17,7 @@
   }
 
   // TODO Disable the button until RouteInfo is loaded and ready?
-  async function autoFillDetails() {
+  async function autoFillName() {
     let linestring = $gjScheme.features.find(
       (f) => f.id == id
     ) as Feature<LineString>;
@@ -29,8 +29,10 @@
   }
 </script>
 
-<label
-  >Name:<br />
+<label>
+  Name:
+  <button type="button" on:click={() => autoFillName()}>Auto-fill</button>
+  <br />
   <input type="text" bind:value={name} style="width: 100%" />
 </label>
 
@@ -64,9 +66,7 @@
 
 {#if length_meters}
   Length: {prettyPrintMeters(length_meters)}
-  <br /><button type="button" on:click={() => autoFillDetails()}
-    >Auto-fill details</button
-  ><br />
+  <br />
   <RouteInfoLayers {id} />
 {/if}
 


### PR DESCRIPTION
From watching UX sessions, two small things jumped out, easy to fix:

The "Auto-fill details" button is too far away from where people type in the name, and its effect is unclear. So move it:
![Screenshot from 2023-05-23 14-40-50](https://github.com/acteng/atip/assets/1664407/96e1e446-1726-42fa-87b8-94bee6e62cbd)

In the split tool, someone was confused by "Click near a route". I just meant the mouse doesn't need to be exactly on the route before it snaps, but that's obvious anyway when trying to use it. So adjust the wording to "Click on a route"