### PR TITLE
Add some dropdown filters to the scheme browsing page

### DIFF
--- a/src/lib/govuk/Select.svelte
+++ b/src/lib/govuk/Select.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import FormElement from "../govuk/FormElement.svelte";
+
+  export let label: string;
+  // A unique (per page) ID
+  export let id: string;
+  // A list of [value, label] representing the choices
+  export let choices: [string, string][];
+  // Make the first option the empty string
+  export let emptyOption = true;
+
+  // The current value
+  export let value: string;
+</script>
+
+<FormElement {label} {id}>
+  <select class="govuk-select" {id} bind:value>
+    {#if emptyOption}
+      <option value="" />
+    {/if}
+
+    {#each choices as [thisValue, thisLabel]}
+      <option value={thisValue}>{thisLabel}</option>
+    {/each}
+  </select>
+</FormElement>


### PR DESCRIPTION
Inspired by yesterday, this is a small improvement to the scheme browse page. Beside free-text filtering, also filter by two particular fields in the input data:

https://github.com/acteng/atip/assets/1664407/a0c16b66-a3dd-4a41-9479-e53eeb69fc3f

My goal is to flesh out a few more improvements to this page ahead of next week's meetings, so we can explore more possible directions to take this.

To try it out, https://acteng.github.io/atip/browse_dropdown_filters/browse.html and load magicfoo.geojson (from emails/Sharepoint). Motivation to make progress on auth soon :)