### PR TITLE
Enable TS strict mode and enforce it with GH actions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Run Playwright tests
       run: npm test
 
+    - name: Run type-checker
+      run: npm run check
+
     - uses: actions/upload-artifact@v3
       with:
         name: playwright-report

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { LineString, Polygon } from "geojson";
+  import type { LineString, Point, Polygon } from "geojson";
   import { MapMouseEvent } from "maplibre-gl";
   import type { FeatureWithProps } from "../../maplibre_helpers";
   import { currentMode, gjScheme, map, mapHover } from "../../stores";
@@ -250,7 +250,10 @@
   }
 
   // Copy geometry and properties from source to destination
-  function updateFeature(destination, source) {
+  function updateFeature(
+    destination: FeatureUnion,
+    source: FeatureWithProps<Point | LineString | Polygon>
+  ) {
     destination.geometry = source.geometry;
 
     // Copy properties that may come from routeTool. Not all tools or cases

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -55,17 +55,19 @@
     "street-view": new EventHandler(),
   };
 
-  MapEvents.forEach((eventName) => {
+  for (let eventName of MapEvents) {
     $map.on(eventName, (event) => {
+      // @ts-ignore TODO Can't express that MapEvents are the keys
       eventHandlers[get(currentMode)].mapHandlers[eventName](event);
     });
-  });
+  }
 
-  DocumentEvents.forEach((eventName) => {
+  for (let eventName of DocumentEvents) {
     document.addEventListener(eventName, (event) => {
+      // @ts-ignore TODO Can't express that DocumentEvents are the keys
       eventHandlers[get(currentMode)].documentHandlers[eventName](event);
     });
-  });
+  }
 
   // This must be used; don't manually change mode
   function changeMode(newMode: Mode) {
@@ -96,17 +98,19 @@
     polygonTool?.tearDown();
     routeTool?.tearDown();
 
-    MapEvents.forEach((eventName) => {
+    for (let eventName of MapEvents) {
       $map.off(eventName, (event) => {
+        // @ts-ignore TODO Can't express that MapEvents are the keys
         eventHandlers[get(currentMode)].mapHandlers[eventName](event);
       });
-    });
+    }
 
-    DocumentEvents.forEach((eventName) => {
+    for (let eventName of DocumentEvents) {
       document.removeEventListener(eventName, (event) => {
+        // @ts-ignore TODO Can't express that DocumentEvents are the keys
         eventHandlers[get(currentMode)].documentHandlers[eventName](event);
       });
-    });
+    }
   });
 </script>
 

--- a/src/lib/draw/common.ts
+++ b/src/lib/draw/common.ts
@@ -7,11 +7,11 @@ import type { FeatureUnion, Mode } from "../../types";
 interface Tool {
   addEventListenerSuccess(
     callback: (f: FeatureWithProps<LineString | Polygon>) => void
-  );
+  ): void;
   addEventListenerUpdated(
     callback: (f: FeatureWithProps<LineString | Polygon>) => void
-  );
-  addEventListenerFailure(callback: () => void);
+  ): void;
+  addEventListenerFailure(callback: () => void): void;
 }
 
 // unsavedFeature is nested in an object, so pass-by-reference works
