### PR TITLE
Use new route snapper data to fix #255

### DIFF
--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -31,10 +31,11 @@
   let style: string = params.get("style") || "streets";
   let schema: Schema = (params.get("schema") as Schema) || "v1";
 
-  // The "v2" here is an arbitrary number, not necessarily related to the app's
-  // version. The version of the code deployed has to match the data, and it's
-  // simplest to increment the number here for new incompatible data releases.
-  let routeSnapperUrl = `https://atip.uk/route-snappers/v2/${authorityName}.bin.gz`;
+  // The version numbers here are arbitrary, not necessarily related to the
+  // app's version. The version of the code deployed has to match the data, and
+  // it's simplest to increment the number here for new incompatible data
+  // releases. The two data releases may also be changed independently.
+  let routeSnapperUrl = `https://atip.uk/route-snappers/v2.1/${authorityName}.bin.gz`;
   let routeInfoUrl = `https://atip.uk/route-info/v2/${authorityName}.bin.gz`;
 
   function toggleAbout() {

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -3,7 +3,7 @@ import { clickMap } from "./shared.js";
 
 // This is separate from modes.spec.ts to avoid the common beforeAll
 test("other tools work when route tool doesn't load", async ({ page }) => {
-  await page.route("https://atip.uk/route-snappers/v2/Adur.bin.gz", (route) =>
+  await page.route("https://atip.uk/route-snappers/v2.1/Adur.bin.gz", (route) =>
     route.fulfill({
       status: 404,
     })


### PR DESCRIPTION
See bug for details. To repro the problem, draw a route crossing the Meadows and look for the thick "bulge" near intersections.

Before this PR:
https://acteng.github.io/atip/scheme.html?authority=Surrey&schema=v1#18.69/51.2285668/-0.5773313
![Screenshot from 2023-07-03 09-22-05](https://github.com/acteng/atip/assets/1664407/77f69388-e67d-49ad-a8b9-2b6f391a71f3)

After this PR (give github a few mins to deploy):
https://acteng.github.io/atip/fix_route_snappers/scheme.html?authority=Surrey&schema=v1#20.17/51.2287442/-0.5778096
![Screenshot from 2023-07-03 09-00-51](https://github.com/acteng/atip/assets/1664407/c6d58dfc-97dd-4a0f-bd34-8f30c56106b6)


The fix is in the other repo, https://github.com/dabreegster/route_snapper/pull/34.