### PR TITLE
Some usability improvements for browse page

### DIFF
--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -12,7 +12,8 @@
   // by scheme_reference
   export let schemesToBeShown: Set<string> = new Set();
 
-  let filterText = "";
+  // Read-only, so callers can highlight search terms
+  export let filterText = "";
 
   // Dropdown filters
   let authorities: [string, string][] = [];
@@ -127,7 +128,7 @@
     emptyOption
     bind:value={filterFundingProgramme}
   />
-  <FormElement label="Name or description" id="filterText">
+  <FormElement label="Intervention name or description" id="filterText">
     <input
       type="text"
       class="govuk-input govuk-input--width-10"

--- a/src/lib/browse/OptionalLayer.svelte
+++ b/src/lib/browse/OptionalLayer.svelte
@@ -33,7 +33,7 @@
     opacity: 0.8,
   });
 
-  let show = true;
+  let show = false;
   $: {
     if ($map.getLayer(name)) {
       $map.setLayoutProperty(name, "visibility", show ? "visible" : "none");

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -7,6 +7,12 @@
   import type { Scheme } from "./data";
 
   export let scheme: Scheme;
+  export let authorityNames: Set<string>;
+
+  let disableEdit = !authorityNames.has(scheme.authority_or_region);
+  let editTooltip = disableEdit
+    ? "This scheme doesn't have an authority specified correctly, so you can't edit this scheme. We're working to fix this problem."
+    : undefined;
 
   function showScheme() {
     // TODO Highlight on the map? Or fade everything else?
@@ -46,6 +52,12 @@
   <p>Funding programme: {scheme.funding_programme}</p>
   <div class="govuk-button-group">
     <SecondaryButton on:click={showScheme}>Show on map</SecondaryButton>
-    <SecondaryButton on:click={editScheme}>Edit scheme</SecondaryButton>
+    <SecondaryButton
+      on:click={editScheme}
+      disabled={disableEdit}
+      title={editTooltip}
+    >
+      Edit scheme locally
+    </SecondaryButton>
   </div>
 </CollapsibleCard>

--- a/src/lib/common/data_getter.ts
+++ b/src/lib/common/data_getter.ts
@@ -1,8 +1,9 @@
-import type { FeatureCollection } from "geojson";
+import type { FeatureCollection, Polygon } from "geojson";
 import authoritiesUrl from "../../../assets/authorities.geojson?url";
 
-export async function getAuthoritiesGeoJson(): Promise<FeatureCollection> {
+export async function getAuthoritiesGeoJson(): Promise<
+  FeatureCollection<Polygon>
+> {
   const resp = await fetch(authoritiesUrl);
-  const body = await resp.text();
-  return JSON.parse(body);
+  return await resp.json();
 }

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -5,7 +5,6 @@
   import * as Comlink from "comlink";
   import type { FeatureCollection, Polygon } from "geojson";
   import { onMount } from "svelte";
-  import authoritiesUrl from "../../assets/authorities.geojson?url";
   import BoundaryLayer from "../lib/BoundaryLayer.svelte";
   import {
     BaselayerSwitcher,
@@ -13,6 +12,7 @@
     Layout,
     ZoomOutMap,
   } from "../lib/common";
+  import { getAuthoritiesGeoJson } from "../lib/common/data_getter";
   import HoverLayer from "../lib/draw/HoverLayer.svelte";
   import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
   import Toolbox from "../lib/draw/Toolbox.svelte";
@@ -84,9 +84,7 @@
   });
 
   async function loadAuthorityBoundary(): Promise<FeatureCollection<Polygon>> {
-    const resp = await fetch(authoritiesUrl);
-    const body = await resp.text();
-    const geojson: FeatureCollection<Polygon> = JSON.parse(body);
+    let geojson = await getAuthoritiesGeoJson();
     geojson.features = geojson.features.filter(
       (feature) => feature.properties?.name == authorityName
     );

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -36,6 +36,7 @@
 
   let schemes: Map<string, Scheme> = new Map();
   let schemesToBeShown: Set<string> = new Set();
+  let filterText = "";
 
   onDestroy(() => {
     gjScheme.set(emptyGeojson() as GjScheme);
@@ -57,15 +58,28 @@
   function tooltip(props: { [name: string]: any }): string {
     // TODO Move into a Svelte component, so we don't have to awkwardly build up HTML like this
     var html = `<div class="govuk-prose" style="max-width: 30vw;">`;
-    html += `<h2>${props.name} (${props.intervention_type})</h2>`;
+    html += `<h2>${highlightFilter(props.name)} (${
+      props.intervention_type
+    })</h2>`;
     html += `<p>Scheme reference: ${props.scheme_reference}</p>`;
     if (props.length_meters) {
       html += `<p>Length: ${prettyPrintMeters(props.length_meters)}</p>`;
     }
     if (props.description) {
-      html += `<p>${props.description}</p>`;
+      html += `<p>${highlightFilter(props.description)}</p>`;
     }
     return html;
+  }
+
+  // When the user is filtering name/description by freeform text, highlight the matching pieces.
+  function highlightFilter(input: string): string {
+    if (!filterText) {
+      return input;
+    }
+    return input.replace(
+      new RegExp(filterText, "gi"),
+      (match) => `<mark>${match}</mark>`
+    );
   }
 </script>
 
@@ -84,7 +98,7 @@
     <FileInput label="Load from GeoJSON" id="load-geojson" {loadFile} />
 
     {#if schemes.size > 0}
-      <Filters {schemes} bind:schemesToBeShown />
+      <Filters {schemes} bind:schemesToBeShown bind:filterText />
     {/if}
 
     <ul>


### PR DESCRIPTION
First off, our free-form text filter is confusing before this PR. If you search for "school", you see things on the map that just happen to be in the same scheme that mentions schools. This PR changes it so that you _only_ see interventions mentioning that word. And to make that clear, highlight the search result in the popup.

Second, I flipped the optional layers to be disabled by default. We can revisit this as we have more of them and understand how they're used, but at the moment, I think they're a distraction when loading scheme data.

Third, the "edit on map" button is disabled when the authority name is incorrect, so people don't even click and later get an error. I'd very much like to fix the root cause here and rebuild the all-scheme dataset from its original input, but this is a stop-gap.

https://github.com/acteng/atip/assets/1664407/2d117def-87f4-49f2-8706-80646c9a1912

