### PR TITLE
Make prettier handle closing tags better

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "importOrderTypeScriptVersion": "5.0.0"
+  "importOrderTypeScriptVersion": "5.0.0",
+  "htmlWhitespaceSensitivity": "ignore"
 }

--- a/src/lib/Legend.svelte
+++ b/src/lib/Legend.svelte
@@ -10,17 +10,39 @@
   <CollapsibleCard label="Objects" open>
     <ul>
       {#if schema == "planning"}
-        <li><span style:background={colors.preapp} />Preapp</li>
-        <li><span style:background={colors.outline} />Outline</li>
         <li>
-          <span style:background={colors["reserved matters"]} />Reserved matters
+          <span style:background={colors.preapp} />
+          Preapp
         </li>
-        <li><span style:background={colors["local plan"]} />Local plan</li>
+        <li>
+          <span style:background={colors.outline} />
+          Outline
+        </li>
+        <li>
+          <span style:background={colors["reserved matters"]} />
+          Reserved matters
+        </li>
+        <li>
+          <span style:background={colors["local plan"]} />
+          Local plan
+        </li>
       {:else}
-        <li><span style:background={colors.area} />Areas</li>
-        <li><span style:background={colors.route} />Routes</li>
-        <li><span style:background={colors.crossing} />Crossings</li>
-        <li><span style:background={colors.other} />Other</li>
+        <li>
+          <span style:background={colors.area} />
+          Areas
+        </li>
+        <li>
+          <span style:background={colors.route} />
+          Routes
+        </li>
+        <li>
+          <span style:background={colors.crossing} />
+          Crossings
+        </li>
+        <li>
+          <span style:background={colors.other} />
+          Other
+        </li>
       {/if}
     </ul>
   </CollapsibleCard>

--- a/src/lib/common/ConfirmationModal.svelte
+++ b/src/lib/common/ConfirmationModal.svelte
@@ -32,8 +32,8 @@
   <p>{message}</p>
   <div class="govuk-button-group">
     <WarningButton on:click={onClickConfirm}>{confirmButtonText}</WarningButton>
-    <SecondaryButton on:click={onClickCancel}
-      >{cancelButtonText}</SecondaryButton
-    >
+    <SecondaryButton on:click={onClickCancel}>
+      {cancelButtonText}
+    </SecondaryButton>
   </div>
 </Modal>

--- a/src/lib/common/Layout.svelte
+++ b/src/lib/common/Layout.svelte
@@ -14,8 +14,10 @@
     <button
       type="button"
       class="sidebar-toggle rounded-rect"
-      on:click={toggleSidebar}>&rarr;</button
+      on:click={toggleSidebar}
     >
+      &rarr;
+    </button>
   </aside>
   <main>
     <slot name="main" />

--- a/src/lib/draw/SelectToolButton.svelte
+++ b/src/lib/draw/SelectToolButton.svelte
@@ -12,8 +12,10 @@
   type="button"
   on:click={() => changeMode(thisMode)}
   disabled={$currentMode == thisMode}
-  ><img src={icon} alt={label} /> {label}</button
 >
+  <img src={icon} alt={label} />
+  {label}
+</button>
 
 <style>
   button {

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -58,9 +58,13 @@
   <CollapsibleCard label="Help">
     <ul>
       <li>
-        <b>Click</b> on the map to open a new tab with a 3rd-party imagery provider
+        <b>Click</b>
+         on the map to open a new tab with a 3rd-party imagery provider
       </li>
-      <li>Press <b>Escape</b> to exit this mode</li>
+      <li>
+        Press <b>Escape</b>
+         to exit this mode
+      </li>
     </ul>
   </CollapsibleCard>
 {/if}

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -14,7 +14,10 @@
     {:else}
       <li>Click to add a new point</li>
     {/if}
-    <li>Press <b>Escape</b> to cancel</li>
+    <li>
+      Press <b>Escape</b>
+       to cancel
+    </li>
   </ul>
 </CollapsibleCard>
 

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -9,16 +9,34 @@
 
 <CollapsibleCard label="Help">
   <ul>
-    <li><b>Click</b> the map to add a vertex</li>
-    <li><b>Click</b> a vertex to delete it</li>
-    <li><b>Drag</b> a vertex or the polygon to move it</li>
-    <li>Press <b>Enter</b> or <b>double click</b> to finish</li>
-    <li>Press <b>Escape</b> to cancel</li>
+    <li>
+      <b>Click</b>
+       the map to add a vertex
+    </li>
+    <li>
+      <b>Click</b>
+       a vertex to delete it
+    </li>
+    <li>
+      <b>Drag</b>
+       a vertex or the polygon to move it
+    </li>
+    <li>
+      Press <b>Enter</b>
+      or
+      <b>double click</b>
+       to finish
+    </li>
+    <li>
+      Press <b>Escape</b>
+       to cancel
+    </li>
   </ul>
 </CollapsibleCard>
 
 <div style="display: flex; justify-content: space-between">
   <DefaultButton on:click={() => polygonTool.finish()}>Finish</DefaultButton>
-  <SecondaryButton on:click={() => polygonTool.cancel()}>Cancel</SecondaryButton
-  >
+  <SecondaryButton on:click={() => polygonTool.cancel()}>
+    Cancel
+  </SecondaryButton>
 </div>

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -25,13 +25,31 @@
 <CollapsibleCard label="Help">
   <ul>
     <li>
-      <b>Click</b> green points on the transport network to create snapped routes
+      <b>Click</b>
+       green points on the transport network to create snapped routes
     </li>
-    <li>Hold <b>Shift</b> to draw a point anywhere</li>
-    <li><b>Click and drag</b> any point to move it</li>
-    <li><b>Click</b> a red waypoint to delete it</li>
-    <li>Press <b>Enter</b> or <b>double click</b> to finish</li>
-    <li>Press <b>Escape</b> to cancel</li>
+    <li>
+      Hold <b>Shift</b>
+       to draw a point anywhere
+    </li>
+    <li>
+      <b>Click and drag</b>
+       any point to move it
+    </li>
+    <li>
+      <b>Click</b>
+       a red waypoint to delete it
+    </li>
+    <li>
+      Press <b>Enter</b>
+      or
+      <b>double click</b>
+       to finish
+    </li>
+    <li>
+      Press <b>Escape</b>
+       to cancel
+    </li>
   </ul>
 </CollapsibleCard>
 

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -258,8 +258,16 @@
 {#if $currentMode == thisMode}
   <CollapsibleCard label="Help">
     <ul>
-      <li><b>Click</b> on a route to split it</li>
-      <li><b>Click</b> on the map or press <b>Escape</b> to cancel</li>
+      <li>
+        <b>Click</b>
+         on a route to split it
+      </li>
+      <li>
+        <b>Click</b>
+        on the map or press
+        <b>Escape</b>
+         to cancel
+      </li>
     </ul>
   </CollapsibleCard>
 {/if}

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -12,12 +12,27 @@
 <CollapsibleCard label="Help">
   <ul>
     <li>
-      <b>Click</b> green points on the transport network to create snapped routes
+      <b>Click</b>
+       green points on the transport network to create snapped routes
     </li>
-    <li><b>Click and drag</b> any point to move it</li>
-    <li><b>Click</b> a red waypoint to delete it</li>
-    <li>Press <b>Enter</b> or <b>double click</b> to finish</li>
-    <li>Press <b>Escape</b> to cancel</li>
+    <li>
+      <b>Click and drag</b>
+       any point to move it
+    </li>
+    <li>
+      <b>Click</b>
+       a red waypoint to delete it
+    </li>
+    <li>
+      Press <b>Enter</b>
+      or
+      <b>double click</b>
+       to finish
+    </li>
+    <li>
+      Press <b>Escape</b>
+       to cancel
+    </li>
   </ul>
 </CollapsibleCard>
 

--- a/src/lib/forms/AutogenerateForm.svelte
+++ b/src/lib/forms/AutogenerateForm.svelte
@@ -98,7 +98,8 @@
           on:change={otherOneOf}
           value={x.name}
         />
-        {x.name}<br />
+        {x.name}
+        <br />
       </label>
 
       {#if oneOfCase == x.name && typeof value == "object"}

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -38,9 +38,9 @@
   <input type="text" class="govuk-input" bind:value={name} />
   <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
   {#if length_meters}
-    <SecondaryButton on:click={() => autoFillName()} disabled={!$routeInfo}
-      >Auto-fill</SecondaryButton
-    >
+    <SecondaryButton on:click={() => autoFillName()} disabled={!$routeInfo}>
+      Auto-fill
+    </SecondaryButton>
   {/if}
 </FormElement>
 

--- a/src/lib/govuk/Checkbox.svelte
+++ b/src/lib/govuk/Checkbox.svelte
@@ -13,7 +13,7 @@
 
 <div class="govuk-checkboxes__item">
   <input type="checkbox" class="govuk-checkboxes__input" {id} bind:checked />
-  <label class="govuk-label govuk-checkboxes__label" for={id} title={hint}
-    >{label}</label
-  >
+  <label class="govuk-label govuk-checkboxes__label" for={id} title={hint}>
+    {label}
+  </label>
 </div>

--- a/src/lib/sidebar/About.svelte
+++ b/src/lib/sidebar/About.svelte
@@ -9,26 +9,27 @@
   <div class="govuk-prose">
     <p>
       ATIP v2 is an
-      <ExternalLink href="https://github.com/acteng/atip"
-        >open source project</ExternalLink
-      > supported by Active Travel England and developed by:
+      <ExternalLink href="https://github.com/acteng/atip">
+        open source project
+      </ExternalLink> supported by Active Travel England and developed by:
     </p>
 
     <ul>
       <li>
         <ExternalLink
           href="https://www.turing.ac.uk/people/researchers/dustin-carlino"
-          >Dustin Carlino</ExternalLink
-        >: lead developer, from The Alan Turing Institute
+        >
+          Dustin Carlino
+        </ExternalLink>: lead developer, from The Alan Turing Institute
       </li>
       <li>
         With UX help from
-        <ExternalLink href="https://www.linkedin.com/in/madison-wang-841977bb/"
-          >Madison Wang</ExternalLink
-        > and CSS help from
-        <ExternalLink href="https://github.com/BudgieInWA"
-          >Ben Ritter</ExternalLink
-        >
+        <ExternalLink href="https://www.linkedin.com/in/madison-wang-841977bb/">
+          Madison Wang
+        </ExternalLink> and CSS help from
+        <ExternalLink href="https://github.com/BudgieInWA">
+          Ben Ritter
+        </ExternalLink>
       </li>
       <li>
         With great thanks to ATIP's various users for feedback, testing, and
@@ -38,27 +39,29 @@
 
     <p>
       ATIP builds on
-      <ExternalLink href="https://www.openstreetmap.org/about"
-        >OpenStreetMap</ExternalLink
-      >
+      <ExternalLink href="https://www.openstreetmap.org/about">
+        OpenStreetMap
+      </ExternalLink>
       contributors,
       <ExternalLink href="https://maplibre.org/">MapLibre</ExternalLink>,
       <ExternalLink href="https://georust.org/">GeoRust</ExternalLink>,
-      <ExternalLink href="https://github.com/a-b-street/osm2streets"
-        >osm2streets</ExternalLink
-      >,
-      <ExternalLink href="https://material.io/resources/icons/"
-        >Material icons</ExternalLink
-      >, and other open source projects.
+      <ExternalLink href="https://github.com/a-b-street/osm2streets">
+        osm2streets
+      </ExternalLink>,
+      <ExternalLink href="https://material.io/resources/icons/">
+        Material icons
+      </ExternalLink>, and other open source projects.
     </p>
 
     <p>
       We want your feedback about ATIP! Please <ExternalLink
         href="https://github.com/acteng/atip/issues/new"
-        >start an issue on Github</ExternalLink
       >
+        start an issue on Github
+      </ExternalLink>
       or email
-      <a href="mailto: dcarlino@turing.ac.uk">dcarlino@turing.ac.uk</a>.
+      <a href="mailto: dcarlino@turing.ac.uk">dcarlino@turing.ac.uk</a>
+      .
     </p>
 
     <hr />
@@ -66,11 +69,15 @@
     <h2>Recent changes</h2>
     <ul>
       <li>
-        <b>v2</b> launched on 2 June 2023. Changes: a complete UI rewrite, new draw
-        tools, drawing areas snapped to roads, splitting routes, multiple data schemas,
+        <b>v2</b>
+         launched on 2 June 2023. Changes: a complete UI rewrite, new draw tools,
+        drawing areas snapped to roads, splitting routes, multiple data schemas,
         speed limit layer, lane visualization layer
       </li>
-      <li><b>v1</b> launched in March 2023</li>
+      <li>
+        <b>v1</b>
+         launched in March 2023
+      </li>
     </ul>
   </div>
 </Modal>

--- a/src/lib/sidebar/AccordionItem.svelte
+++ b/src/lib/sidebar/AccordionItem.svelte
@@ -45,7 +45,8 @@
   on:mouseleave={() => sidebarHover.set(null)}
   aria-expanded={isOpen}
   class:underlined={underlineRemotely}
-  ><svg
+>
+  <svg
     style="tran"
     width="20"
     height="20"
@@ -54,8 +55,10 @@
     stroke-linejoin="round"
     stroke-width="2"
     viewBox="0 0 24 24"
-    stroke="currentColor"><path d="M9 5l7 7-7 7" /></svg
+    stroke="currentColor"
   >
+    <path d="M9 5l7 7-7 7" />
+  </svg>
   {label}
 </button>
 {#if isOpen}

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -180,8 +180,9 @@
   <WarningButton
     on:click={openClearAllDialogue}
     disabled={$gjScheme.features.length == 0 || $isAToolInUse}
-    >Clear all</WarningButton
   >
+    Clear all
+  </WarningButton>
 </div>
 <ConfirmationModal
   bind:open={displayClearAllConfirmation}

--- a/src/lib/sidebar/Instructions.svelte
+++ b/src/lib/sidebar/Instructions.svelte
@@ -16,12 +16,15 @@
       that appear when you click on its icon.
     </p>
     <p>
-      Modify existing {noun} on the map using <b>Edit geometry</b> and clicking something.
+      Modify existing {noun} on the map using
+      <b>Edit geometry</b>
+       and clicking something.
     </p>
 
     <h2>Filling out data</h2>
     <p>
-      <b>Edit attributes</b> mode allows selecting and adding attributes to {noun}
+      <b>Edit attributes</b>
+      mode allows selecting and adding attributes to {noun}
       that appear on the left.
     </p>
 
@@ -30,11 +33,15 @@
       ATIP does not send any data over the network or store your data in the
       cloud. The current file you're editing will be saved in your browser's
       local storage and automatically resume when you return to the page. The <b
-        >Export to GeoJSON</b
       >
-      and <b>Load from GeoJSON</b> buttons save and load GeoJSON files (with a
-      <i>.txt</i> file extension) to your computer. You share these files with others
-      to collaborate on designs.
+        Export to GeoJSON
+      </b>
+      and
+      <b>Load from GeoJSON</b>
+      buttons save and load GeoJSON files (with a
+      <i>.txt</i>
+       file extension) to your computer. You share these files with others to collaborate
+      on designs.
     </p>
   </div>
 </Modal>

--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -91,11 +91,12 @@
     <br />
     <br />
     <div style="display: flex; justify-content: space-between">
-      <WarningButton on:click={() => deleteIntervention(feature.id)}
-        >Delete</WarningButton
-      >
-      <SecondaryButton on:click={() => formOpen.set(null)}>Save</SecondaryButton
-      >
+      <WarningButton on:click={() => deleteIntervention(feature.id)}>
+        Delete
+      </WarningButton>
+      <SecondaryButton on:click={() => formOpen.set(null)}>
+        Save
+      </SecondaryButton>
     </div>
   </AccordionItem>
 {/each}

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -97,12 +97,12 @@
   <div slot="sidebar" class="govuk-prose">
     <div class="govuk-button-group">
       <SecondaryButton on:click={() => (window.location.href = "index.html")}>
-        Home</SecondaryButton
-      >
+        Home
+      </SecondaryButton>
       <SecondaryButton on:click={toggleAbout}>About</SecondaryButton>
-      <SecondaryButton on:click={toggleInstructions}
-        >Instructions</SecondaryButton
-      >
+      <SecondaryButton on:click={toggleInstructions}>
+        Instructions
+      </SecondaryButton>
     </div>
     <p>{schemaTitle(schema)} mode</p>
     <div style="display: flex; justify-content: space-between">

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -212,8 +212,8 @@
 <Layout>
   <div slot="sidebar" class="govuk-prose">
     <SecondaryButton on:click={() => window.open("index.html")}>
-      Home</SecondaryButton
-    >
+      Home
+    </SecondaryButton>
     <div style="display: flex; justify-content: space-between">
       <h1>Browse schemes</h1>
       <ZoomOutMap boundaryGeojson={$gjScheme} />
@@ -243,9 +243,9 @@
           id="filterText"
           bind:value={filterText}
         />
-        <SecondaryButton on:click={() => (filterText = "")}
-          >Clear</SecondaryButton
-        >
+        <SecondaryButton on:click={() => (filterText = "")}>
+          Clear
+        </SecondaryButton>
       </FormElement>
     </CollapsibleCard>
 
@@ -264,12 +264,12 @@
             <p>Capital scheme ID: {scheme.capital_scheme_id}</p>
             <p>Funding programme: {scheme.funding_programme}</p>
             <div class="govuk-button-group">
-              <SecondaryButton on:click={() => showScheme(scheme)}
-                >Show on map</SecondaryButton
-              >
-              <SecondaryButton on:click={() => editScheme(scheme)}
-                >Edit scheme</SecondaryButton
-              >
+              <SecondaryButton on:click={() => showScheme(scheme)}>
+                Show on map
+              </SecondaryButton>
+              <SecondaryButton on:click={() => editScheme(scheme)}>
+                Edit scheme
+              </SecondaryButton>
             </div>
           </CollapsibleCard>
         {/if}

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -156,9 +156,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half left">
     <h1 class="govuk-heading-l">Welcome to ATIP v2</h1>
-    <SecondaryButton on:click={() => (showAbout = !showAbout)}
-      >About</SecondaryButton
-    >
+    <SecondaryButton on:click={() => (showAbout = !showAbout)}>
+      About
+    </SecondaryButton>
     {#if pageErrorMessage}
       <ErrorMessage errorMessage={pageErrorMessage} />
     {/if}


### PR DESCRIPTION
The code is much easier to read this way, personally.

See https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting. This can theoretically affect display. I'm combing through the changes in code / on-screen and don't spot any differences, so I think we're fine and this is worth it.