### PR TITLE
Add a layer showing bus routes with and without bus lanes

### DIFF
--- a/src/lib/browse/BusRoutesLayerControl.svelte
+++ b/src/lib/browse/BusRoutesLayerControl.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import {
+    hoveredToggle,
+    overwriteLineLayer,
+    overwritePmtilesSource,
+  } from "../../maplibre_helpers";
+  import { map } from "../../stores";
+  import {
+    ColorLegend,
+    ExternalLink,
+    HelpButton,
+    InteractiveLayer,
+  } from "../common";
+  import { Checkbox } from "../govuk";
+  import { colors } from "./colors";
+
+  let name = "bus_routes";
+
+  overwritePmtilesSource(
+    $map,
+    name,
+    `https://atip.uk/layers/v1/${name}.pmtiles`
+  );
+
+  overwriteLineLayer($map, {
+    id: name,
+    source: name,
+    sourceLayer: name,
+    color: [
+      "case",
+      ["boolean", ["get", "has_bus_lane"], false],
+      colors.bus_route_with_lane,
+      colors.bus_route_without_lane,
+    ],
+    width: 5,
+    opacity: hoveredToggle(0.5, 1.0),
+  });
+
+  let show = false;
+
+  function tooltip(feature: MapGeoJSONFeature): string {
+    if (feature.properties.has_bus_lane) {
+      return "<p>At least one bus route crosses here, with a bus lane in one or more directions</p>";
+    } else {
+      return "<p>At least one bus route crosses here, without any bus lanes</p>";
+    }
+  }
+</script>
+
+<Checkbox id={name} bind:checked={show}>
+  <ColorLegend color={colors.bus_route_with_lane} />
+  Bus routes
+  <span slot="right">
+    <HelpButton>
+      <p>
+        This shows all roads with at least one bus route crossing them. It also
+        shows whether the road has a bus lane or not.
+      </p>
+      <p>
+        Note this data is from OpenStreetMap, not <ExternalLink
+          href="https://gtfs.org"
+        >
+          GTFS
+        </ExternalLink>, and doesn't include which routes are run or the
+        frequency of service.
+      </p>
+      <p>
+        License: <ExternalLink href="https://www.openstreetmap.org/copyright">
+          Open Data Commons Open Database License
+        </ExternalLink>
+      </p>
+    </HelpButton>
+  </span>
+</Checkbox>
+
+<InteractiveLayer layer={name} {tooltip} {show} clickable={false} />

--- a/src/lib/browse/colors.ts
+++ b/src/lib/browse/colors.ts
@@ -10,6 +10,8 @@ export const colors = {
   combined_authorities: "cyan",
   local_authority_districts: "orange",
   local_planning_authorities: "red",
+  bus_route_with_lane: "#9362BA",
+  bus_route_without_lane: "#C2A6D8",
 
   // Color ramp from https://www.ons.gov.uk/census/maps/choropleth
   sequential_low_to_high: [

--- a/src/maplibre_helpers.ts
+++ b/src/maplibre_helpers.ts
@@ -296,6 +296,7 @@ const layerZorder = [
   "hospitals",
   "sports_spaces",
   "mrn",
+  "bus_routes",
   "railway_stations",
 
   // Polygons are bigger than lines, which're bigger than points. When geometry

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -4,6 +4,7 @@
   import "../style/main.css";
   import type { MapGeoJSONFeature } from "maplibre-gl";
   import { onDestroy, onMount } from "svelte";
+  import BusRoutesLayerControl from "../lib/browse/BusRoutesLayerControl.svelte";
   import CensusOutputAreaLayerControl from "../lib/browse/CensusOutputAreaLayerControl.svelte";
   import CombinedAuthoritiesLayerControl from "../lib/browse/CombinedAuthoritiesLayerControl.svelte";
   import { processInput, type Scheme } from "../lib/browse/data";
@@ -164,6 +165,7 @@
           <CollapsibleCard label="Road network">
             <CheckboxGroup small>
               <MrnLayerControl />
+              <BusRoutesLayerControl />
             </CheckboxGroup>
           </CollapsibleCard>
           <CollapsibleCard label="Boundaries">


### PR DESCRIPTION
Demo at https://acteng.github.io/atip/bus_routes/browse.html

Two colors and a tooltip to indicate if each road involving some bus route has a dedicated lane or not. Not attempting yet to show _direction_ of the bus lane. We could consider arrows or lines clearly on the left or right side of a road to do this in the future, or even showing a full-blown schematic like streetmix.net or osm2streets.org on hover.

The line width is kind of thick and awkward at low zooms. Existing problem with MRN too; might followup with a separate PR and try out changing width based on zoom level.