### PR TITLE
Generate random data for the scheme browse page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@turf/bbox": "^6.5.0",
+        "@turf/boolean-contains": "^6.5.0",
         "@turf/boolean-point-in-polygon": "^6.5.0",
         "@turf/helpers": "^6.5.0",
         "@turf/length": "^6.5.0",
@@ -16,6 +17,7 @@
         "@turf/line-split": "^6.5.0",
         "@turf/mask": "^6.5.0",
         "@turf/nearest-point-on-line": "^6.5.0",
+        "@turf/random": "^6.5.0",
         "@types/geojson": "^7946.0.10",
         "comlink": "^4.4.1",
         "govuk-frontend": "^4.6.0",
@@ -1082,10 +1084,37 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/boolean-contains": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.5.0.tgz",
+      "integrity": "sha512-4m8cJpbw+YQcKVGi8y0cHhBUnYT+QRfx6wzM4GI1IdtYH3p4oh/DOBJKrepQyiDzFDaNIjxuWXBh0ai1zVwOQQ==",
+      "dependencies": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/boolean-point-on-line": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/boolean-point-in-polygon": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
       "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.5.0.tgz",
+      "integrity": "sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==",
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/invariant": "^6.5.0"
@@ -1246,6 +1275,17 @@
         "@turf/invariant": "^6.5.0",
         "@turf/line-intersect": "^6.5.0",
         "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-6.5.0.tgz",
+      "integrity": "sha512-8Q25gQ/XbA7HJAe+eXp4UhcXM9aOOJFaxZ02+XSNwMvY8gtWSCBLVqRcW4OhqilgZ8PeuQDWgBxeo+BIqqFWFQ==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
       },
       "funding": {
         "url": "https://opencollective.com/turf"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "npx playwright test",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "generate-schema-ts": "for x in v2 planning criticals atf4; do npx ts-node --project tsconfig_tsnode.json --esm src/lib/forms/generate_ts.ts src/schemas/$x.json > src/schemas/$x.ts; done",
-    "setup-govuk": "sass src/style/main.sass src/style/main.css; rm -rf public/assets; mkdir -p public/assets; cp -R node_modules/govuk-frontend/govuk/assets/ public/"
+    "setup-govuk": "sass src/style/main.sass src/style/main.css; rm -rf public/assets; mkdir -p public/assets; cp -R node_modules/govuk-frontend/govuk/assets/ public/",
+    "generate-random-schemes": "npx ts-node --project tsconfig_tsnode.json --esm src/random_schemes.ts"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
@@ -33,6 +34,7 @@
   },
   "dependencies": {
     "@turf/bbox": "^6.5.0",
+    "@turf/boolean-contains": "^6.5.0",
     "@turf/boolean-point-in-polygon": "^6.5.0",
     "@turf/helpers": "^6.5.0",
     "@turf/length": "^6.5.0",
@@ -40,6 +42,7 @@
     "@turf/line-split": "^6.5.0",
     "@turf/mask": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.5.0",
+    "@turf/random": "^6.5.0",
     "@types/geojson": "^7946.0.10",
     "comlink": "^4.4.1",
     "govuk-frontend": "^4.6.0",

--- a/src/random_schemes.ts
+++ b/src/random_schemes.ts
@@ -1,0 +1,119 @@
+// This script generates random sample data for input to the scheme browse page.
+// Note the random seed can't be set; this is non-deterministic.
+
+import * as fs from "fs";
+import turfBbox from "@turf/bbox";
+import booleanContains from "@turf/boolean-contains";
+import { lineString, point, polygon } from "@turf/helpers";
+import length from "@turf/length";
+import { randomPoint } from "@turf/random";
+import type {
+  Feature,
+  FeatureCollection,
+  LineString,
+  Polygon,
+  Position,
+} from "geojson";
+
+main();
+
+function main() {
+  let gj: FeatureCollection & { schemes: { [name: string]: any } } = {
+    type: "FeatureCollection",
+    features: [],
+    schemes: {},
+  };
+
+  let authorities = JSON.parse(
+    fs.readFileSync("assets/authorities.geojson", { encoding: "utf8" })
+  );
+
+  let count = 0;
+  for (let authority of authorities.features) {
+    let scheme_reference = `ATE${count}`;
+    count++;
+    gj.schemes[scheme_reference] = {
+      authority_or_region: authority.properties.name,
+      capital_scheme_id: count,
+      funding_programme: pickRandom(["ATF2", "ATF3", "ATF4"]),
+    };
+
+    // Make a few interventions for every authority
+
+    let pt = point(makePoints(authority.geometry, 1)[0]);
+    pt.properties!.scheme_reference = scheme_reference;
+    if (Math.random() < 0.5) {
+      pt.properties!.intervention_type = "crossing";
+      pt.properties!.name = pickRandom([
+        "New crossing",
+        "Upgrade existing crossing",
+      ]);
+      pt.properties!.description = pickRandom([
+        "Zebra",
+        "Toucan",
+        "Signalized",
+      ]);
+    } else {
+      pt.properties!.intervention_type = "other";
+      pt.properties!.name = pickRandom([
+        "Street lighting",
+        "Improve drainage",
+        "Repair damaged surface",
+      ]);
+    }
+    gj.features.push(pt);
+
+    let route = makeLineString(authority.geometry);
+    route.properties!.scheme_reference = scheme_reference;
+    route.properties!.intervention_type = "route";
+    route.properties!.length_meters =
+      length(route, { units: "kilometers" }) * 1000.0;
+    route.properties!.name = pickRandom(["School street", "Route from X to Y"]);
+    route.properties!.description = pickRandom([
+      "Bidirectional segregated",
+      "Shared use with segregation",
+      "Stepped cycle-track on the north side only",
+    ]);
+    gj.features.push(route);
+
+    let area = makePolygon(authority.geometry);
+    area.properties!.scheme_reference = scheme_reference;
+    area.properties!.intervention_type = "area";
+    area.properties!.name = pickRandom([
+      "Area-wide traffic management",
+      "Lighting improvements",
+      "New cycle hangars",
+    ]);
+    gj.features.push(area);
+  }
+
+  fs.writeFileSync("random_schemes.geojson", JSON.stringify(gj));
+}
+
+function makePoints(boundary: Feature<Polygon>, count: number): Position[] {
+  let points = [];
+  let bbox = turfBbox(boundary);
+  while (points.length < count) {
+    let pt = randomPoint(1, { bbox }).features[0];
+    if (booleanContains(boundary, pt)) {
+      points.push(pt.geometry.coordinates);
+    }
+  }
+  return points;
+}
+
+function makeLineString(boundary: Feature<Polygon>): Feature<LineString> {
+  // turf's randomLineString picks really tiny lengths
+  let points = makePoints(boundary, 2);
+  return lineString([points[0], points[1]]);
+}
+
+function makePolygon(boundary: Feature<Polygon>): Feature<Polygon> {
+  // turf's randomPolygon produces tiny areas
+  let points = makePoints(boundary, 3);
+  return polygon([[points[0], points[1], points[2], points[0]]]);
+}
+
+function pickRandom<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}


### PR DESCRIPTION
Just a quick script to churn out vaguely sensible looking example data. We can use this to explore GCP deployment in the short-term, performance-test the browse page, take videos for GH pull requests, etc.

https://github.com/acteng/atip/assets/1664407/b4fb9751-eb23-40d1-b2bd-1bd33d788be4

