### PR TITLE
Fix bug where we zoom to an object at the wrong time

### DIFF
--- a/src/lib/draw/AttributeMode.svelte
+++ b/src/lib/draw/AttributeMode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { type MapMouseEvent } from "maplibre-gl";
+  import { onDestroy } from "svelte";
   import { bbox } from "../../maplibre_helpers";
   import {
     currentMode,
@@ -22,8 +23,8 @@
     formOpen.set(null);
   }
 
-  $: {
-    let id = $openFromSidebar;
+  // Only run when openFromSidebar changes, not when gj changes.
+  const unsubscribe = openFromSidebar.subscribe((id) => {
     if (id) {
       // When the user starts editing something from the sidebar, warp to what's
       // being edited. (Don't do this when clicking the object on the map.)
@@ -46,7 +47,8 @@
       // touch formOpen.
       changeMode(thisMode);
     }
-  }
+  });
+  onDestroy(unsubscribe);
 
   eventHandler.mapHandlers.mousemove = (e: MapMouseEvent) => {
     let results = $map.queryRenderedFeatures(e.point, {

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -258,8 +258,7 @@ test("the viewport changes only once when opening a form", async () => {
   await page.getByText("Crossing", { exact: true }).click();
   // If we're incorrectly changing the viewport here, wait for the effect to happen
   await page.waitForTimeout(700);
-  // TODO Expect the test to fails here. Remove 'not' after fixing.
-  expect(new URL(page.url()).hash).not.toEqual(customViewport);
+  expect(new URL(page.url()).hash).toEqual(customViewport);
 });
 
 // Assert the page is in attribute mode with nothing selected.


### PR DESCRIPTION
See the test for a description of the bug. We zoom to an object when opening it from the sidebar. But while the form is open, if you move or zoom the map and then click anything in the open form, we zoom again. This PR adds a test and fixes the problem.