### PR TITLE
Fix TS errors involving shared.ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
     "checkJs": true,
     "isolatedModules": true,
     "types": ["node", "vite/client"],
-    "strict": false
+    "strict": false,
+    /* Necessary for Playwright tests */
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "tests/**/*"]
 }


### PR DESCRIPTION
In `main` right now, `npm run check` complains:

```
Error: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled. 
import { expect, test, type Page } from "@playwright/test";
import { loadInitialPage, clearExistingInterventions } from "./shared.ts";
```

Elsewhere in the codebase we don't include any file extension. If I import `from "./shared"`, then `npm run check` is happy, but `npm run test` breaks. With this PR, both `check` and `test` appear to be happy.

I don't understand why Playwright is doing anything special here. Only relevant thing I could find is https://github.com/microsoft/playwright/issues/19710. So, this PR seems fine, unless one of us understands TS build config better.