### PR TITLE
Convert the scheme browse and area choose page to govuk style

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
     <script type="module">
       import ChooseArea from "./src/pages/ChooseArea.svelte";
 
+      // For govuk setup. For some reason, the initAll step doesn't work here.
+      document.body.className = document.body.className
+        ? document.body.className + " js-enabled"
+        : "js-enabled";
+
       new ChooseArea({
         target: document.getElementById("app"),
       });

--- a/src/lib/ZoomOutMap.svelte
+++ b/src/lib/ZoomOutMap.svelte
@@ -3,6 +3,7 @@
   import icon from "../../assets/zoom_out_map.svg";
   import { bbox } from "../maplibre_helpers";
   import { map } from "../stores";
+  import SecondaryButton from "./govuk/SecondaryButton.svelte";
 
   export let boundaryGeojson: GeoJSON;
 
@@ -15,12 +16,6 @@
   }
 </script>
 
-<button type="button" title="Zoom to show entire boundary" on:click={recenter}>
+<SecondaryButton title="Zoom to show entire boundary" on:click={recenter}>
   <img src={icon} alt="Zoom to show entire boundary" />
-</button>
-
-<style>
-  button {
-    margin: 2px;
-  }
-</style>
+</SecondaryButton>

--- a/src/lib/common/CollapsibleCard.svelte
+++ b/src/lib/common/CollapsibleCard.svelte
@@ -1,53 +1,13 @@
 <script lang="ts">
-  // TODO Lots of overlap with AccordionItem
-  import { slide } from "svelte/transition";
-
   export let label: string;
   export let open = false;
 </script>
 
-<button on:click={() => (open = !open)} aria-expanded={open}
-  ><svg
-    style="tran"
-    width="20"
-    height="20"
-    fill="none"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    stroke-width="2"
-    viewBox="0 0 24 24"
-    stroke="currentColor"><path d="M9 5l7 7-7 7" /></svg
-  >
-  {label}
-</button>
-{#if open}
-  <div transition:slide={{ duration: 100 }}>
+<details {open} class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">{label}</span>
+  </summary>
+  <div class="govuk-details__text">
     <slot />
   </div>
-{/if}
-
-<style>
-  button {
-    border: none;
-    background: none;
-    display: block;
-    font-size: 20px;
-    cursor: pointer;
-    margin: 0;
-    padding-bottom: 0.5em;
-    padding-top: 0.5em;
-    text-align: left;
-  }
-
-  button:hover {
-    text-decoration: underline;
-  }
-
-  svg {
-    transition: transform 0.2s ease-in;
-  }
-
-  [aria-expanded="true"] svg {
-    transform: rotate(0.25turn);
-  }
-</style>
+</details>

--- a/src/lib/common/FileInput.svelte
+++ b/src/lib/common/FileInput.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import FormElement from "../govuk/FormElement.svelte";
+
   export let label: string;
+  // This must be unique in the page
+  export let id: string;
   // Called with the file contents as text
   export let loadFile: (text: string) => void;
 
@@ -17,15 +21,13 @@
   }
 </script>
 
-<div class="govuk-form-group">
-  <label class="govuk-label" for="file-upload">{label}</label>
+<FormElement {label} {id}>
   <input
     bind:this={fileInput}
     on:change={onChange}
     {disabled}
     class="govuk-file-upload"
-    id="file-upload"
-    name="file-upload"
+    {id}
     type="file"
   />
-</div>
+</FormElement>

--- a/src/lib/common/FileInput.svelte
+++ b/src/lib/common/FileInput.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   export let label: string;
-  // This must be unique in the DOM
-  export let uniqueId: string;
   // Called with the file contents as text
   export let loadFile: (text: string) => void;
 
@@ -19,30 +17,15 @@
   }
 </script>
 
-<!-- TODO Interactive elements inside a label are apparently invalid, but this works -->
-<label>
+<div class="govuk-form-group">
+  <label class="govuk-label" for="file-upload">{label}</label>
   <input
-    type="file"
-    id={uniqueId}
     bind:this={fileInput}
     on:change={onChange}
     {disabled}
+    class="govuk-file-upload"
+    id="file-upload"
+    name="file-upload"
+    type="file"
   />
