### PR TITLE
Replace the schema dropdown with a title for the current mode. #254

### DIFF
--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -18,7 +18,7 @@
   import InterventionList from "../lib/sidebar/InterventionList.svelte";
   import ZoomOutMap from "../lib/ZoomOutMap.svelte";
   import { routeInfo } from "../stores";
-  import type { Schema } from "../types";
+  import { schemaTitle, type Schema } from "../types";
   import { type RouteInfo } from "../worker";
   import workerWrapper from "../worker?worker";
 
@@ -81,15 +81,6 @@
     );
     return geojson;
   }
-
-  function changeSchema() {
-    let params = new URLSearchParams(window.location.search);
-    params.set("schema", schema);
-    let href = `${window.location.pathname}?${params.toString()}${
-      window.location.hash
-    }`;
-    window.location.href = href;
-  }
 </script>
 
 <Layout>
@@ -104,16 +95,7 @@
       <button type="button" on:click={toggleAbout}>About</button>
       <button type="button" on:click={toggleInstructions}>Instructions</button>
     </div>
-    <br />
-    <label>
-      ATIP schema:
-      <select bind:value={schema} on:change={changeSchema}>
-        <option value="v1">v1</option>
-        <!-- <option value="v2">v2</option> -->
-        <option value="planning">Housing developments</option>
-        <option value="criticals">Critical issues</option>
-      </select>
-    </label>
+    <p>{schemaTitle(schema)} mode</p>
     <h1>{authorityName} <ZoomOutMap {boundaryGeojson} /></h1>
     <EntireScheme {authorityName} {schema} />
     <br />

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,3 +80,12 @@ export type Mode =
   | "snap-polygon"
   | "split-route"
   | "street-view";
+
+export function schemaTitle(schema: Schema): string {
+  return {
+    v1: "Schema design",
+    v2: "Experimental schema design",
+    planning: "Development planning",
+    criticals: "Critical issues",
+  }[schema];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,9 +83,9 @@ export type Mode =
 
 export function schemaTitle(schema: Schema): string {
   return {
-    v1: "Schema design",
-    v2: "Experimental schema design",
-    planning: "Development planning",
-    criticals: "Critical issues",
+    v1: "Scheme Design",
+    v2: "Experimental Schema Design",
+    planning: "Development Planning",
+    criticals: "Critical Issues",
   }[schema];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export type Mode =
 export function schemaTitle(schema: Schema): string {
   return {
     v1: "Scheme Design",
-    v2: "Experimental Schema Design",
+    v2: "Experimental Scheme Design",
     planning: "Development Planning",
     criticals: "Critical Issues",
   }[schema];


### PR DESCRIPTION
![Screenshot from 2023-06-28 10-07-43](https://github.com/acteng/atip/assets/1664407/7f9aa9f8-0387-415b-819f-1fde5d9fdb0c)

See issue for details. We don't want most users to change the schema right now; if someone's using something other than v1, we'll send them a URL with instructions. But all the same, if someone has used ATIP in multiple modes, we want to communicate somewhere which schema they're working with.

Changes to text styling or wording are welcome!