### PR TITLE
Double click to finish a freehand polygon

### DIFF
--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -11,7 +11,7 @@
     <li><b>Click</b> the map to add a vertex</li>
     <li><b>Click</b> a vertex to delete it</li>
     <li><b>Drag</b> a vertex or the polygon to move it</li>
-    <li>Press <b>Enter</b> to finish</li>
+    <li>Press <b>Enter</b> or <b>double click</b> to finish</li>
     <li>Press <b>Escape</b> to cancel</li>
   </ul>
 </CollapsibleCard>

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -123,7 +123,9 @@ export class RouteTool {
     }
     // When we finish, we'll re-enable doubleClickZoom, but we don't want this to zoom in
     e.preventDefault();
-    // Treat it like a click, to possibly add a final point
+    // Double clicks happen as [click, click, dblclick]. The first click adds a
+    // point, the second immediately deletes it, and so we simulate a third
+    // click to add it again.
     this.inner.onClick();
     this.finish();
   }

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -15,7 +15,7 @@
     </li>
     <li><b>Click and drag</b> any point to move it</li>
     <li><b>Click</b> a red waypoint to delete it</li>
-    <li>Press <b>Enter</b> to finish area</li>
+    <li>Press <b>Enter</b> or <b>double click</b> to finish</li>
     <li>Press <b>Escape</b> to cancel</li>
   </ul>
 </CollapsibleCard>


### PR DESCRIPTION
Robin noticed this bug yesterday. Thanks to OSMUS for advice: https://osmus.slack.com/archives/C01G3D28DAB/p1685016451984109

We have a remaining bug double clicking in the snap polygon tool, but the fix for that needs to happen in the route-snapper repo; I'll do it separately.