### PR TITLE
Don't lose geometry edits when changing modes

### DIFF
--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -124,6 +124,21 @@
     });
   }
 
+  // Auto-save
+  for (let tool of [polygonTool]) {
+    tool.addEventListenerUpdated((feature) => {
+      if ($currentMode == thisMode) {
+        gjScheme.update((gj) => {
+          let updateFeature = gj.features.find(
+            (f) => f.id == currentlyEditing
+          )!;
+          updateFeature.geometry = feature.geometry;
+          return gj;
+        });
+      }
+    });
+  }
+
   // Handle failures
   for (let tool of [pointTool, polygonTool, routeTool]) {
     tool.addEventListenerFailure(() => {

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -94,6 +94,18 @@
           let updateFeature = gj.features.find(
             (f) => f.id == currentlyEditing
           )!;
+          if (!updateFeature) {
+            stopEditing();
+            // We could've been editing anything; just handle all possibilities
+            pointTool.stop();
+            polygonTool.stop();
+            routeTool.stop();
+            window.alert(
+              "You loaded another file or cleared everything while editing. Your changes were lost."
+            );
+            return gj;
+          }
+
           updateFeature.geometry = feature.geometry;
           if (feature.properties.length_meters) {
             updateFeature.properties.length_meters =

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -50,55 +50,7 @@
   }
 
   // Handle successful edits
-  routeTool.addEventListenerSuccessRoute((editedRoute) => {
-    if ($currentMode == thisMode) {
-      gjScheme.update((gj) => {
-        let feature = gj.features.find((f) => f.id == currentlyEditing)!;
-        // TODO Hack around https://github.com/acteng/atip/issues/142
-        if (!feature) {
-          window.alert(
-            "You loaded another file or cleared everything while editing. Your changes were lost."
-          );
-          return gj;
-        }
-        // Keep the ID and any properties. Just copy over stuff from routeSnapper.
-        // TODO We're depending on implementation details here and knowing what to copy...
-        feature.properties.length_meters = editedRoute.properties.length_meters;
-        feature.properties.waypoints = editedRoute.properties.waypoints;
-        delete feature.properties.hide_while_editing;
-        feature.geometry = editedRoute.geometry;
-        return gj;
-      });
-
-      // Stay in this mode
-      stopEditing();
-    }
-  });
-
-  routeTool.addEventListenerSuccessArea((editedArea) => {
-    if ($currentMode == thisMode) {
-      gjScheme.update((gj) => {
-        let feature = gj.features.find((f) => f.id == currentlyEditing)!;
-        if (!feature) {
-          window.alert(
-            "You loaded another file or cleared everything while editing. Your changes were lost."
-          );
-          return gj;
-        }
-        // Keep the ID and any properties. Just copy over stuff from routeSnapper.
-        // TODO We're depending on implementation details here and knowing what to copy...
-        feature.properties.waypoints = editedArea.properties.waypoints;
-        delete feature.properties.hide_while_editing;
-        feature.geometry = editedArea.geometry;
-        return gj;
-      });
-
-      // Stay in this mode
-      stopEditing();
-    }
-  });
-
-  for (let tool of [pointTool, polygonTool]) {
+  for (let tool of [pointTool, polygonTool, routeTool]) {
     tool.addEventListenerSuccess((feature) => {
       if ($currentMode == thisMode) {
         gjScheme.update((gj) => {
@@ -112,6 +64,18 @@
             return gj;
           }
           updateFeature.geometry = feature.geometry;
+
+          // Copy properties that may come from routeTool. Not all tools or
+          // cases will produce all of these.
+          // TODO We're depending on implementation details here and knowing what to copy...
+          if (feature.properties.length_meters) {
+            updateFeature.properties.length_meters =
+              feature.properties.length_meters;
+          }
+          if (feature.properties.waypoints) {
+            updateFeature.properties.waypoints = feature.properties.waypoints;
+          }
+
           delete updateFeature.properties.hide_while_editing;
           return gj;
         });

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -29,7 +29,7 @@
     | "route"
     | null = null;
   // As a feature is being edited, store the latest version
-  let latestEditedFeature: FeatureWithProps<LineString | Polygon> | null = null;
+  let unsavedFeature: FeatureWithProps<LineString | Polygon> | null = null;
 
   export function start() {}
   export function stop() {
@@ -53,8 +53,8 @@
 
         // If there are unsaved edits to the feature, copy them over. If the
         // user explicitly canceled, then a failure callback would've run.
-        if (latestEditedFeature) {
-          updateFeature(feature, latestEditedFeature);
+        if (unsavedFeature) {
+          updateFeature(feature, unsavedFeature);
         }
         return gj;
       });
@@ -92,7 +92,7 @@
     tool.addEventListenerUpdated((feature) => {
       if ($currentMode == thisMode) {
         // Just remember the update; don't apply it yet
-        latestEditedFeature = feature;
+        unsavedFeature = feature;
       }
     });
   }
@@ -234,7 +234,7 @@
   function stopEditing() {
     currentlyEditing = null;
     currentlyEditingControls = null;
-    latestEditedFeature = null;
+    unsavedFeature = null;
   }
 
   // Copy geometry and properties from source to destination

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -62,6 +62,7 @@
 
   polygonTool.addEventListenerFailure(() => {
     if ($currentMode == thisMode) {
+      unsavedFeature = null;
       changeMode("edit-attribute");
     }
   });

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -84,6 +84,8 @@ export class PolygonTool {
   finish() {
     let polygon = this.polygonFeature();
     if (polygon) {
+      // TODO RouteTool passes a copy to each callback for paranoia. Should we
+      // do the same everywhere here?
       for (let cb of this.eventListenersSuccess) {
         cb(polygon);
       }

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -57,7 +57,7 @@
       }
     });
 
-    routeTool.addEventListenerSuccessRoute((feature) => {
+    routeTool.addEventListenerSuccess((feature) => {
       if ($currentMode == thisMode) {
         gjScheme.update((gj) => {
           feature.id = newFeatureId(gj);

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -88,6 +88,7 @@
 
     routeTool.addEventListenerFailure(() => {
       if ($currentMode == thisMode) {
+        unsavedFeature = null;
         changeMode("edit-attribute");
       }
     });

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -26,7 +26,7 @@
     routeTool.stop();
   }
 
-  routeTool.addEventListenerSuccessArea((feature) => {
+  routeTool.addEventListenerSuccess((feature) => {
     if ($currentMode == thisMode) {
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -63,6 +63,7 @@
 
   routeTool.addEventListenerFailure(() => {
     if ($currentMode == thisMode) {
+      unsavedFeature = null;
       changeMode("edit-attribute");
     }
   });


### PR DESCRIPTION
See #247 for context. This PR does a few things:

- If you're drawing something new and switch to another mode (by clicking something in the sidebar, or clicking another draw tool), the new object is added anyway, but the form isn't opened. The user doesn't unexpectedly lose work.
- If you're in edit geometry mode and switch to another mode, the unsaved changes do get saved.
- The existing "Cancel" buttons continue to work as expected. For new objects, they totally throw away whatever's drawn. For editing, they revert to the previous state of the object. This lets the user undo any accidental changes.

These changes are for polygons and linestrings, but not points. The point tool is trivial; the user just has to click the map to place or move something. If they go click another button somewhere, there's no reasonable "last edited state" to save.

Manual testing seems rock solid, but I'm working on new Playwright tests now.