### PR TITLE
Trim coordinate precision for drawing points and freehand polygons

### DIFF
--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -1,6 +1,6 @@
-import type { Point, Position } from "geojson";
+import type { Point } from "geojson";
 import type { Map, MapMouseEvent } from "maplibre-gl";
-import { type FeatureWithProps } from "../../../maplibre_helpers";
+import { pointFeature, type FeatureWithProps } from "../../../maplibre_helpers";
 import { isAToolInUse } from "../../../stores";
 import type { EventHandler } from "../event_handler";
 
@@ -86,15 +86,4 @@ export class PointTool {
     this.active = isActive;
     isAToolInUse.set(isActive);
   }
-}
-
-function pointFeature(pt: Position): FeatureWithProps<Point> {
-  return {
-    type: "Feature",
-    properties: {},
-    geometry: {
-      type: "Point",
-      coordinates: pt,
-    },
-  };
 }

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -17,7 +17,7 @@ import {
   overwritePolygonLayer,
   overwriteSource,
   pointFeature,
-  trimPrecision,
+  setPrecision,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { isAToolInUse } from "../../../stores";
@@ -337,7 +337,7 @@ export class PolygonTool {
     if (this.points.length < 3) {
       return null;
     }
-    let trimmed = this.points.map(trimPrecision);
+    let trimmed = this.points.map(setPrecision);
     // Deep clone here, or face the wrath of crazy bugs later!
     let coordinates = [JSON.parse(JSON.stringify(trimmed))];
     coordinates[0].push(JSON.parse(JSON.stringify(coordinates[0][0])));

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -16,6 +16,8 @@ import {
   overwriteLineLayer,
   overwritePolygonLayer,
   overwriteSource,
+  pointFeature,
+  trimPrecision,
   type FeatureWithProps,
 } from "../../../maplibre_helpers";
 import { isAToolInUse } from "../../../stores";
@@ -335,8 +337,9 @@ export class PolygonTool {
     if (this.points.length < 3) {
       return null;
     }
+    let trimmed = this.points.map(trimPrecision);
     // Deep clone here, or face the wrath of crazy bugs later!
-    let coordinates = [JSON.parse(JSON.stringify(this.points))];
+    let coordinates = [JSON.parse(JSON.stringify(trimmed))];
     coordinates[0].push(JSON.parse(JSON.stringify(coordinates[0][0])));
     return {
       type: "Feature",
@@ -347,17 +350,6 @@ export class PolygonTool {
       properties: {},
     };
   }
-}
-
-function pointFeature(pt: Position): Feature<Point> {
-  return {
-    type: "Feature",
-    properties: {},
-    geometry: {
-      type: "Point",
-      coordinates: pt,
-    },
-  };
 }
 
 // Includes the line connecting the last to the first point

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -12,7 +12,7 @@
     emptyGeojson,
     overwriteCircleLayer,
     overwriteSource,
-    trimPrecision,
+    setPrecision,
   } from "../../../maplibre_helpers";
   import { currentMode, gjScheme, map, newFeatureId } from "../../../stores";
   import type { Mode, Feature as OurFeature } from "../../../types";
@@ -113,9 +113,9 @@
         let piece2 = result.features[1];
         // lineSplit may introduce unnecessary coordinate precision
         piece1.geometry.coordinates =
-          piece1.geometry.coordinates.map(trimPrecision);
+          piece1.geometry.coordinates.map(setPrecision);
         piece2.geometry.coordinates =
-          piece2.geometry.coordinates.map(trimPrecision);
+          piece2.geometry.coordinates.map(setPrecision);
 
         gjScheme.update((gj) => {
           // Keep the old ID for one, assign a new ID to the other
@@ -168,7 +168,7 @@
       properties: {},
       geometry: {
         type: "Point",
-        coordinates: trimPrecision(pt),
+        coordinates: setPrecision(pt),
       },
     };
   }

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -12,6 +12,7 @@
     emptyGeojson,
     overwriteCircleLayer,
     overwriteSource,
+    trimPrecision,
   } from "../../../maplibre_helpers";
   import { currentMode, gjScheme, map, newFeatureId } from "../../../stores";
   import type { Mode, Feature as OurFeature } from "../../../types";
@@ -110,6 +111,11 @@
       if (result.features.length == 2) {
         let piece1 = result.features[0];
         let piece2 = result.features[1];
+        // lineSplit may introduce unnecessary coordinate precision
+        piece1.geometry.coordinates =
+          piece1.geometry.coordinates.map(trimPrecision);
+        piece2.geometry.coordinates =
+          piece2.geometry.coordinates.map(trimPrecision);
 
         gjScheme.update((gj) => {
           // Keep the old ID for one, assign a new ID to the other
@@ -162,7 +168,7 @@
       properties: {},
       geometry: {
         type: "Point",
-        coordinates: pt,
+        coordinates: trimPrecision(pt),
       },
     };
   }

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -184,14 +184,14 @@ export function pointFeature(pt: Position): FeatureWithProps<Point> {
     properties: {},
     geometry: {
       type: "Point",
-      coordinates: trimPrecision(pt),
+      coordinates: setPrecision(pt),
     },
   };
 }
 
 // Per https://datatracker.ietf.org/doc/html/rfc7946#section-11.2, 6 decimal
 // places (10cm) is plenty of precision
-export function trimPrecision(pt: Position): Position {
+export function setPrecision(pt: Position): Position {
   return [Math.round(pt[0] * 10e6) / 10e6, Math.round(pt[1] * 10e6) / 10e6];
 }
 

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -1,6 +1,13 @@
 // Helpers for https://maplibre.org/maplibre-gl-js-docs/style-spec/
 import turfBbox from "@turf/bbox";
-import type { Feature, FeatureCollection, GeoJSON, Geometry } from "geojson";
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJSON,
+  Geometry,
+  Point,
+  Position,
+} from "geojson";
 import type {
   DataDrivenPropertyValueSpecification,
   FilterSpecification,
@@ -169,6 +176,23 @@ export function emptyGeojson(): FeatureCollection {
     type: "FeatureCollection",
     features: [],
   };
+}
+
+export function pointFeature(pt: Position): FeatureWithProps<Point> {
+  return {
+    type: "Feature",
+    properties: {},
+    geometry: {
+      type: "Point",
+      coordinates: trimPrecision(pt),
+    },
+  };
+}
+
+// Per https://datatracker.ietf.org/doc/html/rfc7946#section-11.2, 6 decimal
+// places (10cm) is plenty of precision
+export function trimPrecision(pt: Position): Position {
+  return [Math.round(pt[0] * 10e6) / 10e6, Math.round(pt[1] * 10e6) / 10e6];
 }
 
 // Helper for https://maplibre.org/maplibre-style-spec/expressions/#case based on one property


### PR DESCRIPTION
For #252. Trim to 6 decimal places recommended by the GJ spec.

https://github.com/dabreegster/route_snapper/pull/38 did this for the route and snapped polygon tool, but it's not included in ATIP yet (I'll make another few changes and then release a new NPM version). This PR does it for the point, freehand polygon tool, and when splitting routes.

I thought about also doing this transformation in the backfill routine (when we load a GJ file from somewhere), but I don't think it's as important. If/when we have a story about storing official submitted data in one central place, we could do the transformation there.

Tested by drawing/splitting stuff, exporting, and manually checking the file