### PR TITLE
Show clickable objects on the map using cursor, not an outline. Reser…

### DIFF
--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -18,6 +18,11 @@
     sidebarHover,
   } from "../../stores";
 
+  // Show clickable objects on the map using the cursor
+  $: {
+    $map.getCanvas().style.cursor = $mapHover ? "pointer" : "grab";
+  }
+
   let source = "hover";
 
   // Use a layer that only ever has zero or one features for hovering. I think


### PR DESCRIPTION
…ve the outline for the object currently opened in the sidebar.

The UX session with Kelin demonstrated confusion about possible mouse actions at different points. It's not obvious you can click a waypoint in the polygon or route tool to delete it, but also click and drag to move it. Other tools change the cursor icon to show this. This PR is a very gentle first step in that direction, showing hover state on the map by changing the cursor. The thick black outline is reserved for showing the object opened in the sidebar.

Before/after screenshots are tough; try before at https://acteng.github.io/atip/scheme.html?authority=Adur, after at https://acteng.github.io/atip/cursors/scheme.html?authority=Adur

I'm thinking through the changes to the cursor we want to make for all of the drawing tools, aiming to draw inspiration from terra-draw, mapbox-gl-draw, etc.