### PR TITLE
Disable some controls before RouteInfo is ready

### DIFF
--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -16,13 +16,12 @@
     return (x / 1000.0).toFixed(1) + "km";
   }
 
-  // TODO Disable the button until RouteInfo is loaded and ready?
   async function autoFillName() {
     let linestring = $gjScheme.features.find(
       (f) => f.id == id
     ) as Feature<LineString>;
     try {
-      name = await $routeInfo.nameForRoute(linestring);
+      name = await $routeInfo!.nameForRoute(linestring);
     } catch (e) {
       window.alert(`Couldn't auto-name route: ${e}`);
     }
@@ -31,7 +30,9 @@
 
 <label>
   Name:
-  <button type="button" on:click={() => autoFillName()}>Auto-fill</button>
+  <button type="button" on:click={() => autoFillName()} disabled={!$routeInfo}
+    >Auto-fill</button
+  >
   <br />
   <input type="text" bind:value={name} style="width: 100%" />
 </label>

--- a/src/lib/forms/RouteInfoLayers.svelte
+++ b/src/lib/forms/RouteInfoLayers.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { routeInfo } from "../../stores";
   import SpeedLimits from "../layers/SpeedLimits.svelte";
   import LaneDetails from "../layers/LaneDetails.svelte";
 
@@ -7,16 +8,20 @@
   let layer: "none" | "speed limits" | "lane details" = "none";
 </script>
 
-<label>
-  Show details:
-  <select bind:value={layer}>
-    <option value="none">None</option>
-    <option value="speed limits">Speed limits</option>
-    <option value="lane details">Lane details</option>
-  </select>
-</label>
-{#if layer == "speed limits"}
-  <SpeedLimits {id} />
-{:else if layer == "lane details"}
-  <LaneDetails {id} />
+{#if $routeInfo}
+  <label>
+    Show details:
+    <select bind:value={layer}>
+      <option value="none">None</option>
+      <option value="speed limits">Speed limits</option>
+      <option value="lane details">Lane details</option>
+    </select>
+  </label>
+  {#if layer == "speed limits"}
+    <SpeedLimits {id} />
+  {:else if layer == "lane details"}
+    <LaneDetails {id} />
+  {/if}
+{:else}
+  <p>Route info loading...</p>
 {/if}

--- a/src/lib/layers/ContextualLayers.svelte
+++ b/src/lib/layers/ContextualLayers.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SpeedLimits from "./SpeedLimits.svelte";
-  import { formOpen } from "../../stores";
+  import { formOpen, routeInfo } from "../../stores";
 
   let show: "none" | "speed limits" = "none";
 
@@ -12,13 +12,17 @@
   }
 </script>
 
-<label>
-  Show layer:
-  <select bind:value={show} disabled={$formOpen != null}>
-    <option value="none">None</option>
-    <option value="speed limits">Speed limits</option>
-  </select>
-</label>
-{#if show == "speed limits"}
-  <SpeedLimits id={undefined} />
+{#if $routeInfo}
+  <label>
+    Show layer:
+    <select bind:value={show} disabled={$formOpen != null}>
+      <option value="none">None</option>
+      <option value="speed limits">Speed limits</option>
+    </select>
+  </label>
+  {#if show == "speed limits"}
+    <SpeedLimits id={undefined} />
+  {/if}
+{:else}
+  <p>Route info loading...</p>
 {/if}

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import type { LineString } from "geojson";
+  // This component can only be created once routeInfo is ready
+
+  import type { GeoJSON, LineString } from "geojson";
   import type { Feature } from "../../types";
   import { onMount } from "svelte";
   import { gjScheme, routeInfo } from "../../stores";
@@ -14,17 +16,17 @@
 
   // renderLaneDetailsForRoute returns 4 layers in a certain order. They're
   // labeled when used below.
-  let gj1;
-  let gj2;
-  let gj3;
-  let gj4;
+  let gj1: GeoJSON;
+  let gj2: GeoJSON;
+  let gj3: GeoJSON;
+  let gj4: GeoJSON;
 
   onMount(async () => {
     try {
       let linestring = $gjScheme.features.find(
         (f) => f.id == id
       ) as Feature<LineString>;
-      let raw = await $routeInfo.renderLaneDetailsForRoute(
+      let raw = await $routeInfo!.renderLaneDetailsForRoute(
         linestring.properties.waypoints
       );
       gj1 = JSON.parse(raw[0]);

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  // This component can only be created once routeInfo is ready
+
   import { onMount, onDestroy } from "svelte";
   import {
     emptyGeojson,
@@ -77,11 +79,11 @@
           (f) => f.id == id
         ) as Feature<LineString>;
         let gj = JSON.parse(
-          await $routeInfo.speedLimitForRoute(linestring.properties.waypoints)
+          await $routeInfo!.speedLimitForRoute(linestring.properties.waypoints)
         );
         ($map.getSource(source) as GeoJSONSource).setData(gj);
       } else {
-        let gj = JSON.parse(await $routeInfo.allSpeedLimits());
+        let gj = JSON.parse(await $routeInfo!.allSpeedLimits());
         ($map.getSource(source) as GeoJSONSource).setData(gj);
       }
     } catch (e) {

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -77,10 +77,11 @@
     const MyWorker: Comlink.Remote<WorkerConstructor> = Comlink.wrap(
       new workerWrapper()
     );
-    // TODO Maybe don't set it until loadFile is done, so that everywhere using
-    // it can disable controls until loaded
-    routeInfo.set(await new MyWorker());
-    await $routeInfo.loadFile(routeInfoUrl);
+    // Don't populate the routeInfo store until loadFile is done, so other
+    // places can disable controls until it's ready
+    let info = await new MyWorker();
+    await info.loadFile(routeInfoUrl);
+    routeInfo.set(info);
   });
 
   async function loadAuthorityBoundary(): Promise<FeatureCollection<Polygon>> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "allowJs": true,
     "checkJs": true,
     "isolatedModules": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "strict": false
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "tests/**/*"]
 }


### PR DESCRIPTION
One of the most frantic demos I've recorded:

https://github.com/acteng/atip/assets/1664407/6d1c5d18-a788-4b1e-94ba-45c4cea89e2d

I'd still like to improve on this, but this is a step forwards:
- Use a real progress bar, at least for the HTTP fetch (https://github.com/acteng/atip/tree/progress is a start)
- Expose any error messages properly (maybe the `routeInfo` store should be `| error`
- Have some Playwright tests that throttle/halt the file load, assert what's on-screen, let it finish, see it work, etc