### PR TITLE
Add a schema based on ATF4 guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fmt": "npx prettier --write *.html tests/* src/*",
     "test": "npx playwright test",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "generate-schema-ts": "for x in v2 planning criticals; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done"
+    "generate-schema-ts": "for x in v2 planning criticals atf4; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.0.2",

--- a/src/lib/forms/ATF4Form.svelte
+++ b/src/lib/forms/ATF4Form.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import schemaJson from "../../schemas/atf4.json";
+  import type { InterventionProps } from "../../types";
+  import AutogenerateForm from "./AutogenerateForm.svelte";
+  import type { Field } from "./types";
+
+  export let props: InterventionProps;
+
+  props.atf4 ||= {};
+
+  let x: Field = schemaJson;
+</script>
+
+<AutogenerateForm spec={x} bind:value={props.atf4} />

--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { deleteIntervention, formOpen, gjScheme } from "../../stores";
   import type { FeatureUnion, Schema } from "../../types";
+  import ATF4Form from "../forms/ATF4Form.svelte";
   import CriticalsForm from "../forms/CriticalsForm.svelte";
   import FormV1 from "../forms/FormV1.svelte";
   import FormV2 from "../forms/FormV2.svelte";
@@ -22,6 +23,9 @@
     }
     if (schema == "criticals") {
       return feature.properties.criticals?.name || "Untitled issue";
+    }
+    if (schema == "atf4") {
+      return feature.properties.atf4?.name || "Untitled intervention";
     }
 
     if (feature.properties.name) {
@@ -78,6 +82,8 @@
       <PlanningForm bind:props={feature.properties} />
     {:else if schema == "criticals"}
       <CriticalsForm bind:props={feature.properties} />
+    {:else if schema == "atf4"}
+      <ATF4Form bind:props={feature.properties} />
     {/if}
 
     <br />

--- a/src/schemas/atf4.json
+++ b/src/schemas/atf4.json
@@ -1,0 +1,29 @@
+{
+  "name": "ATF4Intervention",
+  "members": [
+    {
+      "name": "name",
+      "type": "one-liner"
+    },
+    {
+      "name": "description",
+      "type": "textbox"
+    },
+    {
+      "name": "type",
+      "oneOf": [
+        "New segregated cycling facility",
+        "New junction treatment",
+        "New permanent footway",
+        "New shared use (walking and cycling) facilities",
+        "Improvements to make an existing walking/cycle route safer",
+        "Area-wide traffic management (including by TROs - both permanent and experimental)",
+        "Bus priority measures that also enable active travel (for example, bus gates)",
+        "Provision of secure cycle parking facilities",
+        "New road crossings",
+        "Restriction or reduction of car parking availability",
+        "School streets"
+      ]
+    }
+  ]
+}

--- a/src/schemas/atf4.ts
+++ b/src/schemas/atf4.ts
@@ -1,0 +1,20 @@
+// This file is auto-generated; do not manually edit
+
+export interface ATF4Intervention {
+  name?: string;
+  description?: string;
+  type?: type;
+}
+
+export type type =
+  | "New segregated cycling facility"
+  | "New junction treatment"
+  | "New permanent footway"
+  | "New shared use (walking and cycling) facilities"
+  | "Improvements to make an existing walking/cycle route safer"
+  | "Area-wide traffic management (including by TROs - both permanent and experimental)"
+  | "Bus priority measures that also enable active travel (for example, bus gates)"
+  | "Provision of secure cycle parking facilities"
+  | "New road crossings"
+  | "Restriction or reduction of car parking availability"
+  | "School streets";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
 import type { LineString, Point, Polygon } from "geojson";
+import type { ATF4Intervention } from "./schemas/atf4";
 import type { CriticalIssue } from "./schemas/criticals";
 import type { Planning } from "./schemas/planning";
 import type { Intervention } from "./schemas/v2";
 
-export type Schema = "v1" | "v2" | "planning" | "criticals";
+export type Schema = "v1" | "v2" | "planning" | "criticals" | "atf4";
 
 // This describes the full structure of the GeoJSON we manage. We constrain the
 // default GeoJSON types and specify feature properties.
@@ -47,6 +48,7 @@ export interface InterventionProps {
   planning?: Planning;
   v2?: Intervention;
   criticals?: CriticalIssue;
+  atf4?: ATF4Intervention;
 
   // Temporary state, not meant to be serialized
   hide_while_editing?: boolean;
@@ -87,5 +89,6 @@ export function schemaTitle(schema: Schema): string {
     v2: "Experimental Scheme Design",
     planning: "Development Planning",
     criticals: "Critical Issues",
+    atf4: "ATF4 Scheme",
   }[schema];
 }


### PR DESCRIPTION
A minimal take on #242. The UX of selecting one of 11 options is not nice, and if we wanted to visualize these categorically on the map, we'd need a discrete palette with 11 choices. Purpose of this is just to raise questions about how we should better collect this type of data.
![Screenshot from 2023-07-10 10-46-14](https://github.com/acteng/atip/assets/1664407/a49252e4-819c-461a-a142-519fd527055a)
https://acteng.github.io/atip/atf4_schema/scheme.html?authority=Adur