### PR TITLE
Color adjustments from Kelin

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,7 +1,7 @@
 export const colors = {
   // https://colorbrewer2.org/#type=qualitative&scheme=Set1&n=4
-  area: "#e41a1c",
-  route: "#377eb8",
+  area: "#D94324",
+  route: "#555F5E",
   crossing: "#4daf4a",
   other: "#984ea3",
 

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -126,7 +126,15 @@
     filter: ["all", isPolygon, hideWhileEditing] as FilterSpecification,
     color:
       schema == "planning" ? colorByReferenceType : colorByInterventionType,
+    opacity: 0.2,
+  });
+  overwriteLineLayer($map, {
+    id: "interventions-polygon-outlines",
+    source,
+    filter: ["all", isPolygon, hideWhileEditing] as FilterSpecification,
+    color:
+      schema == "planning" ? colorByReferenceType : colorByInterventionType,
     opacity: 0.5,
-    // TODO Outline too?
+    width: 0.7 * lineWidth,
   });
 </script>

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -22,7 +22,7 @@
   // Show along a route if specified, or show all otherwise
   export let id: number | undefined;
 
-  let colors = ["#00AB4D", "#8ECA4D", "#F7BB00", "#BB0000", "#470000"];
+  let colors = ["#086063", "#5BC2AE", "#E9C492", "#EBA14D", "#D94324"];
   // This'll never get displayed; its opacity will be set to 0 later
   let unknown = "white";
 

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -22,7 +22,7 @@
   // Show along a route if specified, or show all otherwise
   export let id: number | undefined;
 
-  let colors = ["#086063", "#5BC2AE", "#E9C492", "#EBA14D", "#D94324"];
+  let colors = ["#00AB4D", "#8ECA4D", "#F7BB00", "#BB0000", "#470000"];
   // This'll never get displayed; its opacity will be set to 0 later
   let unknown = "white";
 

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -202,6 +202,7 @@ const layerZorder = [
   // Polygons are bigger than lines, which're bigger than points. When geometry
   // overlaps, put the smaller thing on top
   "interventions-polygons",
+  "interventions-polygon-outlines",
   // This is an outline, so draw on top
   "hover-polygons",
 


### PR DESCRIPTION
Kelin (UA programme manager with an architecture background) kindly joined a UX session, and we generated lots of ideas to improve ATIP. Here are a few simple ones.

First, change the colors for routes and areas, and add an outline to areas. The outline emphasizes it as a clickable object more, and matches how Felt looks. Before:
![Screenshot from 2023-06-25 15-02-11](https://github.com/acteng/atip/assets/1664407/6b3cf043-4104-4a9d-99fd-488c822e287f)
After:
![Screenshot from 2023-06-25 15-02-17](https://github.com/acteng/atip/assets/1664407/d8960bbb-2036-4095-9d65-485cf40b31d6)

And second, change the color scale used for showing speed limits. It's based on the first big map in https://knightlab.northwestern.edu/2016/07/18/three-tools-to-help-you-make-colorblind-friendly-graphics/, but we adjusted the middle color, since it's too close to the basemap background color. We adjusted it by using the "mix" tool in `gpick`, mixing it with the category for 40 mph. Before:
![Screenshot from 2023-06-25 15-02-36](https://github.com/acteng/atip/assets/1664407/05b953ec-6ea7-4f63-82f5-4ba87c46e29d)
After:
![Screenshot from 2023-06-25 15-04-22](https://github.com/acteng/atip/assets/1664407/6d3f8426-977b-4194-8a32-46495b0ba64f)

Also note that the new color for routes (grey) is sort of a "continuation" of that color scale, a darker version of the "< 20" speed category. This is meant to suggest new route infrastructure proposed will be even better than an naturally slow-traffic street.

We can take any or all of the ideas here. Any opinions?