### PR TITLE
Fix final TS errors and enable npm run check

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,10 @@ jobs:
       run: npx playwright install --with-deps
 
     - name: Run Playwright tests
-      run: npm test
+      run: npm run test
+
+    - name: Run type-checker
+      run: npm run check
 
     - uses: actions/upload-artifact@v3
       with:

--- a/src/lib/forms/generate_ts.ts
+++ b/src/lib/forms/generate_ts.ts
@@ -26,6 +26,9 @@ while (queue.length > 0) {
 }
 
 function generate(field: Field) {
+  // The top-level object defined by the schema is the first one processed
+  let isTopLevel = seen.size == 0;
+
   if (seen.has(field.name)) {
     // We could also generate more detailed type names based on the nesting,
     // but this seems confusing
@@ -60,9 +63,15 @@ function generate(field: Field) {
       } else if (isSimpleEnumCase(x)) {
         cases.push(`"${x.value}"`);
       } else {
-        cases.push(x.name);
+        cases.push(`{ ${x.name}: ${x.name}; }`);
         queue.push(x);
       }
+    }
+    // If the top-level field in the schema is an enum, allow the entire thing
+    // to be empty. All fields in a struct are optional; this lets the
+    // top-level enum be optional too.
+    if (isTopLevel) {
+      cases.push(`{}`);
     }
     console.log(`export type ${field.name} = ${cases.join(" | ")};\n`);
   } else {

--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -14,13 +14,18 @@
       return feature.properties.planning?.name || "Untitled polygon";
     }
     if (schema == "v2") {
-      return (
-        feature.properties.v2?.Route?.name ||
-        feature.properties.v2?.Crossing?.name ||
-        "Untitled intervention"
-      );
+      if (feature.properties.v2) {
+        if ("Route" in feature.properties.v2) {
+          return feature.properties.v2!.Route.name || "Untitled route";
+        }
+        if ("Crossing" in feature.properties.v2) {
+          return feature.properties.v2!.Crossing.name || "Untitled crossing";
+        }
+      }
+      return "Untitled intervention";
     }
 
+    // v1
     if (feature.properties.name) {
       return feature.properties.name;
     }

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -95,7 +95,12 @@
 <Layout>
   <div slot="sidebar">
     <div>
-      <button type="button" on:click={() => window.location.href = "index.html"}> Home</button>
+      <button
+        type="button"
+        on:click={() => (window.location.href = "index.html")}
+      >
+        Home</button
+      >
       <button type="button" on:click={toggleAbout}>About</button>
       <button type="button" on:click={toggleInstructions}>Instructions</button>
     </div>

--- a/src/schemas/v2.ts
+++ b/src/schemas/v2.ts
@@ -1,6 +1,6 @@
 // This file is auto-generated; do not manually edit
 
-export type Intervention = Route | Crossing;
+export type Intervention = { Route: Route } | { Crossing: Crossing } | {};
 
 export interface Crossing {
   name?: string;
@@ -17,10 +17,10 @@ export type MotorTrafficFlow = "> 8000" | "3000 - 8000" | "< 3000";
 
 export type CrossingType =
   | "Zebra"
-  | Signalised
+  | { Signalised: Signalised }
   | "SchoolCrossing"
   | "Refuge"
-  | GradeSeparated;
+  | { GradeSeparated: GradeSeparated };
 
 export interface GradeSeparated {
   GradeSeparatedType?: GradeSeparatedType;
@@ -52,14 +52,14 @@ export type Users =
   | "Footpath"
   | "Cyclepath"
   | "SharedUseNoSeparation"
-  | SharedUseWithSeparation;
+  | { SharedUseWithSeparation: SharedUseWithSeparation };
 
 export interface SharedUseWithSeparation {
   width_footpath?: number;
   width_cyclepath?: number;
 }
 
-export type RouteType = OnRoad | OffRoad;
+export type RouteType = { OnRoad: OnRoad } | { OffRoad: OffRoad };
 
 export type OffRoad = "ThroughPark" | "CanalTowpath";
 
@@ -80,6 +80,6 @@ export type OnRoadType =
   | "PartSeparation"
   | "MandatoryLane"
   | "AdvisoryLane"
-  | NoSeparation;
+  | { NoSeparation: NoSeparation };
 
 export type NoSeparation = "TrafficCalming" | "ModalFilters" | "LowSpeed";

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -29,8 +29,8 @@ test("clearing all resets to nothing being selected", async () => {
   await expect(
     page.getByText("Edit attributes to the left, or click another object")
   ).toBeVisible();
-  
-  await clearExistingInterventions(page)
+
+  await clearExistingInterventions(page);
 
   await expect(
     page.getByText("Click an object to fill out its attributes")


### PR DESCRIPTION
This is an alternative to #232 to fix some errors involving incomplete forms. All TS errors are now gone, and so `npm run check` is added to Github CI, with the goal being that we never check in anything that doesn't type-check again!

(As a further step, enabling strict mode would be great, but there are more problems to sort out first)