-  <button type="button" on:click={() => fileInput.click()} {disabled}
-    >{label}</button
-  >
-</label>
-
-<style>
-  input[type="file"] {
-    cursor: pointer;
-
-    /* Make the input type=file effectively invisible, but still let browser accessibility stuff work */
-    width: 0.1px;
-    height: 0.1px;
-    opacity: 0;
-    overflow: hidden;
-    position: absolute;
-    z-index: -1;
-  }
-</style>
+</div>

--- a/src/lib/common/Modal.svelte
+++ b/src/lib/common/Modal.svelte
@@ -20,9 +20,14 @@
     on:click|stopPropagation={() => null}
   >
     <div style="display: flex; justify-content: space-between;">
-      <h1>{title}</h1>
+      <h1 class="govuk-heading-l">{title}</h1>
       {#if displayEscapeButton}
-        <button on:click={() => (open = false)}>X</button>
+        <button
+          class="govuk-button govuk-button--secondary"
+          data-module="govuk-button"
+          type="button"
+          on:click={() => (open = false)}>X</button
+        >
       {/if}
     </div>
     <slot />

--- a/src/lib/common/Modal.svelte
+++ b/src/lib/common/Modal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import SecondaryButton from "../govuk/SecondaryButton.svelte";
+
   export let title: string;
   export let open = false;
   export let displayEscapeButton = true;
@@ -22,12 +24,7 @@
     <div style="display: flex; justify-content: space-between;">
       <h1 class="govuk-heading-l">{title}</h1>
       {#if displayEscapeButton}
-        <button
-          class="govuk-button govuk-button--secondary"
-          data-module="govuk-button"
-          type="button"
-          on:click={() => (open = false)}>X</button
-        >
+        <SecondaryButton on:click={() => (open = false)}>X</SecondaryButton>
       {/if}
     </div>
     <slot />
@@ -44,10 +41,6 @@
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
     display: block;
-  }
-
-  button {
-    background-color: whitesmoke;
   }
 
   .content {

--- a/src/lib/govuk/DefaultButton.svelte
+++ b/src/lib/govuk/DefaultButton.svelte
@@ -1,0 +1,9 @@
+<button
+  type="button"
+  class="govuk-button"
+  data-module="govuk-button"
+  {...$$props}
+  on:click
+>
+  <slot />
+</button>

--- a/src/lib/govuk/FormElement.svelte
+++ b/src/lib/govuk/FormElement.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  // The label to show
+  export let label: string;
+  // A unique (per page) ID of the form element being labelled. Something in
+  // this component's slot must have this ID.
+  export let id: string;
+</script>
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for={id}>{label}</label>
+  <slot />
+</div>

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  // A label for the entire group of radio buttons
+  export let legend: string;
+  // A unique (per page) ID of the radio group
+  export let id: string;
+  // A list of [value, label] representing the choices
+  export let choices: [string, string][];
+
+  // The current value
+  export let value: string;
+</script>
+
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">{legend}</legend>
+    <div class="govuk-radios" data-module="govuk-radios">
+      {#each choices as [thisValue, thisLabel]}
+        <div class="govuk-radios__item">
+          <input
+            class="govuk-radios__input"
+            id={id + thisValue}
+            type="radio"
+            bind:group={value}
+            value={thisValue}
+            on:change
+          />
+          <label class="govuk-label govuk-radios__label" for={id + thisValue}>
+            {thisLabel}
+          </label>
+        </div>
+      {/each}
+    </div>
+  </fieldset>
+</div>

--- a/src/lib/govuk/SecondaryButton.svelte
+++ b/src/lib/govuk/SecondaryButton.svelte
@@ -1,0 +1,9 @@
+<button
+  type="button"
+  class="govuk-button govuk-button--secondary"
+  data-module="govuk-button"
+  {...$$props}
+  on:click
+>
+  <slot />
+</button>

--- a/src/lib/sidebar/About.svelte
+++ b/src/lib/sidebar/About.svelte
@@ -6,67 +6,71 @@
 </script>
 
 <Modal title="About the Active Travel Infrastructure Platform" bind:open>
-  <p>
-    ATIP v2 is an
-    <ExternalLink href="https://github.com/acteng/atip"
-      >open source project</ExternalLink
-    > supported by Active Travel England and developed by:
-  </p>
+  <div class="govuk-prose">
+    <p>
+      ATIP v2 is an
+      <ExternalLink href="https://github.com/acteng/atip"
+        >open source project</ExternalLink
+      > supported by Active Travel England and developed by:
+    </p>
 
-  <ul>
-    <li>
-      <ExternalLink
-        href="https://www.turing.ac.uk/people/researchers/dustin-carlino"
-        >Dustin Carlino</ExternalLink
-      >: lead developer, from The Alan Turing Institute
-    </li>
-    <li>
-      With UX help from
-      <ExternalLink href="https://www.linkedin.com/in/madison-wang-841977bb/"
-        >Madison Wang</ExternalLink
-      > and CSS help from
-      <ExternalLink href="https://github.com/BudgieInWA"
-        >Ben Ritter</ExternalLink
+    <ul>
+      <li>
+        <ExternalLink
+          href="https://www.turing.ac.uk/people/researchers/dustin-carlino"
+          >Dustin Carlino</ExternalLink
+        >: lead developer, from The Alan Turing Institute
+      </li>
+      <li>
+        With UX help from
+        <ExternalLink href="https://www.linkedin.com/in/madison-wang-841977bb/"
+          >Madison Wang</ExternalLink
+        > and CSS help from
+        <ExternalLink href="https://github.com/BudgieInWA"
+          >Ben Ritter</ExternalLink
+        >
+      </li>
+      <li>
+        With great thanks to ATIP's various users for feedback, testing, and
+        ideas
+      </li>
+    </ul>
+
+    <p>
+      ATIP builds on
+      <ExternalLink href="https://www.openstreetmap.org/about"
+        >OpenStreetMap</ExternalLink
       >
-    </li>
-    <li>
-      With great thanks to ATIP's various users for feedback, testing, and ideas
-    </li>
-  </ul>
+      contributors,
+      <ExternalLink href="https://maplibre.org/">MapLibre</ExternalLink>,
+      <ExternalLink href="https://georust.org/">GeoRust</ExternalLink>,
+      <ExternalLink href="https://github.com/a-b-street/osm2streets"
+        >osm2streets</ExternalLink
+      >,
+      <ExternalLink href="https://material.io/resources/icons/"
+        >Material icons</ExternalLink
+      >, and other open source projects.
+    </p>
 
-  <p>
-    ATIP builds on
-    <ExternalLink href="https://www.openstreetmap.org/about"
-      >OpenStreetMap</ExternalLink
-    >
-    contributors,
-    <ExternalLink href="https://maplibre.org/">MapLibre</ExternalLink>,
-    <ExternalLink href="https://georust.org/">GeoRust</ExternalLink>,
-    <ExternalLink href="https://github.com/a-b-street/osm2streets"
-      >osm2streets</ExternalLink
-    >,
-    <ExternalLink href="https://material.io/resources/icons/"
-      >Material icons</ExternalLink
-    >, and other open source projects.
-  </p>
+    <p>
+      We want your feedback about ATIP! Please <ExternalLink
+        href="https://github.com/acteng/atip/issues/new"
+        >start an issue on Github</ExternalLink
+      >
+      or email
+      <a href="mailto: dcarlino@turing.ac.uk">dcarlino@turing.ac.uk</a>.
+    </p>
 
-  <p>
-    We want your feedback about ATIP! Please <ExternalLink
-      href="https://github.com/acteng/atip/issues/new"
-      >start an issue on Github</ExternalLink
-    >
-    or email <a href="mailto: dcarlino@turing.ac.uk">dcarlino@turing.ac.uk</a>.
-  </p>
+    <hr />
 
-  <hr />
-
-  <h2>Recent changes</h2>
-  <ul>
-    <li>
-      <b>v2</b> launched on 2 June 2023. Changes: a complete UI rewrite, new draw
-      tools, drawing areas snapped to roads, splitting routes, multiple data schemas,
-      speed limit layer, lane visualization layer
-    </li>
-    <li><b>v1</b> launched in March 2023</li>
-  </ul>
+    <h2>Recent changes</h2>
+    <ul>
+      <li>
+        <b>v2</b> launched on 2 June 2023. Changes: a complete UI rewrite, new draw
+        tools, drawing areas snapped to roads, splitting routes, multiple data schemas,
+        speed limit layer, lane visualization layer
+      </li>
+      <li><b>v1</b> launched in March 2023</li>
+    </ul>
+  </div>
 </Modal>

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -163,7 +163,12 @@
 <br />
 
 <div>
-  <FileInput label="Load from GeoJSON" disabled={$isAToolInUse} {loadFile} />
+  <FileInput
+    label="Load from GeoJSON"
+    id="load-geojson"
+    disabled={$isAToolInUse}
+    {loadFile}
+  />
   <button
     type="button"
     class="align-right"

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -163,12 +163,7 @@
 <br />
 
 <div>
-  <FileInput
-    label="Load from GeoJSON"
-    uniqueId="load-geojson"
-    disabled={$isAToolInUse}
-    {loadFile}
-  />
+  <FileInput label="Load from GeoJSON" disabled={$isAToolInUse} {loadFile} />
   <button
     type="button"
     class="align-right"

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -170,7 +170,7 @@
 </script>
 
 <Layout>
-  <div slot="sidebar" class="sidebar">
+  <div slot="sidebar">
     <button type="button" on:click={() => window.open("index.html")}>
       Home</button
     >
@@ -178,7 +178,7 @@
       Browse schemes
       <ZoomOutMap boundaryGeojson={$gjScheme} />
     </h1>
-    <FileInput label="Load from GeoJSON" uniqueId="load_geojson" {loadFile} />
+    <FileInput label="Load from GeoJSON" {loadFile} />
 
     <br />
     <br />

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -13,6 +13,8 @@
   import Layout from "../lib/common/Layout.svelte";
   import MapTooltips from "../lib/common/MapTooltips.svelte";
   import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
+  import FormElement from "../lib/govuk/FormElement.svelte";
+  import SecondaryButton from "../lib/govuk/SecondaryButton.svelte";
   import Legend from "../lib/Legend.svelte";
   import Map from "../lib/Map.svelte";
   import ZoomOutMap from "../lib/ZoomOutMap.svelte";
@@ -170,26 +172,28 @@
 </script>
 
 <Layout>
-  <div slot="sidebar">
-    <button type="button" on:click={() => window.open("index.html")}>
-      Home</button
+  <div slot="sidebar" class="govuk-prose">
+    <SecondaryButton on:click={() => window.open("index.html")}>
+      Home</SecondaryButton
     >
-    <h1>
-      Browse schemes
+    <div style="display: flex; justify-content: space-between">
+      <h1>Browse schemes</h1>
       <ZoomOutMap boundaryGeojson={$gjScheme} />
-    </h1>
+    </div>
     <FileInput label="Load from GeoJSON" {loadFile} />
 
     <br />
-    <br />
 
-    <div>
-      <label>
-        Filter by any field: <br />
-        <input type="text" bind:value={filterText} />
-      </label>
-      <button type="button" on:click={() => (filterText = "")}>Clear</button>
-    </div>
+    <FormElement label="Filter by any field" id="filterText">
+      <input
+        type="text"
+        class="govuk-input govuk-input--width-10"
+        id="filterText"
+        bind:value={filterText}
+      />
+      <SecondaryButton on:click={() => (filterText = "")}>Clear</SecondaryButton
+      >
+    </FormElement>
 
     <p>
       Showing {showSchemes.size} schemes ({counts.route} routes, {counts.area} areas,
@@ -202,21 +206,17 @@
           <CollapsibleCard
             label={`${scheme.scheme_reference}: ${scheme.num_features} features`}
           >
-            <ul>
-              <li>Authority or region: {scheme.authority_or_region}</li>
-              <li>Capital scheme ID: {scheme.capital_scheme_id}</li>
-              <li>Funding programme: {scheme.funding_programme}</li>
-              <li>
-                <button type="button" on:click={() => showScheme(scheme)}
-                  >Show on map</button
-                >
-              </li>
-              <li>
-                <button type="button" on:click={() => editScheme(scheme)}
-                  >Edit scheme</button
-                >
-              </li>
-            </ul>
+            <p>Authority or region: {scheme.authority_or_region}</p>
+            <p>Capital scheme ID: {scheme.capital_scheme_id}</p>
+            <p>Funding programme: {scheme.funding_programme}</p>
+            <div class="govuk-button-group">
+              <SecondaryButton on:click={() => showScheme(scheme)}
+                >Show on map</SecondaryButton
+              >
+              <SecondaryButton on:click={() => editScheme(scheme)}
+                >Edit scheme</SecondaryButton
+              >
+            </div>
           </CollapsibleCard>
         {/if}
       {/each}

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -180,7 +180,7 @@
       <h1>Browse schemes</h1>
       <ZoomOutMap boundaryGeojson={$gjScheme} />
     </div>
-    <FileInput label="Load from GeoJSON" {loadFile} />
+    <FileInput label="Load from GeoJSON" id="load-geojson" {loadFile} />
 
     <br />
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import { initAll } from "govuk-frontend";
   import "../style/main.css";
   import type { FeatureCollection } from "geojson";
+  import { initAll } from "govuk-frontend";
   import { Map } from "maplibre-gl";
   import { onMount } from "svelte";
+  import DefaultButton from "../lib/govuk/DefaultButton.svelte";
+  import FormElement from "../lib/govuk/FormElement.svelte";
+  import SecondaryButton from "../lib/govuk/SecondaryButton.svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
   import authoritiesUrl from "../../assets/authorities.geojson?url";
   import FileInput from "../lib/common/FileInput.svelte";
@@ -150,42 +153,30 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half left">
     <h1 class="govuk-heading-l">Welcome to ATIP v2</h1>
-    <button
-      class="govuk-button govuk-button--secondary"
-      data-module="govuk-button"
-      on:click={() => (showAbout = !showAbout)}>About</button
+    <SecondaryButton on:click={() => (showAbout = !showAbout)}
+      >About</SecondaryButton
     >
 
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="inputValue">
-        Select Transport Authority or Local Authority District
-      </label>
+    <FormElement
+      label="Select Transport Authority or Local Authority District"
+      id="inputValue"
+    >
       <input
         class="govuk-input govuk-input--width-20"
         id="inputValue"
-        name="inputValue"
         data-testid="transport-authority"
         list="authorities-list"
         bind:value={inputValue}
       />
       <datalist id="authorities-list" bind:this={dataList} />
-    </div>
-    <button
-      class="govuk-button"
-      data-module="govuk-button"
-      on:click={start}
-      disabled={!validEntry}>Start</button
-    >
+    </FormElement>
+    <DefaultButton on:click={start} disabled={!validEntry}>Start</DefaultButton>
 
     <hr />
 
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="showBoundaries">
-        Or pick from the map
-      </label>
+    <FormElement label="Or pick from the map" id="showBoundaries">
       <select
         id="showBoundaries"
-        name="showBoundaries"
         class="govuk-select"
         bind:value={showBoundaries}
         on:change={changeBoundaries}
@@ -196,7 +187,7 @@
       {#if hoveredBoundary}
         <i>{hoveredBoundary}</i>
       {/if}
-    </div>
+    </FormElement>
 
     <hr />
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -6,6 +6,7 @@
   import { onMount } from "svelte";
   import DefaultButton from "../lib/govuk/DefaultButton.svelte";
   import FormElement from "../lib/govuk/FormElement.svelte";
+  import Radio from "../lib/govuk/Radio.svelte";
   import SecondaryButton from "../lib/govuk/SecondaryButton.svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
   import authoritiesUrl from "../../assets/authorities.geojson?url";
@@ -174,20 +175,19 @@
 
     <hr />
 
-    <FormElement label="Or pick from the map" id="showBoundaries">
-      <select
-        id="showBoundaries"
-        class="govuk-select"
-        bind:value={showBoundaries}
-        on:change={changeBoundaries}
-      >
-        <option value="TA">Transport Authorities</option>
-        <option value="LAD">Local Authority District</option>
-      </select>
-      {#if hoveredBoundary}
-        <i>{hoveredBoundary}</i>
-      {/if}
-    </FormElement>
+    <Radio
+      legend="Or pick from the map"
+      id="showBoundaries"
+      choices={[
+        ["TA", "Transport Authorities"],
+        ["LAD", "Local Authority Districts"],
+      ]}
+      bind:value={showBoundaries}
+      on:change={changeBoundaries}
+    />
+    {#if hoveredBoundary}
+      <i>{hoveredBoundary}</i>
+    {/if}
 
     <hr />
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { initAll } from "govuk-frontend";
+  import "../style/main.css";
   import type { FeatureCollection } from "geojson";
   import { Map } from "maplibre-gl";
   import { onMount } from "svelte";
@@ -27,6 +29,9 @@
   let hoveredBoundary: string | null = null;
 
   onMount(async () => {
+    // For govuk components. Must happen here.
+    initAll();
+
     const resp = await fetch(authoritiesUrl);
     const body = await resp.text();
     const json: FeatureCollection = JSON.parse(body);
@@ -142,40 +147,65 @@
   }
 </script>
 
-<div class="left">
-  <h1>Welcome to ATIP v2</h1>
-  <button type="button" on:click={() => (showAbout = !showAbout)}>About</button>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half left">
+    <h1 class="govuk-heading-l">Welcome to ATIP v2</h1>
+    <button
+      class="govuk-button govuk-button--secondary"
+      data-module="govuk-button"
+      on:click={() => (showAbout = !showAbout)}>About</button
+    >
 
-  <p>Select Transport Authority or Local Authority District:</p>
-  <div>
-    <input
-      data-testid="transport-authority"
-      list="authorities-list"
-      bind:value={inputValue}
-    />
-    <datalist id="authorities-list" bind:this={dataList} />
-    <button type="button" on:click={start} disabled={!validEntry}>Start</button>
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="inputValue">
+        Select Transport Authority or Local Authority District
+      </label>
+      <input
+        class="govuk-input govuk-input--width-20"
+        id="inputValue"
+        name="inputValue"
+        data-testid="transport-authority"
+        list="authorities-list"
+        bind:value={inputValue}
+      />
+      <datalist id="authorities-list" bind:this={dataList} />
+    </div>
+    <button
+      class="govuk-button"
+      data-module="govuk-button"
+      on:click={start}
+      disabled={!validEntry}>Start</button
+    >
+
+    <hr />
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="showBoundaries">
+        Or pick from the map
+      </label>
+      <select
+        id="showBoundaries"
+        name="showBoundaries"
+        class="govuk-select"
+        bind:value={showBoundaries}
+        on:change={changeBoundaries}
+      >
+        <option value="TA">Transport Authorities</option>
+        <option value="LAD">Local Authority District</option>
+      </select>
+      {#if hoveredBoundary}
+        <i>{hoveredBoundary}</i>
+      {/if}
+    </div>
+
+    <hr />
+
+    <FileInput label="Or upload an ATIP GeoJSON file" {loadFile} />
   </div>
-  <hr />
-  <label>
-    Or pick from the map:
-    <select bind:value={showBoundaries} on:change={changeBoundaries}>
-      <option value="TA">Transport Authorities</option>
-      <option value="LAD">Local Authority District</option>
-    </select>
-    {#if hoveredBoundary}
-      <i>{hoveredBoundary}</i>
-    {/if}
-  </label>
-  <hr />
-  <p>Or upload an ATIP file:</p>
-  <FileInput
-    label="Upload ATIP GeoJSON file"
-    uniqueId="load-geojson"
-    {loadFile}
-  />
+  <div class="govuk-grid-column-one-half">
+    <div id="map" />
+  </div>
 </div>
-<div id="map" />
 <About bind:open={showAbout} />
 
 <style>
@@ -184,8 +214,8 @@
     padding: 0;
   }
 
-  button {
-    margin-left: 6px;
+  .left {
+    margin: 10px;
   }
 
   #map {
@@ -194,9 +224,5 @@
     bottom: 0;
     right: 0;
     width: 50%;
-  }
-
-  .left {
-    margin: 10px;
   }
 </style>

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -191,7 +191,11 @@
 
     <hr />
 
-    <FileInput label="Or upload an ATIP GeoJSON file" {loadFile} />
+    <FileInput
+      label="Or upload an ATIP GeoJSON file"
+      {loadFile}
+      id="load-geojson"
+    />
   </div>
   <div class="govuk-grid-column-one-half">
     <div id="map" />

--- a/src/style/main.sass
+++ b/src/style/main.sass
@@ -5,8 +5,14 @@
 //
 // See https://design-system.service.gov.uk/styles/typography/ for reference on
 // govuk classes
-.sidebar
-  p
-    @extend .govuk-body
+.govuk-prose
   h1
     @extend .govuk-heading-l
+  h2
+    @extend .govuk-heading-m
+  p
+    @extend .govuk-body
+  a
+    @extend .govuk-link
+  ul
+    @extend .govuk-list--bullet

--- a/tests/savefiles.spec.ts
+++ b/tests/savefiles.spec.ts
@@ -21,9 +21,9 @@ test.beforeEach(async () => {
 });
 
 test("loading a file with length displays the length", async () => {
-  // Note we use a weird styling trick to replace the file input element with a regular button.
-  // This will not work: page.getByRole('button', { name: 'Load from GeoJSON' })
-  await page.locator("#load-geojson").setInputFiles("tests/data/Adur.json");
+  await page
+    .getByLabel("Load from GeoJSON")
+    .setInputFiles("tests/data/Adur.json");
 
   page.on("dialog", (dialog) => dialog.accept());
   await page
@@ -43,7 +43,7 @@ test("loading a file without length displays the length", async () => {
   delete copy.features[0].properties.length_meters;
   let uploadFile = JSON.stringify(copy);
 
-  await page.locator("#load-geojson").setInputFiles({
+  await page.getByLabel("Load from GeoJSON").setInputFiles({
     name: "Adur.json",
     mimeType: "application/json",
     buffer: Buffer.from(uploadFile),
@@ -64,7 +64,7 @@ test("loading a file with null properties displays the length", async () => {
   copy.features[0].properties = null;
   let uploadFile = JSON.stringify(copy);
 
-  await page.locator("#load-geojson").setInputFiles({
+  await page.getByLabel("Load from GeoJSON").setInputFiles({
     name: "Adur.json",
     mimeType: "application/json",
     buffer: Buffer.from(uploadFile),
@@ -91,7 +91,9 @@ test("the previous file from local storage is loaded by default", async () => {
 
 test("loading a file from the homepage goes to the correct page", async () => {
   await page.goto("/");
-  await page.locator("#load-geojson").setInputFiles("tests/data/Adur.json");
+  await page
+    .getByLabel("Or upload an ATIP GeoJSON file")
+    .setInputFiles("tests/data/Adur.json");
 
   await expect(page).toHaveURL(/scheme.html\?authority=Adur/);
   await page


### PR DESCRIPTION
This is the next step to use the govuk design system, on our two simpler pages. I've tried my best to interpret https://design-system.service.gov.uk/styles/ and https://design-system.service.gov.uk/components/, but I (really hope!) we go through some kind of design review later, because there are plenty of unclear decisions made.

Compare: [old homepage](https://acteng.github.io/atip/index.html) with [new homepage](https://acteng.github.io/atip/govuk_step2/index.html), and [old browse](https://acteng.github.io/atip/browse.html) with [new browse](https://acteng.github.io/atip/govuk_step2/browse.html)


https://github.com/acteng/atip/assets/1664407/181d3c35-6d86-4e11-93ef-0b540c08663f

In the step after this one, I'll convert our main edit page... or at least the sidebar. I haven't found much guidance yet for design patterns on maps, such as tooltips, changing cursors, hover effects, etc -- lots of the questions we've been asking anyway! I'll search/ask around to see if there's any guidance here yet.

# Code style choices

Copying the sample HTML directly from govuk docs would severely pollute our codebase, and make it tough to check that we've converted all elements on every page to using the right CSS classes. So there are 3 ways we use govuk components:

1) New Svelte components that wrap something, like a group of radio buttons. The user doesn't care that govuk things are happening internally.
2) Automatically adding CSS classes to standard HTML elements, as long as they're under a `<div class="govuk-prose">`
3) In "one-off" situations, directly use govuk HTML+CSS code. When the usage becomes more complex or we need the same pattern somewhere else, we can apply one of the two strategies above, but I feel it'd be premature refactoring at this point.