### PR TITLE
Use cursors in most tools

### DIFF
--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -13,6 +13,7 @@
   import {
     formOpen,
     gjScheme,
+    isAToolInUse,
     map,
     mapHover,
     sidebarHover,
@@ -20,7 +21,10 @@
 
   // Show clickable objects on the map using the cursor
   $: {
-    $map.getCanvas().style.cursor = $mapHover ? "pointer" : "grab";
+    // Don't override what an active tool has set
+    if (!$isAToolInUse) {
+      $map.getCanvas().style.cursor = $mapHover ? "pointer" : "grab";
+    }
   }
 
   let source = "hover";

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -23,7 +23,7 @@
   $: {
     // Don't override what an active tool has set
     if (!$isAToolInUse) {
-      $map.getCanvas().style.cursor = $mapHover ? "pointer" : "grab";
+      $map.getCanvas().style.cursor = $mapHover ? "pointer" : "inherit";
     }
   }
 

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -15,7 +15,7 @@
     $map.getCanvas().style.cursor = "zoom-in";
   }
   export function stop() {
-    $map.getCanvas().style.cursor = "grab";
+    $map.getCanvas().style.cursor = "inherit";
   }
 
   eventHandler.mapHandlers.click = (e: MapMouseEvent) => {

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -93,7 +93,6 @@
   }
 
   onDestroy(() => {
-    pointTool?.tearDown();
     polygonTool?.tearDown();
     routeTool?.tearDown();
 

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -77,7 +77,7 @@ export class PointTool {
   }
 
   stop() {
-    this.map.getCanvas().style.cursor = "grab";
+    this.map.getCanvas().style.cursor = "inherit";
     this.cursor = null;
     this.setActivity(false);
   }

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -258,7 +258,7 @@ export class PolygonTool {
   }
 
   stop() {
-    this.map.getCanvas().style.cursor = "grab";
+    this.map.getCanvas().style.cursor = "inherit";
     this.map.doubleClickZoom.enable();
     this.points = [];
     this.cursor = null;

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -178,12 +178,14 @@ export class PolygonTool {
       e.preventDefault();
       this.cursor = null;
       this.dragFrom = e.lngLat.toArray();
+      this.redraw();
     }
   };
 
   onMouseUp = () => {
     if (this.active && this.dragFrom) {
       this.dragFrom = null;
+      this.redraw();
       this.pointsUpdated();
     }
   };
@@ -256,6 +258,7 @@ export class PolygonTool {
   }
 
   stop() {
+    this.map.getCanvas().style.cursor = "grab";
     this.map.doubleClickZoom.enable();
     this.points = [];
     this.cursor = null;
@@ -274,9 +277,6 @@ export class PolygonTool {
       f.properties!.idx = idx;
       gj.features.push(f);
     });
-    if (this.cursor) {
-      gj.features.push(this.cursor);
-    }
 
     gj.features = gj.features.concat(pointsToLineSegments(this.points));
 
@@ -287,6 +287,11 @@ export class PolygonTool {
     }
 
     (this.map.getSource(source) as GeoJSONSource).setData(gj);
+    let cursorStyle = "crosshair";
+    if (this.hover != null) {
+      cursorStyle = this.dragFrom ? "grabbing" : "pointer";
+    }
+    this.map.getCanvas().style.cursor = cursorStyle;
   }
 
   // If there's a valid polygon, also passes to eventListenersUpdated

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -31,7 +31,7 @@
     $map.getCanvas().style.cursor = `url(${splitIcon}), crosshair`;
   }
   export function stop() {
-    $map.getCanvas().style.cursor = "grab";
+    $map.getCanvas().style.cursor = "inherit";
     snappedCursor = null;
     snappedIndex = null;
   }

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -213,8 +213,6 @@ const layerZorder = [
   "hover-points",
   "interventions-points",
 
-  "edit-point-mode",
-
   "edit-polygon-fill",
   "edit-polygon-lines",
   "edit-polygon-vertices",


### PR DESCRIPTION
A followup to #246. Change the cursor for most of our tools to indicate the current interactions possible on the map. Showing a few off, but easiest to just try at https://acteng.github.io/atip/curses_and_cursors/scheme.html?authority=Adur:

https://github.com/acteng/atip/assets/1664407/346cce17-8ab2-495f-9f8d-9b10a51d95d7

In general I tried to mimic design choices made by geojson.io (mapbox-gl-draw), Felt, terra-draw.