### PR TITLE
Consolidate 3 layer-like controls

### DIFF
--- a/src/lib/Legend.svelte
+++ b/src/lib/Legend.svelte
@@ -6,54 +6,42 @@
   export let schema: Schema;
 </script>
 
-<div>
-  <CollapsibleCard label="Objects" open>
-    <ul>
-      {#if schema == "planning"}
-        <li>
-          <ColorLegend color={colors.preapp} />
-          Preapp
-        </li>
-        <li>
-          <ColorLegend color={colors.outline} />
-          Outline
-        </li>
-        <li>
-          <ColorLegend color={colors["reserved matters"]} />
-          Reserved matters
-        </li>
-        <li>
-          <ColorLegend color={colors["local plan"]} />
-          Local plan
-        </li>
-      {:else}
-        <li>
-          <ColorLegend color={colors.area} />
-          Areas
-        </li>
-        <li>
-          <ColorLegend color={colors.route} />
-          Routes
-        </li>
-        <li>
-          <ColorLegend color={colors.crossing} />
-          Crossings
-        </li>
-        <li>
-          <ColorLegend color={colors.other} />
-          Other
-        </li>
-      {/if}
-    </ul>
-  </CollapsibleCard>
-</div>
-
-<style>
-  div {
-    position: absolute;
-    left: 10px;
-    top: 60px;
-    background-color: white;
-    padding: 16px;
-  }
-</style>
+<CollapsibleCard label="Legend">
+  <ul>
+    {#if schema == "planning"}
+      <li>
+        <ColorLegend color={colors.preapp} />
+        Preapp
+      </li>
+      <li>
+        <ColorLegend color={colors.outline} />
+        Outline
+      </li>
+      <li>
+        <ColorLegend color={colors["reserved matters"]} />
+        Reserved matters
+      </li>
+      <li>
+        <ColorLegend color={colors["local plan"]} />
+        Local plan
+      </li>
+    {:else}
+      <li>
+        <ColorLegend color={colors.area} />
+        Areas
+      </li>
+      <li>
+        <ColorLegend color={colors.route} />
+        Routes
+      </li>
+      <li>
+        <ColorLegend color={colors.crossing} />
+        Crossings
+      </li>
+      <li>
+        <ColorLegend color={colors.other} />
+        Other
+      </li>
+    {/if}
+  </ul>
+</CollapsibleCard>

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -7,7 +7,12 @@
   import { onMount } from "svelte";
   import authoritiesUrl from "../../assets/authorities.geojson?url";
   import BoundaryLayer from "../lib/BoundaryLayer.svelte";
-  import { BaselayerSwitcher, Layout, ZoomOutMap } from "../lib/common";
+  import {
+    BaselayerSwitcher,
+    CollapsibleCard,
+    Layout,
+    ZoomOutMap,
+  } from "../lib/common";
   import HoverLayer from "../lib/draw/HoverLayer.svelte";
   import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
   import Toolbox from "../lib/draw/Toolbox.svelte";
@@ -111,8 +116,6 @@
     <EntireScheme {authorityName} {schema} />
     <hr />
     <InterventionList {schema} />
-    <hr />
-    <ContextualLayers />
   </div>
   <div slot="main">
     <Map {style}>
@@ -120,10 +123,13 @@
       <InterventionLayer {schema} />
       <HoverLayer />
       <Toolbox {routeSnapperUrl} {schema} />
-      <div class="bottom-left">
-        <BaselayerSwitcher {style} />
+      <div class="top-left">
+        <CollapsibleCard label="Layers">
+          <Legend {schema} />
+          <BaselayerSwitcher {style} />
+          <ContextualLayers />
+        </CollapsibleCard>
       </div>
-      <Legend {schema} />
     </Map>
   </div>
 </Layout>
@@ -132,10 +138,10 @@
 <Instructions bind:open={showInstructions} {schema} />
 
 <style>
-  .bottom-left {
+  .top-left {
     position: absolute;
     left: 10px;
-    bottom: 50px;
+    top: 60px;
     background-color: white;
     padding: 16px;
   }

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -19,7 +19,6 @@
   import PmTiles from "../lib/common/PmTiles.svelte";
   import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
   import { CheckboxGroup, ErrorMessage, SecondaryButton } from "../lib/govuk";
-  import Legend from "../lib/Legend.svelte";
   import MapLibreMap from "../lib/Map.svelte";
   import { bbox, emptyGeojson, prettyPrintMeters } from "../maplibre_helpers";
   import { gjScheme, map } from "../stores";
@@ -100,7 +99,6 @@
     <PmTiles />
     <MapLibreMap {style}>
       <InterventionLayer {schema} />
-      <Legend {schema} />
       <MapTooltips
         layers={[
           "interventions-points",


### PR DESCRIPTION
Layer controls are often a map overlay, like in https://www.planning.data.gov.uk/map. We use that today for switching basemaps and showing a legend, but the speed limit layer is smushed into the sidebar for no good reason. Group everything and make the entire overlay hideable.

https://github.com/acteng/atip/assets/1664407/12fe6689-530e-4c73-ad09-7f575a24dfa7

