### PR TITLE
Get govuk installed, following

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Build schema TS files
       run: npm run generate-schema-ts
 
+    - name: Setup GOV.UK
+      run: npm run setup-govuk
+
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,6 +35,14 @@ jobs:
               base=/atip/$branch
             fi
 
+            # TODO New build step not present in all branches yet. Rebase them all and remove.
+            npm ci
+            if npm run setup-govuk; then
+              echo "GOV.UK setup successful"
+            else
+              echo "GOV.UK setup failed, continuing"
+            fi
+
             if npm run wasm-release && npm ci && npm run generate-schema-ts && npm run build --if-present -- --base=$base; then
               if [ "$branch" == "main" ]; then
                 mv dist/* deployme

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules/
 /playwright/.cache/
 dist
 src/schemas/*.ts
+src/style/main.css
+src/style/main.css.map
+.sass-cache/
+public/assets

--- a/browse.html
+++ b/browse.html
@@ -13,6 +13,11 @@
     <script type="module">
       import BrowseSchemes from "./src/pages/BrowseSchemes.svelte";
 
+      // For govuk setup. For some reason, the initAll step doesn't work here.
+      document.body.className = document.body.className
+        ? document.body.className + " js-enabled"
+        : "js-enabled";
+
       new BrowseSchemes({
         target: document.getElementById("app"),
       });

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -7,6 +7,7 @@ This repository contains the Svelte ATIP app. Our tech stack is:
 - [Vite](https://vitejs.dev) as the build tool
 - [Svelte](https://svelte.dev) as the UI framework
 - [MapLibre GL](https://maplibre.org) as the map
+- [GOV.UK frontend](https://frontend.design-system.service.gov.uk) for styling
 
 There are some related repositorites also part of ATIP:
 
@@ -30,6 +31,10 @@ These are some resources to learn languages and libraries used in ATIP. Feel fre
 - Rust
   - [Docs](https://www.rust-lang.org/learn) for different learning styles
   - [The Rust Book](https://doc.rust-lang.org/stable/book/)
+- GOV.UK frontend
+  - [Typography](https://design-system.service.gov.uk/styles/typography/) for CSS class reference
+  - [Components](https://design-system.service.gov.uk/components/)
+
 ## Installation
 
 To run locally you'll need:
@@ -42,11 +47,12 @@ To run locally you'll need:
   `wasm-release` to build slowly but run quickly)
   - If you're modifying the Rust code, a handy command is `npm run wasm && npm run dev`
 - `npm run generate-schema-ts` to rebuild TS definitions from changes to `src/schemas/*.json`
+- `npm run setup-govuk` to rerun Sass and generate GOV.UK styles
 - `npm run fmt` to auto-format code
 - `npm run check` to see TypeScript errors
 
-Upon first setup, you'll need to `npm run wasm` and `npm run
-generate-schema-ts` to get all mandatory files for running.
+Upon first setup, you'll need to `npm run wasm`, `npm run generate-schema-ts`,
+`npm run setup-govuk` to get all mandatory files for running.
 
 If you're using Firefox locally to develop and get "import declarations may
 only appear at top level" errors, upgrade to at least Firefox 112, go to

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@turf/nearest-point-on-line": "^6.5.0",
         "@types/geojson": "^7946.0.10",
         "comlink": "^4.4.1",
+        "govuk-frontend": "^4.6.0",
         "maplibre-gl": "^3.1.0",
         "route-snapper": "^0.1.14",
         "svelte": "^4.0.0"
@@ -31,6 +32,7 @@
         "playwright": "^1.35.1",
         "prettier": "2.8.8",
         "prettier-plugin-svelte": "^2.10.1",
+        "sass": "^1.63.6",
         "svelte-check": "^3.4.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3",
@@ -1966,6 +1968,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/govuk-frontend": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -1999,6 +2009,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2708,6 +2724,23 @@
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.63.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "fmt": "npx prettier --write *.html tests/* src/*",
     "test": "npx playwright test",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "generate-schema-ts": "for x in v2 planning criticals atf4; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done"
+    "generate-schema-ts": "for x in v2 planning criticals atf4; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done",
+    "setup-govuk": "sass src/style/main.sass src/style/main.css; rm -rf public/assets; mkdir -p public/assets; cp -R node_modules/govuk-frontend/govuk/assets/ public/"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
@@ -23,6 +24,7 @@
     "playwright": "^1.35.1",
     "prettier": "2.8.8",
     "prettier-plugin-svelte": "^2.10.1",
+    "sass": "^1.63.6",
     "svelte-check": "^3.4.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
@@ -40,6 +42,7 @@
     "@turf/nearest-point-on-line": "^6.5.0",
     "@types/geojson": "^7946.0.10",
     "comlink": "^4.4.1",
+    "govuk-frontend": "^4.6.0",
     "maplibre-gl": "^3.1.0",
     "route-snapper": "^0.1.14",
     "svelte": "^4.0.0"

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -3,8 +3,10 @@
   // TODO After figuring out the features of this page, work on the errors
   // here. Need to decide how much we use gjScheme, and what new feature-level
   // properties to expect.
+  import { initAll } from "govuk-frontend";
+  import "../style/main.css";
   import type { GeoJSON } from "geojson";
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import BaselayerSwitcher from "../lib/BaselayerSwitcher.svelte";
   import CollapsibleCard from "../lib/common/CollapsibleCard.svelte";
   import FileInput from "../lib/common/FileInput.svelte";
@@ -16,6 +18,11 @@
   import ZoomOutMap from "../lib/ZoomOutMap.svelte";
   import { bbox } from "../maplibre_helpers";
   import { gjScheme, map } from "../stores";
+
+  onMount(() => {
+    // For govuk components. Must happen here.
+    initAll();
+  });
 
   const params = new URLSearchParams(window.location.search);
   let style: string = params.get("style") || "streets";
@@ -163,7 +170,7 @@
 </script>
 
 <Layout>
-  <div slot="sidebar">
+  <div slot="sidebar" class="sidebar">
     <button type="button" on:click={() => window.open("index.html")}>
       Home</button
     >

--- a/src/style/main.sass
+++ b/src/style/main.sass
@@ -1,0 +1,12 @@
+@import "../../node_modules/govuk-frontend/govuk/all"
+
+// Rather than specify class="govuk-body" on every <p> element, use these rules
+// to modify all elements under anything with class="sidebar".
+//
+// See https://design-system.service.gov.uk/styles/typography/ for reference on
+// govuk classes
+.sidebar
+  p
+    @extend .govuk-body
+  h1
+    @extend .govuk-heading-l


### PR DESCRIPTION
https://frontend.design-system.service.gov.uk/get-started. Very lightly change the browse scheme page typography using Sass, to preview the next steps for integration.

This is an alternative to #258. Because switching is going to take a few steps, I propose we do it gradually. The build setup is subtle enough to deserve its own step. After this PR, I propose we update the two simple pages (scheme browsing and choosing an area) to completely use govuk styles, figuring out some of the patterns for using Sass vs Svelte components. Then tackle the much more complex main page.

Preview: https://acteng.github.io/atip/govuk_frontend_v2/browse.html
The text style changes slightly:
![Screenshot from 2023-07-11 18-46-56](https://github.com/acteng/atip/assets/1664407/ac52af39-b633-4128-a57d-6f653b413006)
I have also temporarily copied in https://design-system.service.gov.uk/components/accordion to test the JS integration e2e.

Great thanks for help in https://github.com/alphagov/govuk-frontend/issues/3940 figuring out how to use Sass to keep our code simple!