### PR TITLE
Refactor the scheme browse page

### DIFF
--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { gjScheme } from "../../stores";
+  import CollapsibleCard from "../common/CollapsibleCard.svelte";
+  import FormElement from "../govuk/FormElement.svelte";
+  import SecondaryButton from "../govuk/SecondaryButton.svelte";
+  import Select from "../govuk/Select.svelte";
+  import { type Scheme } from "./data";
+
+  // These are immutable; re-create this component if they change
+  export let schemes: Map<string, Scheme>;
+
+  // by scheme_reference
+  export let showSchemes: Set<string> = new Set();
+
+  let filterText = "";
+
+  // Dropdown filters
+  let authorities: [string, string][] = [];
+  let filterAuthority = "";
+  let fundingProgrammes: [string, string][] = [];
+  let filterFundingProgramme = "";
+
+  // Stats about filtered schemes
+  let counts = { area: 0, route: 0, crossing: 0, other: 0 };
+
+  onMount(() => {
+    let set1 = new Set();
+    let set2 = new Set();
+    for (let x of schemes.values()) {
+      if (x.authority_or_region) {
+        set1.add(x.authority_or_region);
+      }
+      if (x.funding_programme) {
+        set2.add(x.funding_programme);
+      }
+    }
+    authorities = Array.from(set1.entries());
+    authorities.sort();
+    fundingProgrammes = Array.from(set2.entries());
+    fundingProgrammes.sort();
+  });
+
+  // When any filters change, update showSchemes
+  function filtersUpdated(
+    filterText: string,
+    filterAuthority: string,
+    filterFundingProgramme: string
+  ) {
+    showSchemes.clear();
+    let filterNormalized = filterText.toLowerCase();
+    for (let feature of $gjScheme.features) {
+      // TODO This is a very blunt free-form text search of any property in the
+      // feature only, not the scheme.
+      if (
+        filterNormalized &&
+        !JSON.stringify(feature.properties)
+          .toLowerCase()
+          .includes(filterNormalized)
+      ) {
+        continue;
+      }
+      if (filterAuthority || filterFundingProgramme) {
+        let scheme = schemes.get(feature.properties.scheme_reference);
+        if (filterAuthority && scheme.authority_or_region != filterAuthority) {
+          continue;
+        }
+        if (
+          filterFundingProgramme &&
+          scheme.funding_programme != filterFundingProgramme
+        ) {
+          continue;
+        }
+      }
+      showSchemes.add(feature.properties.scheme_reference);
+    }
+    // Make Svelte see the update
+    showSchemes = showSchemes;
+
+    // Hide things on the map, and recalculate stats
+    counts = { area: 0, route: 0, crossing: 0, other: 0 };
+    gjScheme.update((gj) => {
+      for (let feature of gj.features) {
+        if (showSchemes.has(feature.properties.scheme_reference)) {
+          delete feature.properties.hide_while_editing;
+          counts[feature.properties.intervention_type]++;
+        } else {
+          feature.properties.hide_while_editing = true;
+        }
+      }
+      return gj;
+    });
+    counts = counts;
+  }
+  $: filtersUpdated(filterText, filterAuthority, filterFundingProgramme);
+</script>
+
+<CollapsibleCard label="Filters">
+  <Select
+    label="Authority or region"
+    id="filterAuthority"
+    choices={authorities}
+    emptyOption
+    bind:value={filterAuthority}
+  />
+  <Select
+    label="Funding programme"
+    id="filterFundingProgramme"
+    choices={fundingProgrammes}
+    emptyOption
+    bind:value={filterFundingProgramme}
+  />
+  <FormElement label="Any field" id="filterText">
+    <input
+      type="text"
+      class="govuk-input govuk-input--width-10"
+      id="filterText"
+      bind:value={filterText}
+    />
+    <SecondaryButton on:click={() => (filterText = "")}>Clear</SecondaryButton>
+  </FormElement>
+</CollapsibleCard>
+
+<p>
+  Showing {showSchemes.size} schemes ({counts.route} routes, {counts.area} areas,
+  {counts.crossing} crossings, {counts.other} other)
+</p>

