### PR TITLE
Display user-friendly field names for auto-generated forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/geojson": "^7946.0.10",
         "comlink": "^4.4.1",
         "govuk-frontend": "^4.6.0",
+        "humanize-string": "^3.0.0",
         "maplibre-gl": "^3.1.0",
         "route-snapper": "^0.1.14",
         "svelte": "^4.0.0"
@@ -1662,6 +1663,17 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1989,6 +2001,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/humanize-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-3.0.0.tgz",
+      "integrity": "sha512-jhWD2GAZRMELz0IEIfqpEdi0M4CMQF1GpJpBYIopFN6wT+78STiujfQTKcKqZzOJgUkIgJSo2xFeHdsg922JZQ==",
+      "dependencies": {
+        "decamelize": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/geojson": "^7946.0.10",
     "comlink": "^4.4.1",
     "govuk-frontend": "^4.6.0",
+    "humanize-string": "^3.0.0",
     "maplibre-gl": "^3.1.0",
     "route-snapper": "^0.1.14",
     "svelte": "^4.0.0"

--- a/src/lib/forms/AutogenerateForm.svelte
+++ b/src/lib/forms/AutogenerateForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import humanizeString from "humanize-string";
   import { slide } from "svelte/transition";
   import {
     isBarewordEnumCase,
@@ -57,7 +58,7 @@
 {#if isStruct(spec)}
   {#each spec.members as x}
     <div>
-      <h3>{x.name}</h3>
+      <h3>{humanizeString(x.name)}</h3>
       <svelte:self spec={x} bind:value={value[x.name]} />
     </div>
   {/each}


### PR DESCRIPTION
Closes #273 
https://acteng.github.io/atip/capitalize_auto_form/scheme.html?authority=Adur&schema=v2

![Screenshot from 2023-07-14 14-52-43](https://github.com/acteng/atip/assets/1664407/30efb252-fedf-4ef9-9967-cec1f6bfca68)

An incremental improvement. It'd also be nice to apply these to radio buttons, so we don't see `SchoolCrossing`. But we need to be careful with https://github.com/sindresorhus/humanize-string, because it mangles the dash in "20 - 30 mph"