### PR TITLE
Disable route info layers (lane details and speed limits) on the sket…

### DIFF
--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -3,7 +3,6 @@
   import { gjScheme, routeInfo } from "../../stores";
   import { FormElement, Radio, SecondaryButton, TextArea } from "../govuk";
   import { prettyPrintMeters } from "../maplibre";
-  import RouteInfoLayers from "./RouteInfoLayers.svelte";
 
   export let id: number;
   export let name: string;
@@ -52,5 +51,4 @@
 
 {#if length_meters}
   <p>Length: {prettyPrintMeters(length_meters)}</p>
-  <RouteInfoLayers {id} />
 {/if}

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -19,7 +19,6 @@
   import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
   import Toolbox from "../lib/draw/Toolbox.svelte";
   import { SecondaryButton } from "../lib/govuk";
-  import ContextualLayers from "../lib/layers/ContextualLayers.svelte";
   import About from "../lib/sidebar/About.svelte";
   import EntireScheme from "../lib/sidebar/EntireScheme.svelte";
   import Instructions from "../lib/sidebar/Instructions.svelte";
@@ -132,7 +131,6 @@
         <CollapsibleCard label="Layers">
           <Legend rows={schemaLegend(schema)} />
           <BaselayerSwitcher {style} />
-          <ContextualLayers />
         </CollapsibleCard>
       </div>
     </MapLibreMap>


### PR DESCRIPTION
…ch page, because they both show incomplete data, haven't had much user testing yet, and likely to just cause confusion

Only change is to remove two things from the UI:
![Screenshot from 2023-08-29 10-10-12](https://github.com/acteng/atip/assets/1664407/778cf854-2078-4e7f-8709-87470105e0a7)
![Screenshot from 2023-08-29 10-10-00](https://github.com/acteng/atip/assets/1664407/aa170a8f-2a66-4984-aa2e-038fe7d04d82)

We keep the route info web worker loading in the background, because it **is** useful for the "Auto-fill name" tool for routes.