--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -25,8 +25,8 @@
   let counts = { area: 0, route: 0, crossing: 0, other: 0 };
 
   onMount(() => {
-    let set1 = new Set();
-    let set2 = new Set();
+    let set1: Set<string> = new Set();
+    let set2: Set<string> = new Set();
     for (let x of schemes.values()) {
       if (x.authority_or_region) {
         set1.add(x.authority_or_region);

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { bbox } from "../../maplibre_helpers";
+  import { gjScheme, map } from "../../stores";
+  import CollapsibleCard from "../common/CollapsibleCard.svelte";
+  import SecondaryButton from "../govuk/SecondaryButton.svelte";
+  import type { Scheme } from "./types";
+
+  export let scheme: Scheme;
+
+  function showScheme() {
+    // TODO Highlight on the map? Or fade everything else?
+    let gj = {
+      type: "FeatureCollection",
+      features: $gjScheme.features.filter(
+        (f) => f.properties.scheme_reference == scheme.scheme_reference
+      ),
+    };
+    $map?.fitBounds(bbox(gj), { padding: 20, animate: false });
+  }
+
+  function editScheme() {
+    let gj = {
+      type: "FeatureCollection",
+      features: $gjScheme.features.filter(
+        (f) => f.properties.scheme_reference == scheme.scheme_reference
+      ),
+    };
+    let filename = scheme.authority_or_region;
+    // Assuming the schema is always v1
+
+    // Put the file in local storage, so it'll be loaded from the next page
+    window.localStorage.setItem(filename, JSON.stringify(gj));
+    window.open(
+      `scheme.html?authority=${scheme.authority_or_region}`,
+      "_blank"
+    );
+  }
+</script>
+
+<CollapsibleCard
+  label={`${scheme.scheme_reference}: ${scheme.num_features} features`}
+>
+  <p>Authority or region: {scheme.authority_or_region}</p>
+  <p>Capital scheme ID: {scheme.capital_scheme_id}</p>
+  <p>Funding programme: {scheme.funding_programme}</p>
+  <div class="govuk-button-group">
+    <SecondaryButton on:click={showScheme}>Show on map</SecondaryButton>
+    <SecondaryButton on:click={editScheme}>Edit scheme</SecondaryButton>
+  </div>
+</CollapsibleCard>

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+  import type { FeatureCollection } from "geojson";
   import { bbox } from "../../maplibre_helpers";
   import { gjScheme, map } from "../../stores";
   import CollapsibleCard from "../common/CollapsibleCard.svelte";
   import SecondaryButton from "../govuk/SecondaryButton.svelte";
-  import type { Scheme } from "./types";
+  import type { Scheme } from "./data";
 
   export let scheme: Scheme;
 
   function showScheme() {
     // TODO Highlight on the map? Or fade everything else?
-    let gj = {
+    let gj: FeatureCollection = {
       type: "FeatureCollection",
       features: $gjScheme.features.filter(
         (f) => f.properties.scheme_reference == scheme.scheme_reference

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -35,17 +35,17 @@ export function processInput(
   }
 
   for (let feature of gj.features) {
-    schemes.get(feature.properties.scheme_reference).num_features++;
+    schemes.get(feature.properties!.scheme_reference).num_features++;
     // Remove extraneous fields from the input. Aside from the v1
     // InterventionProps, there should just be a scheme_reference linking to
     // the top-level dictionary.
-    delete feature.properties.id;
-    delete feature.properties.authority_or_region;
-    delete feature.properties.capital_scheme_id;
-    delete feature.properties.funding_programme;
-    delete feature.properties.valid;
-    delete feature.properties.centroid_lon;
-    delete feature.properties.centroid_lat;
+    delete feature.properties!.id;
+    delete feature.properties!.authority_or_region;
+    delete feature.properties!.capital_scheme_id;
+    delete feature.properties!.funding_programme;
+    delete feature.properties!.valid;
+    delete feature.properties!.centroid_lon;
+    delete feature.properties!.centroid_lat;
   }
 
   return schemes;

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -1,0 +1,44 @@
+import type { FeatureCollection } from "geojson";
+
+export interface Scheme {
+  scheme_reference: string;
+  num_features: number;
+  authority_or_region: string;
+  capital_scheme_id: string;
+  funding_programme: string;
+}
+
+// Takes a GeoJSON file representing a bunch of scheme files combined into one.
+// Cleans up some problems with this input (temporary, until fixed upstream)
+// and returns a list of Schemes. Each feature (intervention) in the GJ links
+// back to one of these schemes by scheme_reference.
+export function processInput(gj: FeatureCollection): Scheme[] {
+  let byScheme = {};
+
+  // Assume the input has a top-level dictionary keyed by scheme_reference
+  for (let [scheme_reference, scheme] of Object.entries(gj.schemes)) {
+    byScheme[scheme_reference] = {
+      scheme_reference,
+      num_features: 0,
+      authority_or_region: scheme.authority_or_region,
+      capital_scheme_id: scheme.capital_scheme_id,
+      funding_programme: scheme.funding_programme,
+    };
+  }
+
+  for (let feature of gj.features) {
+    byScheme[feature.properties.scheme_reference].num_features++;
+    // Remove extraneous fields from the input. Aside from the v1
+    // InterventionProps, there should just be a scheme_reference linking to
+    // the top-level dictionary.
+    delete feature.properties.id;
+    delete feature.properties.authority_or_region;
+    delete feature.properties.capital_scheme_id;
+    delete feature.properties.funding_programme;
+    delete feature.properties.valid;
+    delete feature.properties.centroid_lon;
+    delete feature.properties.centroid_lat;
+  }
+
+  return Object.values(byScheme);
+}

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -1,6 +1,7 @@
 import type { FeatureCollection } from "geojson";
 
-export interface Scheme {
+// This must be filled out in the input file
+interface SchemeData {
   scheme_reference: string;
   num_features: number;
   authority_or_region: string;
@@ -8,12 +9,18 @@ export interface Scheme {
   funding_programme: string;
 }
 
+export interface Scheme extends SchemeData {
+  num_features: number;
+}
+
 // Takes a GeoJSON file representing a bunch of scheme files combined into one.
 // Cleans up some problems with this input (temporary, until fixed upstream) and
 // returns a dictionary of Schemes, keyed (and ordered) by scheme_reference.
 // Each feature (intervention) in the GJ links back to one of these schemes by
 // scheme_reference.
-export function processInput(gj: FeatureCollection): Map<string, Scheme> {
+export function processInput(
+  gj: FeatureCollection & { schemes: { [name: string]: SchemeData } }
+): Map<string, Scheme> {
   let schemes = new Map();
 
   // Assume the input has a top-level dictionary keyed by scheme_reference
@@ -41,6 +48,5 @@ export function processInput(gj: FeatureCollection): Map<string, Scheme> {
     delete feature.properties.centroid_lat;
   }
 
-  window.x = schemes;
   return schemes;
 }

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -9,25 +9,26 @@ export interface Scheme {
 }
 
 // Takes a GeoJSON file representing a bunch of scheme files combined into one.
-// Cleans up some problems with this input (temporary, until fixed upstream)
-// and returns a list of Schemes. Each feature (intervention) in the GJ links
-// back to one of these schemes by scheme_reference.
-export function processInput(gj: FeatureCollection): Scheme[] {
-  let byScheme = {};
+// Cleans up some problems with this input (temporary, until fixed upstream) and
+// returns a dictionary of Schemes, keyed (and ordered) by scheme_reference.
+// Each feature (intervention) in the GJ links back to one of these schemes by
+// scheme_reference.
+export function processInput(gj: FeatureCollection): Map<string, Scheme> {
+  let schemes = new Map();
 
   // Assume the input has a top-level dictionary keyed by scheme_reference
   for (let [scheme_reference, scheme] of Object.entries(gj.schemes)) {
-    byScheme[scheme_reference] = {
+    schemes.set(scheme_reference, {
       scheme_reference,
       num_features: 0,
       authority_or_region: scheme.authority_or_region,
       capital_scheme_id: scheme.capital_scheme_id,
       funding_programme: scheme.funding_programme,
-    };
+    });
   }
 
   for (let feature of gj.features) {
-    byScheme[feature.properties.scheme_reference].num_features++;
+    schemes.get(feature.properties.scheme_reference).num_features++;
     // Remove extraneous fields from the input. Aside from the v1
     // InterventionProps, there should just be a scheme_reference linking to
     // the top-level dictionary.
@@ -40,5 +41,6 @@ export function processInput(gj: FeatureCollection): Scheme[] {
     delete feature.properties.centroid_lat;
   }
 
-  return Object.values(byScheme);
+  window.x = schemes;
+  return schemes;
 }

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Feature, LineString } from "geojson";
+  import { prettyPrintMeters } from "../../maplibre_helpers";
   import { gjScheme, routeInfo } from "../../stores";
   import FormElement from "../govuk/FormElement.svelte";
   import Radio from "../govuk/Radio.svelte";
@@ -12,13 +13,6 @@
   export let intervention_type: "area" | "route" | "crossing" | "other";
   export let description: string;
   export let length_meters: number | undefined;
-
-  function prettyPrintMeters(x: number): string {
-    if (x < 1000.0) {
-      return Math.round(x) + " m";
-    }
-    return (x / 1000.0).toFixed(1) + "km";
-  }
 
   // Sets the intervention name to "From {road1 and road2} to {road3 and
   // road4}". Only meant to be useful for routes currently.

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -215,6 +215,13 @@ export function bbox(gj: GeoJSON): [number, number, number, number] {
   return turfBbox(gj) as [number, number, number, number];
 }
 
+export function prettyPrintMeters(x: number): string {
+  if (x < 1000.0) {
+    return Math.round(x) + " m";
+  }
+  return (x / 1000.0).toFixed(1) + "km";
+}
+
 // Properties are guaranteed to exist
 export type FeatureWithProps<G extends Geometry> = Feature<G> & {
   properties: { [name: string]: any };

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // @ts-ignore no declarations
   import { initAll } from "govuk-frontend";
   import "../style/main.css";
   import { onDestroy, onMount } from "svelte";
@@ -15,8 +16,9 @@
   import Legend from "../lib/Legend.svelte";
   import MapLibreMap from "../lib/Map.svelte";
   import ZoomOutMap from "../lib/ZoomOutMap.svelte";
-  import { bbox, prettyPrintMeters } from "../maplibre_helpers";
+  import { bbox, emptyGeojson, prettyPrintMeters } from "../maplibre_helpers";
   import { gjScheme, map } from "../stores";
+  import type { Scheme as GjScheme } from "../types";
 
   onMount(() => {
     // For govuk components. Must happen here.
@@ -29,10 +31,10 @@
   let errorMessage = "";
 
   let schemes: Map<string, Scheme> = new Map();
-  let showSchemes: Set<string> = new Set();
+  let schemesToBeShown: Set<string> = new Set();
 
   onDestroy(() => {
-    gjScheme.set(null);
+    gjScheme.set(emptyGeojson() as GjScheme);
   });
 
   function loadFile(text: string) {
@@ -78,12 +80,12 @@
     <FileInput label="Load from GeoJSON" id="load-geojson" {loadFile} />
 
     {#if schemes.size > 0}
-      <Filters {schemes} bind:showSchemes />
+      <Filters {schemes} bind:schemesToBeShown />
     {/if}
 
     <ul>
       {#each schemes.values() as scheme}
-        {#if showSchemes.has(scheme.scheme_reference)}
+        {#if schemesToBeShown.has(scheme.scheme_reference)}
           <SchemeCard {scheme} />
         {/if}
       {/each}

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { initAll } from "govuk-frontend";
   import "../style/main.css";
-  import type { GeoJSON } from "geojson";
   import { onDestroy, onMount } from "svelte";
   import BaselayerSwitcher from "../lib/BaselayerSwitcher.svelte";
   import { processInput, type Scheme } from "../lib/browse/data";

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface InterventionProps {
   v2?: Intervention;
   criticals?: CriticalIssue;
   atf4?: ATF4Intervention;
+  // An extra field present in input for the browse schemes page only
+  scheme_reference?: string;
 
   // Temporary state, not meant to be serialized
   hide_while_editing?: boolean;


### PR DESCRIPTION
#173. This splits the monolithic Svelte component with TS checks disabled into a few logical components, and fixes all TS errors. Not much behavioral change yet, other than simplifying the map tooltips to only show the meaningful fields.