### PR TITLE
WIP: Add scheme-wide ATF4 category checkboxes

### DIFF
--- a/docs/data_spec.md
+++ b/docs/data_spec.md
@@ -15,6 +15,8 @@ ATIP produces a [GeoJSON file](https://datatracker.ietf.org/doc/html/rfc7946). T
   - An optional string `authority`, belonging to [this set](https://github.com/acteng/atip/blob/main/assets/authority_names.json)
   - An optional free-form string `scheme_name`
 
+TODO: Update
+
 An example of the overall structure:
 
 ```
@@ -57,6 +59,8 @@ If you are generating a file from another tool, omit `waypoints` and don't expec
 ## Versioning
 
 This format was defined as of 23 March, 2023. It has not changed since then. If you used an earlier prototype of ATIP, the output file may not match this specification.
+
+TODO: Update
 
 ## Example
 

--- a/src/lib/sidebar/Atf4Categories.svelte
+++ b/src/lib/sidebar/Atf4Categories.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { gjScheme } from "../../stores";
+  import { CollapsibleCard, ExternalLink } from "../common";
+  import { Checkbox, CheckboxGroup } from "../govuk";
+
+  $gjScheme.atf4 ||= {};
+
+  let choices = [
+    ["new_segregated_cycling", "New segregated cycling facility"],
+    ["new_junction_treatment", "New junction treatment"],
+    ["new_permanent_footway", "New permanent footway"],
+    ["new_shared_use", "New shared use (walking and cycling) facilities"],
+    [
+      "improvements_existing_route",
+      "Improvements to make an existing walking/cycle route safer",
+    ],
+    [
+      "area_traffic_managemenet",
+      "Area-wide traffic management (including by TROs - both permanent and experimental)",
+    ],
+    [
+      "bus_priority",
+      "Bus priority measures that also enable active travel (for example, bus gates)",
+    ],
+    ["cycle_parking", "Provision of secure cycle parking facilities"],
+    ["new_crossings", "New road crossings"],
+    [
+      "car_parking_restrictions",
+      "Restriction or reduction of car parking availability",
+    ],
+    ["school_streets", "School streets"],
+  ];
+</script>
+
+<CollapsibleCard label="Select ATF4 types of infrastructure">
+  <p>
+    Select all <ExternalLink
+      href="https://www.gov.uk/government/publications/how-to-complete-the-active-travel-fund-4-proforma/guidance-note-for-local-authorities-to-support-completion-of-the-active-travel-fund-4-proforma#types-of-infrastructure"
+    >
+      types of infrastructure
+    </ExternalLink> that apply this scheme contains.
+  </p>
+
+  <CheckboxGroup small>
+    {#each choices as [id, description]}
+      <Checkbox {id} bind:checked={$gjScheme.atf4[id]}>{description}</Checkbox>
+    {/each}
+  </CheckboxGroup>
+</CollapsibleCard>

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -18,6 +18,7 @@
     TextInput,
     WarningButton,
   } from "../govuk";
+  import Atf4Categories from "./Atf4Categories.svelte";
 
   export let authorityName: string;
   export let schema: Schema;
@@ -161,6 +162,10 @@
 </script>
 
 <TextInput label="Scheme name" bind:value={$gjScheme.scheme_name} />
+
+{#if schema == "v1"}
+  <Atf4Categories />
+{/if}
 
 {#if errorMessage}
   <ErrorMessage {errorMessage} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export interface Scheme {
   scheme_name?: string;
   authority?: string;
   origin?: string;
+  atf4?: Atf4Categories;
+}
+
+interface Atf4Categories {
+  // TODO
+  new_segregated_cycling: boolean;
 }
 
 // TODO Can we use a wildcard type, like Feature<? extends Geometry>


### PR DESCRIPTION
Demo at https://acteng.github.io/atip/atf4_checkboxes/scheme.html?authority=Adur
![Screenshot from 2023-08-29 10-49-29](https://github.com/acteng/atip/assets/1664407/43a7a1e0-d92d-448f-81a3-99b08d27032b)


Questions:

- This is a collection of checkboxes at the scheme level -- is that what we want? (Not at the intervention or sub-scheme level?) Do we want to require people to select at least one?
- Do we also want to ask people the high/medium/low complexity question for these?
- How should we encode the set in JSON?
  - An object with boolean values is awkward, because a missing key and a value of `false` mean the same thing. Maybe a sorted list of strings?
  - We can decouple the text shown on the page from the way we store the result. Is the mapping I made up reasonable? How's most convenient to later represent in the DB?
- Would a larger popup/modal be nicer than embedding the long list in the sidebar?
- Any changes to the exact wording of things?