### PR TITLE
Add a vehicle counts layer. #318

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -17,6 +17,7 @@
   import RailwayStationsLayerControl from "./layers/RailwayStationsLayerControl.svelte";
   import SchoolsLayerControl from "./layers/SchoolsLayerControl.svelte";
   import SportsSpacesLayerControl from "./layers/SportsSpacesLayerControl.svelte";
+  import VehicleCountsLayerControl from "./layers/VehicleCountsLayerControl.svelte";
   import WardsLayerControl from "./layers/WardsLayerControl.svelte";
 
   export let style: string;
@@ -60,6 +61,9 @@
   <CollapsibleCard label="Census">
     <CensusOutputAreaLayerControl />
     <ImdLayerControl />
+  </CollapsibleCard>
+  <CollapsibleCard label="Other">
+    <VehicleCountsLayerControl />
   </CollapsibleCard>
   <StreetViewController
     bind:this={streetViewController}

--- a/src/lib/browse/layers/VehicleCountsLayerControl.svelte
+++ b/src/lib/browse/layers/VehicleCountsLayerControl.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "../../../stores";
+  import { ExternalLink, HelpButton, InteractiveLayer } from "../../common";
+  import { Checkbox } from "../../govuk";
+  import {
+    makeColorRamp,
+    overwriteCircleLayer,
+    overwritePmtilesSource,
+  } from "../../maplibre";
+  import { colors } from "../colors";
+  import SequentialLegend from "./SequentialLegend.svelte";
+
+  let name = "vehicle_counts";
+
+  let colorScale = colors.sequential_low_to_high;
+  // Manual buckets for motor_vehicles_2022, which max out at 205,000
+  let limits = [0, 40000, 80000, 120000, 160000, 205000];
+  // Remove some because there's not much width
+  let describeLimits = ["", "40k", "80k", "120k", "160k", ""];
+
+  overwritePmtilesSource(
+    $map,
+    name,
+    `https://atip.uk/layers/v1/${name}.pmtiles`
+  );
+
+  overwriteCircleLayer($map, {
+    id: name,
+    source: name,
+    sourceLayer: name,
+    color: makeColorRamp(["get", "motor_vehicles_2022"], limits, colorScale),
+    opacity: 0.9,
+    radius: 15,
+    strokeColor: "black",
+    strokeWidth: 3,
+  });
+
+  let show = false;
+
+  function tooltip(feature: MapGeoJSONFeature): string {
+    let x = `<h2>${feature.properties.location}</h2>`;
+    x += `<p>Total motor vehicles (2022 AADF): <b>${feature.properties.motor_vehicles_2022.toLocaleString()}</b></p>`;
+    x += `<p>Total pedal cycles (2022 AADF): <b>${feature.properties.pedal_cycles_2022.toLocaleString()}</b></p>`;
+    x += `<p>Count method: <b>${feature.properties.method}</b></p>`;
+    return x;
+  }
+
+  function onClick(e: CustomEvent<MapGeoJSONFeature>) {
+    window.open(
+      `https://roadtraffic.dft.gov.uk/manualcountpoints/${e.detail.properties.count_point}`,
+      "_blank"
+    );
+  }
+</script>
+
+<Checkbox id={name} bind:checked={show}>
+  Vehicle counts
+  <span slot="right">
+    <HelpButton>
+      <p>
+        2022 AADF (annual average daily flow) data from <ExternalLink
+          href="https://roadtraffic.dft.gov.uk/downloads"
+        >
+          DfT road statistics
+        </ExternalLink>. This counts the total daily number of vehicles
+        traveling past a count point (in both directions) on an average day of
+        the year. See <ExternalLink
+          href="https://storage.googleapis.com/dft-statistics/road-traffic/all-traffic-data-metadata.pdf"
+        >
+          methodology
+        </ExternalLink> for details and caveats about the measurements.
+      </p>
+      <p>
+        The colors show motor vehicles AADF, not pedal cycles. Click a point for
+        full data.
+      </p>
+      <p>
+        License: <ExternalLink
+          href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        >
+          Open Government License
+        </ExternalLink>
+      </p>
+    </HelpButton>
+  </span>
+</Checkbox>
+{#if show}
+  <SequentialLegend {colorScale} limits={describeLimits} />
+{/if}
+
+<InteractiveLayer layer={name} {tooltip} {show} clickable on:click={onClick} />

--- a/src/lib/maplibre/utils.ts
+++ b/src/lib/maplibre/utils.ts
@@ -320,6 +320,7 @@ const layerZorder = [
   "railway_stations",
   "cycle_parking",
   "cycle_paths",
+  "vehicle_counts",
 
   // Polygons are bigger than lines, which're bigger than points. When geometry
   // overlaps, put the smaller thing on top


### PR DESCRIPTION
Demo: https://acteng.github.io/atip/vehicle_counts/browse.html

https://github.com/acteng/atip/assets/1664407/2f8c5780-dcdb-4a95-9055-177f21ffe024

This should be enough to start, but plenty of next steps:
- icons instead of points
- display all points when unzoomed (or at least some kind of clustering or heatmap to indicate where the points are)
- adjust the buckets -- not seeing the higher values much