@@ -59,7 +59,7 @@ export function handleUnsavedFeature(
 ) {
   if (unsavedFeature.value) {
     gjScheme.update((gj) => {
-      let feature = unsavedFeature.value;
+      let feature = unsavedFeature.value!;
       feature.id = newFeatureId(gj);
       feature.properties.intervention_type = intervention_type;
       gj.features.push(feature as FeatureUnion);

--- a/src/lib/draw/event_handler.ts
+++ b/src/lib/draw/event_handler.ts
@@ -13,6 +13,22 @@ export const MapEvents = [
 export const DocumentEvents = ["keypress", "keyup", "keydown"];
 
 export class EventHandler {
+  mapHandlers: {
+    click: (e: MapMouseEvent) => void;
+    dblclick: (e: MapMouseEvent) => void;
+    mousemove: (e: MapMouseEvent) => void;
+    mousedown: (e: MapMouseEvent) => void;
+    mouseup: (e: MapMouseEvent) => void;
+    mouseout: (e: MapMouseEvent) => void;
+    dragstart: (e: MapMouseEvent) => void;
+  };
+
+  documentHandlers: {
+    keypress: (e: KeyboardEvent) => void;
+    keyup: (e: KeyboardEvent) => void;
+    keydown: (e: KeyboardEvent) => void;
+  };
+
   constructor() {
     this.mapHandlers = {
       click: (e: MapMouseEvent) => {},
@@ -29,20 +45,4 @@ export class EventHandler {
       keydown: (e: KeyboardEvent) => {},
     };
   }
-
-  mapHandlers: {
-    click: (e: MapMouseEvent) => void;
-    dblclick: (e: MapMouseEvent) => void;
-    mousemove: (e: MapMouseEvent) => void;
-    mousedown: (e: MapMouseEvent) => void;
-    mouseup: (e: MapMouseEvent) => void;
-    mouseout: (e: MapMouseEvent) => void;
-    dragstart: (e: MapMouseEvent) => void;
-  };
-
-  documentHandlers: {
-    keypress: (e: KeyboardEvent) => void;
-    keyup: (e: KeyboardEvent) => void;
-    keydown: (e: KeyboardEvent) => void;
-  };
 }

--- a/src/lib/govuk/TextInput.svelte
+++ b/src/lib/govuk/TextInput.svelte
@@ -2,7 +2,7 @@
   import FormElement from "./FormElement.svelte";
 
   export let label: string;
-  export let value: string;
+  export let value: string | undefined;
 
   // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
 </script>

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -27,7 +27,7 @@
         (f) => f.id == id
       ) as Feature<LineString>;
       let raw = await $routeInfo!.renderLaneDetailsForRoute(
-        linestring.properties.waypoints
+        linestring.properties.waypoints!
       );
       gj1 = JSON.parse(raw[0]);
       gj2 = JSON.parse(raw[1]);

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -79,7 +79,7 @@
           (f) => f.id == id
         ) as Feature<LineString>;
         let gj = JSON.parse(
-          await $routeInfo!.speedLimitForRoute(linestring.properties.waypoints)
+          await $routeInfo!.speedLimitForRoute(linestring.properties.waypoints!)
         );
         ($map.getSource(source) as GeoJSONSource).setData(gj);
       } else {

--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -17,8 +17,11 @@
       return feature.properties.planning?.name || "Untitled polygon";
     }
     if (schema == "v2") {
+      // TODO Revisit auto-generated enum types
       return (
+        // @ts-ignore
         feature.properties.v2?.Route?.name ||
+        // @ts-ignore
         feature.properties.v2?.Crossing?.name ||
         "Untitled intervention"
       );

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // @ts-ignore no declarations
   import { initAll } from "govuk-frontend";
   import "../style/main.css";
   import * as Comlink from "comlink";

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import "../style/main.css";
   import type { FeatureCollection } from "geojson";
+  // @ts-ignore no declarations
   import { initAll } from "govuk-frontend";
   import { Map } from "maplibre-gl";
   import { onMount } from "svelte";
@@ -26,13 +27,13 @@
   let authoritySet: Set<string> = new Set();
   $: validEntry = authoritySet.has(inputValue);
 
-  let map: Map | null = null;
+  let loadedMap: Map | null = null;
   let source = "boundary";
   let layer = "boundary-layer";
 
   let showBoundaries: "TA" | "LAD" = "TA";
   function changeBoundaries() {
-    map?.setFilter(layer, ["==", ["get", "level"], showBoundaries]);
+    loadedMap?.setFilter(layer, ["==", ["get", "level"], showBoundaries]);
   }
   let hoveredBoundary: string | null = null;
 
@@ -48,11 +49,13 @@
       authoritySet.add(feature.properties!.name);
     }
 
-    map = new Map({
+    let map = new Map({
       container: "map",
       style:
         "https://api.maptiler.com/maps/streets/style.json?key=MZEJTanw3WpxRvt7qDfo",
     });
+    // Use map within onMount, so it's guaranteed to exist
+    loadedMap = map;
 
     let hoverId: number | null = null;
     function unhover() {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -11,7 +11,8 @@ import {
 import { type RouteInfo } from "./worker";
 
 // A global singleton, containing a loaded map
-// TODO | null. When we enable strictNullChecks, this'll become a problem
+// @ts-ignore TODO By construction, no components using the store should be
+// mounted before this is populated.
 export const map: Writable<Map> = writable(null);
 
 // A global singleton, with a RouteInfo web worker. It's null before it's loaded.

--- a/tests/savefiles.spec.ts
+++ b/tests/savefiles.spec.ts
@@ -1,12 +1,13 @@
 import { readFile } from "fs/promises";
 import { expect, test, type Page } from "@playwright/test";
+import type { FeatureCollection } from "geojson";
 import {
   clearExistingInterventions,
   loadInitialPageFromBrowser,
 } from "./shared.js";
 
 let page: Page;
-let json;
+let json: FeatureCollection;
 
 test.beforeAll(async ({ browser }) => {
   page = await loadInitialPageFromBrowser(browser);
@@ -38,7 +39,9 @@ test("loading a file with length displays the length", async () => {
 // property. Upload a file with that missing, and make sure it's backfilled.
 test("loading a file without length displays the length", async () => {
   // Remove the property from the test data first
-  await expect(Math.round(json.features[0].properties.length_meters)).toBe(450);
+  await expect(Math.round(json.features[0].properties!.length_meters)).toBe(
+    450
+  );
   let copy = JSON.parse(JSON.stringify(json));
   delete copy.features[0].properties.length_meters;
   let uploadFile = JSON.stringify(copy);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "checkJs": true,
     "isolatedModules": true,
     "types": ["node", "vite/client"],
-    "strict": false,
+    "strict": true,
     /* Necessary for Playwright tests */
     "allowImportingTsExtensions": true,
     "noUnusedLocals": true


### PR DESCRIPTION
Closes #89.

In recent PRs, there have been some simple errors that TS would've caught, but we're not enforcing checks yet. My goal here is to catch new problems with as many compile-time warnings as possible. There are still some difficult cases for us to fix, but we can `@ts-ignore` them and treat them as TODOs.