### PR TITLE
Hide the autofill button unless we have a linestring

### DIFF
--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -30,9 +30,9 @@
 
 <label>
   Name:
-  <button type="button" on:click={() => autoFillName()} disabled={!$routeInfo}
-    >Auto-fill</button
-  >
+  {#if length_meters}
+    <button type="button" on:click={() => autoFillName()} disabled={!$routeInfo}>Auto-fill</button>
+  {/if}
   <br />
   <input type="text" bind:value={name} style="width: 100%" />
 </label>

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -16,6 +16,8 @@
     return (x / 1000.0).toFixed(1) + "km";
   }
 
+  // Sets the intervention name to "From {road1 and road2} to {road3 and
+  // road4}". Only meant to be useful for routes currently.
   async function autoFillName() {
     let linestring = $gjScheme.features.find(
       (f) => f.id == id
@@ -30,8 +32,11 @@
 
 <label>
   Name:
+  <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
   {#if length_meters}
-    <button type="button" on:click={() => autoFillName()} disabled={!$routeInfo}>Auto-fill</button>
+    <button type="button" on:click={() => autoFillName()} disabled={!$routeInfo}
+      >Auto-fill</button
+    >
   {/if}
   <br />
   <input type="text" bind:value={name} style="width: 100%" />


### PR DESCRIPTION
Oops! Quick fix for this:
![Screenshot from 2023-06-01 12-48-29](https://github.com/acteng/atip/assets/1664407/4282b7e6-a4fb-43d5-8ef2-f5328a589af3)
