### PR TITLE
Cache the WASM build in Github Actions. #223

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,6 +24,12 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Cache WASM build
+      uses: actions/cache@v3
+      with:
+        path: route_info/target
+        key: doesnt-matter-share-everything-for-tests
+
     - name: Build WASM
       run: npm run wasm-release
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
 
+      - name: Cache WASM build
+        uses: actions/cache@v3
+        with:
+          path: route_info/target
+          key: doesnt-matter-share-everything
+
       - name: Build all branches
         run: |
           mkdir deployme


### PR DESCRIPTION
The deploy web workflow in https://github.com/acteng/atip/actions takes around 15 minutes lately, dependent on the number of open branches we've got. This PR uses [GH caches](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) to at least save the initial step of building the Rust route-info crate.

Much of the time is unfortunately spent in a `wasm-opt` step, which doesn't look like it's good at figuring out no source has changed and short-circuiting. This new cache step can't hurt, though.