### PR TITLE
By default, don't keep appending points to the end of a route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/geojson": "^7946.0.10",
         "comlink": "^4.4.1",
         "maplibre-gl": "^2.4.0",
-        "route-snapper": "^0.1.13",
+        "route-snapper": "^0.1.14",
         "svelte": "^3.54.0"
       },
       "devDependencies": {
@@ -1953,9 +1953,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.13.tgz",
-      "integrity": "sha512-GjILba/OSor8gU2LkdAtioxlNdHx8CVTtFcR1QG9XpRIXjINgzv1slnC3nfpQ2yzb8rGvCEHqqHtUFNqDy2dCg=="
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.14.tgz",
+      "integrity": "sha512-/3zRoRI0VL+aPas+fDQ9lvp5Fqkc5WosRh0gd/JrlJ3dA4nfXCzxZG9l04NsGzvhIYoDPy/2j3ivvost6GW7BA=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/geojson": "^7946.0.10",
     "comlink": "^4.4.1",
     "maplibre-gl": "^2.4.0",
-    "route-snapper": "^0.1.13",
+    "route-snapper": "^0.1.14",
     "svelte": "^3.54.0"
   }
 }

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -210,7 +210,7 @@
   {:else if currentlyEditingControls == "snap-polygon"}
     <SnapPolygonControls {routeTool} />
   {:else if currentlyEditingControls == "route"}
-    <RouteControls {routeTool} />
+    <RouteControls {routeTool} extendRoute={false} />
   {:else}
     <p>Click an object to edit its geometry</p>
   {/if}

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -6,9 +6,11 @@
 
   export let routeTool: RouteTool;
 
+  let extendRoute = false;
   // TODO When editing, we should save in the route and use the previous value
   $: routeTool.setRouteConfig({
     avoid_doubling_back: $userSettings.avoidDoublingBack,
+    extend_route: extendRoute,
   });
 
   // TODO Show if shift is held or not
@@ -28,7 +30,16 @@
   </ul>
 </CollapsibleCard>
 
-<label>
+<label title="Keep clicking to add more points to the end of the route">
+  <input type="checkbox" bind:checked={extendRoute} />
+  Add points to end
+</label>
+
+<br />
+
+<label
+  title="Try to make the route avoid using the same streets with multiple waypoints"
+>
   <input type="checkbox" bind:checked={$userSettings.avoidDoublingBack} />
   Avoid doubling back
 </label>

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -5,8 +5,10 @@
   import { userSettings } from "../../../stores";
 
   export let routeTool: RouteTool;
+  // Start with this enabled or disabled, based on whether we're drawing a new
+  // route or editing an existing.
+  export let extendRoute: boolean;
 
-  let extendRoute = false;
   // TODO When editing, we should save in the route and use the previous value
   $: routeTool.setRouteConfig({
     avoid_doubling_back: $userSettings.avoidDoublingBack,

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -69,5 +69,5 @@
   <!-- TODO the text should be fixed, and the progress bar float -->
   <div bind:this={progress}>Route tool loading...</div>
 {:else if mode == thisMode}
-  <RouteControls {routeTool} />
+  <RouteControls {routeTool} extendRoute />
 {/if}

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -203,7 +203,11 @@ export class RouteTool {
       return;
     }
 
-    this.inner.setConfig({ avoid_doubling_back: true, area_mode: true });
+    this.inner.setConfig({
+      avoid_doubling_back: true,
+      area_mode: true,
+      extend_route: true,
+    });
     this.active = true;
     this.map.boxZoom.disable();
     this.map.doubleClickZoom.disable();
@@ -329,7 +333,10 @@ export class RouteTool {
     this.finish();
   }
 
-  setRouteConfig(config: { avoid_doubling_back: boolean }) {
+  setRouteConfig(config: {
+    avoid_doubling_back: boolean;
+    extend_route: boolean;
+  }) {
     this.inner.setConfig({ ...config, area_mode: false });
     this.redraw();
   }


### PR DESCRIPTION
See https://github.com/dabreegster/route_snapper/pull/30 for context. I haven't done UX testing with anyone, but I suspect this'll make the default experience much less weird. It's much easier to drag intermediate waypoints this way.

For people who want to change the default, combined with #201 would let them make the setting sticky.