### PR TITLE
Move API key and resource base URL into vite config, in preparation f…

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_MAPTILER_API_KEY="MZEJTanw3WpxRvt7qDfo"
+VITE_RESOURCE_BASE="https://atip.uk"

--- a/src/lib/browse/layers/BusRoutesLayerControl.svelte
+++ b/src/lib/browse/layers/BusRoutesLayerControl.svelte
@@ -20,7 +20,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwriteLineLayer($map, {

--- a/src/lib/browse/layers/CensusOutputAreaLayerControl.svelte
+++ b/src/lib/browse/layers/CensusOutputAreaLayerControl.svelte
@@ -48,7 +48,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
@@ -20,7 +20,11 @@
   let color = colors.combined_authorities;
   let outlineLayer = `${name}-outline`;
 
-  overwriteSource($map, name, `https://atip.uk/layers/v1/${name}.geojson`);
+  overwriteSource(
+    $map,
+    name,
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.geojson`
+  );
 
   overwritePolygonLayer($map, {
     id: name,

--- a/src/lib/browse/layers/CycleParkingLayerControl.svelte
+++ b/src/lib/browse/layers/CycleParkingLayerControl.svelte
@@ -17,7 +17,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwriteCircleLayer($map, {

--- a/src/lib/browse/layers/CyclePathsLayerControl.svelte
+++ b/src/lib/browse/layers/CyclePathsLayerControl.svelte
@@ -28,7 +28,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwriteLineLayer($map, {

--- a/src/lib/browse/layers/ImdLayerControl.svelte
+++ b/src/lib/browse/layers/ImdLayerControl.svelte
@@ -23,7 +23,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
+++ b/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
@@ -20,7 +20,11 @@
   let color = colors.local_authority_districts;
   let outlineLayer = `${name}-outline`;
 
-  overwriteSource($map, name, `https://atip.uk/layers/v1/${name}.geojson`);
+  overwriteSource(
+    $map,
+    name,
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.geojson`
+  );
 
   overwritePolygonLayer($map, {
     id: name,

--- a/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
@@ -23,7 +23,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/browse/layers/MrnLayerControl.svelte
+++ b/src/lib/browse/layers/MrnLayerControl.svelte
@@ -21,7 +21,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwriteLineLayer($map, {

--- a/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
+++ b/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
@@ -23,7 +23,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/browse/layers/PointAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/PointAmenityLayerControl.svelte
@@ -24,7 +24,11 @@
   // @ts-ignore TODO Also constrain name to exist in the colors type
   let color = colors[name];
 
-  overwriteSource($map, name, `https://atip.uk/layers/v1/${name}.geojson`);
+  overwriteSource(
+    $map,
+    name,
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.geojson`
+  );
 
   overwriteCircleLayer($map, {
     id: name,

--- a/src/lib/browse/layers/PolygonAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/PolygonAmenityLayerControl.svelte
@@ -29,7 +29,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/browse/layers/VehicleCountsLayerControl.svelte
+++ b/src/lib/browse/layers/VehicleCountsLayerControl.svelte
@@ -22,7 +22,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwriteCircleLayer($map, {

--- a/src/lib/browse/layers/WardsLayerControl.svelte
+++ b/src/lib/browse/layers/WardsLayerControl.svelte
@@ -23,7 +23,7 @@
   overwritePmtilesSource(
     $map,
     name,
-    `https://atip.uk/layers/v1/${name}.pmtiles`
+    `${import.meta.env.VITE_RESOURCE_BASE}/layers/v1/${name}.pmtiles`
   );
 
   overwritePolygonLayer($map, {

--- a/src/lib/common/MapLibreMap.svelte
+++ b/src/lib/common/MapLibreMap.svelte
@@ -24,7 +24,9 @@
   onMount(() => {
     map = new Map({
       container: mapContainer,
-      style: `https://api.maptiler.com/maps/${style}/style.json?key=MZEJTanw3WpxRvt7qDfo`,
+      style: `https://api.maptiler.com/maps/${style}/style.json?key=${
+        import.meta.env.VITE_MAPTILER_API_KEY
+      }`,
       hash: true,
     });
     map.addControl(new ScaleControl({}));

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -47,8 +47,12 @@
   // app's version. The version of the code deployed has to match the data, and
   // it's simplest to increment the number here for new incompatible data
   // releases. The two data releases may also be changed independently.
-  let routeSnapperUrl = `https://atip.uk/route-snappers/v2.1/${authorityName}.bin.gz`;
-  let routeInfoUrl = `https://atip.uk/route-info/v2/${authorityName}.bin.gz`;
+  let routeSnapperUrl = `${
+    import.meta.env.VITE_RESOURCE_BASE
+  }/route-snappers/v2.1/${authorityName}.bin.gz`;
+  let routeInfoUrl = `${
+    import.meta.env.VITE_RESOURCE_BASE
+  }/route-info/v2/${authorityName}.bin.gz`;
 
   function toggleAbout() {
     showAbout = !showAbout;

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -53,8 +53,9 @@
 
     let map = new Map({
       container: "map",
-      style:
-        "https://api.maptiler.com/maps/streets/style.json?key=MZEJTanw3WpxRvt7qDfo",
+      style: `https://api.maptiler.com/maps/streets/style.json?key=${
+        import.meta.env.VITE_MAPTILER_API_KEY
+      }`,
     });
     // Use map within onMount, so it's guaranteed to exist
     loadedMap = map;


### PR DESCRIPTION
…or #257

This uses https://vitejs.dev/guide/env-and-mode.html, and has no behavioral change. It's just a simple change that can be done independently of the rest of the GCP deployment work.

When we're ready, we can define a `.env.prod` file with a different resource base URL (the private GCS bucket).