### PR TITLE
Let critical issues be nameable

### DIFF
--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -20,6 +20,9 @@
         "Untitled intervention"
       );
     }
+    if (schema == "criticals") {
+      return feature.properties.criticals?.name || "Untitled issue";
+    }
 
     if (feature.properties.name) {
       return feature.properties.name;

--- a/src/schemas/criticals.json
+++ b/src/schemas/criticals.json
@@ -2,6 +2,10 @@
   "name": "CriticalIssue",
   "members": [
     {
+      "name": "name",
+      "type": "one-liner"
+    },
+    {
       "name": "Type",
       "oneOf": [
         {

--- a/src/schemas/criticals.ts
+++ b/src/schemas/criticals.ts
@@ -1,6 +1,7 @@
 // This file is auto-generated; do not manually edit
 
 export interface CriticalIssue {
+  name?: string;
   Type?: Type;
   comment?: string;
   photographed?: boolean;


### PR DESCRIPTION
This makes things consistent with other modes, but we still need to improve the UX for filling out criticals. Having to name something is an extra step that people may not want to do? Maybe there's no meaningful name, and instead the sidebar should list things differently. Filtering to show by type of critical, or some resolution status, etc could be more relevant.