### PR TITLE
Stop using relative module imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3",
         "vite": "^4.1.1",
-        "vite-plugin-wasm-pack": "0.1.11"
+        "vite-plugin-wasm-pack": "0.1.11",
+        "vite-tsconfig-paths": "^4.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2109,6 +2110,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/govuk-frontend": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
@@ -3346,6 +3353,26 @@
         }
       }
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
+      "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
@@ -3510,6 +3537,25 @@
         "chalk": "^4.1.2",
         "fs-extra": "^10.0.0",
         "narrowing": "^1.4.0"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitefu": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
     "vite": "^4.1.1",
-    "vite-plugin-wasm-pack": "0.1.11"
+    "vite-plugin-wasm-pack": "0.1.11",
+    "vite-tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
     "@turf/bbox": "^6.5.0",

--- a/src/lib/BoundaryLayer.svelte
+++ b/src/lib/BoundaryLayer.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
   import mask from "@turf/mask";
   import type { FeatureCollection, Polygon } from "geojson";
+  import { bbox, overwritePolygonLayer, overwriteSource } from "lib/maplibre";
+  import { map } from "stores";
   import { getContext } from "svelte";
-  import {
-    bbox,
-    overwritePolygonLayer,
-    overwriteSource,
-  } from "../lib/maplibre";
-  import { map } from "../stores";
 
   export let boundaryGeojson: FeatureCollection<Polygon>;
 

--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { gjScheme, map } from "../../stores";
-  import type { FeatureUnion } from "../../types";
-  import { CollapsibleCard } from "../common";
+  import { CollapsibleCard } from "lib/common";
   import {
     Checkbox,
     CheckboxGroup,
     FormElement,
     SecondaryButton,
     Select,
-  } from "../govuk";
+  } from "lib/govuk";
+  import { gjScheme, map } from "stores";
+  import { onMount } from "svelte";
+  import type { FeatureUnion } from "types";
   import { type Scheme } from "./data";
   import InterventionColorSelector from "./InterventionColorSelector.svelte";
 

--- a/src/lib/browse/InterventionColorSelector.svelte
+++ b/src/lib/browse/InterventionColorSelector.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { colorInterventionsBySchema, schemaLegend } from "../../schemas";
-  import { map } from "../../stores";
-  import { Legend } from "../common";
-  import { Select } from "../govuk";
-  import { constructMatchExpression } from "../maplibre";
+  import { Legend } from "lib/common";
+  import { Select } from "lib/govuk";
+  import { constructMatchExpression } from "lib/maplibre";
+  import { colorInterventionsBySchema, schemaLegend } from "schemas";
+  import { map } from "stores";
   import { colors } from "./colors";
 
   let colorInterventionsAccordingTo = "interventionType";

--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-  import { interactiveMapLayersEnabled } from "../../stores";
-  import { BaselayerSwitcher, CollapsibleCard } from "../common";
-  import StreetViewController from "../common/StreetViewController.svelte";
-  import { CheckboxGroup } from "../govuk";
+  import {
+    BaselayerSwitcher,
+    CollapsibleCard,
+    StreetViewController,
+  } from "lib/common";
+  import { CheckboxGroup } from "lib/govuk";
+  import { interactiveMapLayersEnabled } from "stores";
   import BusRoutesLayerControl from "./layers/BusRoutesLayerControl.svelte";
   import CensusOutputAreaLayerControl from "./layers/CensusOutputAreaLayerControl.svelte";
   import CombinedAuthoritiesLayerControl from "./layers/CombinedAuthoritiesLayerControl.svelte";

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type { FeatureCollection } from "geojson";
-  import { gjScheme, map } from "../../stores";
-  import { CollapsibleCard } from "../common";
-  import { SecondaryButton } from "../govuk";
-  import { bbox } from "../maplibre";
+  import { CollapsibleCard } from "lib/common";
+  import { SecondaryButton } from "lib/govuk";
+  import { bbox } from "lib/maplibre";
+  import { gjScheme, map } from "stores";
   import type { Scheme } from "./data";
 
   export let scheme: Scheme;

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -1,6 +1,6 @@
 import type { FeatureCollection } from "geojson";
+import { setPrecision } from "lib/maplibre";
 import readXlsxFile from "read-excel-file";
-import { setPrecision } from "../maplibre";
 
 // This must be filled out in the input file
 interface SchemeData {

--- a/src/lib/browse/layers/BusRoutesLayerControl.svelte
+++ b/src/lib/browse/layers/BusRoutesLayerControl.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "bus_routes";

--- a/src/lib/browse/layers/CensusOutputAreaLayerControl.svelte
+++ b/src/lib/browse/layers/CensusOutputAreaLayerControl.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { ExternalLink, HelpButton, InteractiveLayer } from "../../common";
-  import { Checkbox } from "../../govuk";
+  import { ExternalLink, HelpButton, InteractiveLayer } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     makeColorRamp,
     overwriteLineLayer,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
   import SequentialLegend from "./SequentialLegend.svelte";
 

--- a/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePolygonLayer,
     overwriteSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "combined_authorities";

--- a/src/lib/browse/layers/CriticalIssuesLayerControl.svelte
+++ b/src/lib/browse/layers/CriticalIssuesLayerControl.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import type { GeoJSONSource, MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { CollapsibleCard, ColorLegend, InteractiveLayer } from "../../common";
+  import { CollapsibleCard, ColorLegend, InteractiveLayer } from "lib/common";
   import {
     Checkbox,
     CheckboxGroup,
     ErrorMessage,
     FormElement,
-  } from "../../govuk";
+  } from "lib/govuk";
   import {
     cleanupSource,
     emptyGeojson,
     overwriteCircleLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { GeoJSONSource, MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { parseCriticalIssuesExcel } from "../data";
 
   let fileInput: HTMLInputElement;

--- a/src/lib/browse/layers/CycleParkingLayerControl.svelte
+++ b/src/lib/browse/layers/CycleParkingLayerControl.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
-  import { overwriteCircleLayer, overwritePmtilesSource } from "../../maplibre";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
+  import { overwriteCircleLayer, overwritePmtilesSource } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "cycle_parking";

--- a/src/lib/browse/layers/CyclePathsLayerControl.svelte
+++ b/src/lib/browse/layers/CyclePathsLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     constructMatchExpression,
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "cycle_paths";

--- a/src/lib/browse/layers/HospitalsLayerControl.svelte
+++ b/src/lib/browse/layers/HospitalsLayerControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExternalLink } from "../../common";
+  import { ExternalLink } from "lib/common";
   import PolygonAmenityLayerControl from "./PolygonAmenityLayerControl.svelte";
 </script>
 

--- a/src/lib/browse/layers/ImdLayerControl.svelte
+++ b/src/lib/browse/layers/ImdLayerControl.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { ExternalLink, HelpButton, InteractiveLayer } from "../../common";
-  import { Checkbox } from "../../govuk";
+  import { ExternalLink, HelpButton, InteractiveLayer } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     makeColorRamp,
     overwriteLineLayer,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
   import SequentialLegend from "./SequentialLegend.svelte";
 

--- a/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
+++ b/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePolygonLayer,
     overwriteSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "local_authority_districts";

--- a/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "local_planning_authorities";

--- a/src/lib/browse/layers/MrnLayerControl.svelte
+++ b/src/lib/browse/layers/MrnLayerControl.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "mrn";

--- a/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
+++ b/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "parliamentary_constituencies";

--- a/src/lib/browse/layers/PointAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/PointAmenityLayerControl.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+  import { ColorLegend, HelpButton, InteractiveLayer } from "lib/common";
+  import { Checkbox } from "lib/govuk";
+  import { overwriteCircleLayer, overwriteSource } from "lib/maplibre";
   import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { ColorLegend, HelpButton, InteractiveLayer } from "../../common";
-  import { Checkbox } from "../../govuk";
-  import { overwriteCircleLayer, overwriteSource } from "../../maplibre";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   // This name is used for multiple things:

--- a/src/lib/browse/layers/PolygonAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/PolygonAmenityLayerControl.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { ColorLegend, HelpButton, InteractiveLayer } from "../../common";
-  import { Checkbox } from "../../govuk";
+  import { ColorLegend, HelpButton, InteractiveLayer } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   // This name is used for multiple things:

--- a/src/lib/browse/layers/RailwayStationsLayerControl.svelte
+++ b/src/lib/browse/layers/RailwayStationsLayerControl.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { circleRadius } from "../../../colors";
-  import { ExternalLink } from "../../common";
+  import { circleRadius } from "colors";
+  import { ExternalLink } from "lib/common";
   import PointAmenityLayerControl from "./PointAmenityLayerControl.svelte";
 
   const name = "railway_stations";

--- a/src/lib/browse/layers/SchoolsLayerControl.svelte
+++ b/src/lib/browse/layers/SchoolsLayerControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExternalLink } from "../../common";
+  import { ExternalLink } from "lib/common";
   import PolygonAmenityLayerControl from "./PolygonAmenityLayerControl.svelte";
 </script>
 

--- a/src/lib/browse/layers/SportsSpacesLayerControl.svelte
+++ b/src/lib/browse/layers/SportsSpacesLayerControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExternalLink } from "../../common";
+  import { ExternalLink } from "lib/common";
   import PolygonAmenityLayerControl from "./PolygonAmenityLayerControl.svelte";
 </script>
 

--- a/src/lib/browse/layers/VehicleCountsLayerControl.svelte
+++ b/src/lib/browse/layers/VehicleCountsLayerControl.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
-  import { ExternalLink, HelpButton, InteractiveLayer } from "../../common";
-  import { Checkbox } from "../../govuk";
+  import { ExternalLink, HelpButton, InteractiveLayer } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     makeColorRamp,
     overwriteCircleLayer,
     overwritePmtilesSource,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
   import SequentialLegend from "./SequentialLegend.svelte";
 

--- a/src/lib/browse/layers/WardsLayerControl.svelte
+++ b/src/lib/browse/layers/WardsLayerControl.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { map } from "../../../stores";
   import {
     ColorLegend,
     ExternalLink,
     HelpButton,
     InteractiveLayer,
-  } from "../../common";
-  import { Checkbox } from "../../govuk";
+  } from "lib/common";
+  import { Checkbox } from "lib/govuk";
   import {
     hoveredToggle,
     overwriteLineLayer,
     overwritePmtilesSource,
     overwritePolygonLayer,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { map } from "stores";
   import { colors } from "../colors";
 
   let name = "wards";

--- a/src/lib/common/BaselayerSwitcher.svelte
+++ b/src/lib/common/BaselayerSwitcher.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Select } from "../govuk";
+  import { Select } from "lib/govuk";
 
   // TODO Be specific about "streets" | "hybrid", but then we need actual error
   // handling when we parse it from URL params

--- a/src/lib/common/ConfirmationModal.svelte
+++ b/src/lib/common/ConfirmationModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { Modal } from "lib/common";
+  import { SecondaryButton, WarningButton } from "lib/govuk";
   import { createEventDispatcher } from "svelte";
-  import { SecondaryButton, WarningButton } from "../govuk";
-  import Modal from "./Modal.svelte";
 
   const dispatch = createEventDispatcher();
 

--- a/src/lib/common/FileInput.svelte
+++ b/src/lib/common/FileInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FormElement } from "../govuk";
+  import { FormElement } from "lib/govuk";
 
   export let label: string;
   // This must be unique in the page

--- a/src/lib/common/InteractiveLayer.svelte
+++ b/src/lib/common/InteractiveLayer.svelte
@@ -4,8 +4,8 @@
     type MapGeoJSONFeature,
     type MapLayerMouseEvent,
   } from "maplibre-gl";
+  import { interactiveMapLayersEnabled, map } from "stores";
   import { createEventDispatcher, onDestroy, onMount } from "svelte";
-  import { interactiveMapLayersEnabled, map } from "../../stores";
 
   const dispatch = createEventDispatcher<{
     click: MapGeoJSONFeature;

--- a/src/lib/common/MapLibreMap.svelte
+++ b/src/lib/common/MapLibreMap.svelte
@@ -7,7 +7,7 @@
   } from "maplibre-gl";
   import { onDestroy, onMount, setContext } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
-  import { map as mapStore } from "../../stores";
+  import { map as mapStore } from "stores";
 
   export let style: string;
   export let startBounds: LngLatBoundsLike | null = null;

--- a/src/lib/common/Modal.svelte
+++ b/src/lib/common/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SecondaryButton } from "../govuk";
+  import { SecondaryButton } from "lib/govuk";
 
   export let title: string;
   export let open = false;

--- a/src/lib/common/StreetViewController.svelte
+++ b/src/lib/common/StreetViewController.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
+  import { colors } from "colors";
+  import { CollapsibleCard, ExternalLink } from "lib/common";
+  import { Radio, SecondaryButton } from "lib/govuk";
+  import { getRoadLayerHelpers } from "lib/maplibre";
   import type { MapMouseEvent } from "maplibre-gl";
+  import { map, userSettings } from "stores";
   import cameraCursorUrl from "../../../assets/camera_cursor.svg?url";
-  import { colors } from "../../colors";
-  import { map, userSettings } from "../../stores";
-  import { Radio } from "../govuk";
-  import SecondaryButton from "../govuk/SecondaryButton.svelte";
-  import { getRoadLayerHelpers } from "../maplibre";
-  import { ExternalLink } from "./";
-  import CollapsibleCard from "./CollapsibleCard.svelte";
 
   export let displayEnableButton: boolean;
   export let isInactive: boolean;

--- a/src/lib/common/ZoomOutMap.svelte
+++ b/src/lib/common/ZoomOutMap.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
+  import { SecondaryButton } from "lib/govuk";
+  import { bbox } from "lib/maplibre";
+  import { map } from "stores";
   import icon from "../../../assets/zoom_out_map.svg";
-  import { map } from "../../stores";
-  import { SecondaryButton } from "../govuk";
-  import { bbox } from "../maplibre";
 
   export let boundaryGeojson: GeoJSON;
 

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -11,4 +11,5 @@ export { default as Layout } from "./Layout.svelte";
 export { default as Legend } from "./Legend.svelte";
 export { default as MapLibreMap } from "./MapLibreMap.svelte";
 export { default as Modal } from "./Modal.svelte";
+export { default as StreetViewController } from "./StreetViewController.svelte";
 export { default as ZoomOutMap } from "./ZoomOutMap.svelte";

--- a/src/lib/draw/AttributeMode.svelte
+++ b/src/lib/draw/AttributeMode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { bbox } from "lib/maplibre";
   import { type MapMouseEvent } from "maplibre-gl";
-  import { onDestroy } from "svelte";
-  import { schemaSingularNoun } from "../../schemas";
+  import { schemaSingularNoun } from "schemas";
   import {
     currentMode,
     formOpen,
@@ -9,9 +9,9 @@
     map,
     mapHover,
     openFromSidebar,
-  } from "../../stores";
-  import type { Mode, Schema } from "../../types";
-  import { bbox } from "../maplibre";
+  } from "stores";
+  import { onDestroy } from "svelte";
+  import type { Mode, Schema } from "types";
   import type { EventHandler } from "./event_handler";
 
   const thisMode = "edit-attribute";

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { LineString, Point, Polygon } from "geojson";
+  import type { FeatureWithProps } from "lib/maplibre";
   import { MapMouseEvent } from "maplibre-gl";
-  import { schemaSingularNoun } from "../../schemas";
-  import { currentMode, gjScheme, map, mapHover } from "../../stores";
-  import type { Feature, FeatureUnion, Schema } from "../../types";
-  import type { FeatureWithProps } from "../maplibre";
+  import { schemaSingularNoun } from "schemas";
+  import { currentMode, gjScheme, map, mapHover } from "stores";
+  import type { Feature, FeatureUnion, Schema } from "types";
   import type { EventHandler } from "./event_handler";
   import type { PointTool } from "./point/point_tool";
   import PointControls from "./point/PointControls.svelte";

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -1,14 +1,5 @@
 <script lang="ts">
-  import type { GeoJSONSource } from "maplibre-gl";
-  import { circleRadius, colors, lineWidth } from "../../colors";
-  import {
-    formOpen,
-    gjScheme,
-    isAToolInUse,
-    map,
-    mapHover,
-    sidebarHover,
-  } from "../../stores";
+  import { circleRadius, colors, lineWidth } from "colors";
   import {
     emptyGeojson,
     isLine,
@@ -17,7 +8,16 @@
     overwriteCircleLayer,
     overwriteLineLayer,
     overwriteSource,
-  } from "../maplibre";
+  } from "lib/maplibre";
+  import type { GeoJSONSource } from "maplibre-gl";
+  import {
+    formOpen,
+    gjScheme,
+    isAToolInUse,
+    map,
+    mapHover,
+    sidebarHover,
+  } from "stores";
 
   // Show clickable objects on the map using the cursor
   $: {

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-  import type {
-    DataDrivenPropertyValueSpecification,
-    FilterSpecification,
-    GeoJSONSource,
-  } from "maplibre-gl";
-  import { circleRadius, colors, lineWidth } from "../../colors";
-  import { gjScheme, map } from "../../stores";
+  import { circleRadius, colors, lineWidth } from "colors";
   import {
     isLine,
     isPoint,
@@ -14,7 +8,13 @@
     overwriteLineLayer,
     overwritePolygonLayer,
     overwriteSource,
-  } from "../maplibre";
+  } from "lib/maplibre";
+  import type {
+    DataDrivenPropertyValueSpecification,
+    FilterSpecification,
+    GeoJSONSource,
+  } from "maplibre-gl";
+  import { gjScheme, map } from "stores";
 
   export let colorInterventions: DataDrivenPropertyValueSpecification<string>;
 

--- a/src/lib/draw/SelectToolButton.svelte
+++ b/src/lib/draw/SelectToolButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { currentMode } from "../../stores";
-  import type { Mode } from "../../types";
+  import { currentMode } from "stores";
+  import type { Mode } from "types";
 
   export let thisMode: Mode;
   export let label: string;

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { Mode } from "../../types";
-  import StreetViewController from "../common/StreetViewController.svelte";
+  import { StreetViewController } from "lib/common";
+  import type { Mode } from "types";
   import type { EventHandler } from "./event_handler";
 
   export let eventHandler: EventHandler;

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { currentMode, map } from "stores";
   import { onDestroy } from "svelte";
   import { get } from "svelte/store";
+  import type { Mode, Schema } from "types";
   import editAttributesIcon from "../../../assets/edit_attributes.svg";
   import editGeometryIcon from "../../../assets/edit_geometry.svg";
   import pointIcon from "../../../assets/point.svg";
@@ -9,8 +11,6 @@
   import routeIcon from "../../../assets/route.svg";
   import splitRouteIcon from "../../../assets/split_route.svg";
   import streetViewIcon from "../../../assets/street_view.svg";
-  import { currentMode, map } from "../../stores";
-  import type { Mode, Schema } from "../../types";
   import AttributeMode from "./AttributeMode.svelte";
   import { DocumentEvents, EventHandler, MapEvents } from "./event_handler";
   import GeometryMode from "./GeometryMode.svelte";

--- a/src/lib/draw/common.ts
+++ b/src/lib/draw/common.ts
@@ -1,8 +1,8 @@
 import type { LineString, Polygon } from "geojson";
+import type { FeatureWithProps } from "lib/maplibre";
+import { currentMode, formOpen, gjScheme, newFeatureId } from "stores";
 import { get } from "svelte/store";
-import { currentMode, formOpen, gjScheme, newFeatureId } from "../../stores";
-import type { FeatureUnion, Mode } from "../../types";
-import type { FeatureWithProps } from "../maplibre/utils";
+import type { FeatureUnion, Mode } from "types";
 
 interface Tool {
   addEventListenerSuccess(

--- a/src/lib/draw/point/PointControls.svelte
+++ b/src/lib/draw/point/PointControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { CollapsibleCard } from "../../common";
-  import { SecondaryButton } from "../../govuk";
+  import { CollapsibleCard } from "lib/common";
+  import { SecondaryButton } from "lib/govuk";
   import { PointTool } from "./point_tool";
 
   export let pointTool: PointTool;

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
   import type { Point } from "geojson";
-  import {
-    currentMode,
-    formOpen,
-    gjScheme,
-    newFeatureId,
-  } from "../../../stores";
-  import type { Feature, Mode } from "../../../types";
+  import { currentMode, formOpen, gjScheme, newFeatureId } from "stores";
+  import type { Feature, Mode } from "types";
   import type { EventHandler } from "../event_handler";
   import type { PointTool } from "./point_tool";
   import PointControls from "./PointControls.svelte";

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -1,7 +1,7 @@
 import type { Point } from "geojson";
+import { pointFeature, type FeatureWithProps } from "lib/maplibre";
 import type { Map, MapMouseEvent } from "maplibre-gl";
-import { isAToolInUse } from "../../../stores";
-import { pointFeature, type FeatureWithProps } from "../../maplibre/utils";
+import { isAToolInUse } from "stores";
 import type { EventHandler } from "../event_handler";
 
 // Note this uses the geojson FeatureWithProps, not our specialization in types.ts

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { CollapsibleCard } from "../../common";
-  import { DefaultButton, SecondaryButton } from "../../govuk";
+  import { CollapsibleCard } from "lib/common";
+  import { DefaultButton, SecondaryButton } from "lib/govuk";
   import { PolygonTool } from "./polygon_tool";
 
   export let polygonTool: PolygonTool;

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { Polygon } from "geojson";
-  import { currentMode } from "../../../stores";
-  import type { Mode } from "../../../types";
-  import type { FeatureWithProps } from "../../maplibre";
+  import type { FeatureWithProps } from "lib/maplibre";
+  import { currentMode } from "stores";
+  import type { Mode } from "types";
   import { handleUnsavedFeature, setupEventListeners } from "../common";
   import type { EventHandler } from "../event_handler";
   import type { PolygonTool } from "./polygon_tool";

--- a/src/lib/draw/polygon/polygon_tool.ts
+++ b/src/lib/draw/polygon/polygon_tool.ts
@@ -1,13 +1,6 @@
 import nearestPointOnLine from "@turf/nearest-point-on-line";
+import { circleRadius, colors } from "colors";
 import type { Feature, LineString, Point, Polygon, Position } from "geojson";
-import type {
-  GeoJSONSource,
-  Map,
-  MapLayerMouseEvent,
-  MapMouseEvent,
-} from "maplibre-gl";
-import { circleRadius, colors } from "../../../colors";
-import { isAToolInUse } from "../../../stores";
 import {
   emptyGeojson,
   isLine,
@@ -20,7 +13,14 @@ import {
   pointFeature,
   setPrecision,
   type FeatureWithProps,
-} from "../../maplibre/utils";
+} from "lib/maplibre";
+import type {
+  GeoJSONSource,
+  Map,
+  MapLayerMouseEvent,
+  MapMouseEvent,
+} from "maplibre-gl";
+import { isAToolInUse } from "stores";
 import type { EventHandler } from "../event_handler";
 
 const source = "edit-polygon-mode";

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { userSettings } from "../../../stores";
-  import { CollapsibleCard } from "../../common";
+  import { CollapsibleCard } from "lib/common";
   import {
     Checkbox,
     CheckboxGroup,
     DefaultButton,
     SecondaryButton,
-  } from "../../govuk";
+  } from "lib/govuk";
+  import { userSettings } from "stores";
   import { RouteTool } from "./route_tool";
 
   export let routeTool: RouteTool;

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { LineString } from "geojson";
+  import type { FeatureWithProps } from "lib/maplibre";
   import init from "route-snapper";
+  import { currentMode, map } from "stores";
   import { onMount } from "svelte";
-  import { currentMode, map } from "../../../stores";
-  import type { Mode } from "../../../types";
-  import type { FeatureWithProps } from "../../maplibre";
+  import type { Mode } from "types";
   import { handleUnsavedFeature, setupEventListeners } from "../common";
   import type { EventHandler } from "../event_handler";
   import { RouteTool } from "./route_tool";

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -6,17 +6,17 @@
   import nearestPointOnLine from "@turf/nearest-point-on-line";
   // Note we don't use our specialization of Feature here
   import type { Feature, LineString, Point, Position } from "geojson";
-  import type { GeoJSONSource, MapMouseEvent } from "maplibre-gl";
-  import splitIcon from "../../../../assets/split_route.svg";
-  import { currentMode, gjScheme, map, newFeatureId } from "../../../stores";
-  import type { Mode, Feature as OurFeature } from "../../../types";
-  import { CollapsibleCard } from "../../common";
+  import { CollapsibleCard } from "lib/common";
   import {
     emptyGeojson,
     overwriteCircleLayer,
     overwriteSource,
     setPrecision,
-  } from "../../maplibre";
+  } from "lib/maplibre";
+  import type { GeoJSONSource, MapMouseEvent } from "maplibre-gl";
+  import { currentMode, gjScheme, map, newFeatureId } from "stores";
+  import type { Mode, Feature as OurFeature } from "types";
+  import splitIcon from "../../../../assets/split_route.svg";
   import type { EventHandler } from "../event_handler";
 
   const thisMode = "split-route";

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -1,7 +1,4 @@
 import type { LineString, Polygon } from "geojson";
-import type { GeoJSONSource, Map, MapMouseEvent } from "maplibre-gl";
-import { JsRouteSnapper } from "route-snapper";
-import { isAToolInUse } from "../../../stores";
 import {
   constructMatchExpression,
   emptyGeojson,
@@ -13,7 +10,10 @@ import {
   overwritePolygonLayer,
   overwriteSource,
   type FeatureWithProps,
-} from "../../maplibre/utils";
+} from "lib/maplibre";
+import type { GeoJSONSource, Map, MapMouseEvent } from "maplibre-gl";
+import { JsRouteSnapper } from "route-snapper";
+import { isAToolInUse } from "stores";
 import type { EventHandler } from "../event_handler";
 
 const source = "route-snapper";

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { CollapsibleCard } from "../../common";
-  import { DefaultButton, SecondaryButton } from "../../govuk";
+  import { CollapsibleCard } from "lib/common";
+  import { DefaultButton, SecondaryButton } from "lib/govuk";
   import { RouteTool } from "../route/route_tool";
 
   export let routeTool: RouteTool;

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { Polygon } from "geojson";
-  import { currentMode } from "../../../stores";
-  import type { Mode } from "../../../types";
-  import type { FeatureWithProps } from "../../maplibre";
+  import type { FeatureWithProps } from "lib/maplibre";
+  import { currentMode } from "stores";
+  import type { Mode } from "types";
   import { handleUnsavedFeature, setupEventListeners } from "../common";
   import type { EventHandler } from "../event_handler";
   import type { RouteTool } from "../route/route_tool";

--- a/src/lib/forms/ATF4Form.svelte
+++ b/src/lib/forms/ATF4Form.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import schemaJson from "../../schemas/atf4.json";
-  import type { InterventionProps } from "../../types";
+  import schemaJson from "schemas/atf4.json";
+  import type { InterventionProps } from "types";
   import AutogenerateForm from "./AutogenerateForm.svelte";
   import type { Field } from "./types";
 

--- a/src/lib/forms/CriticalsForm.svelte
+++ b/src/lib/forms/CriticalsForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import schemaJson from "../../schemas/criticals.json";
-  import type { InterventionProps } from "../../types";
+  import schemaJson from "schemas/criticals.json";
+  import type { InterventionProps } from "types";
   import AutogenerateForm from "./AutogenerateForm.svelte";
   import type { Field } from "./types";
 

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { Feature, LineString } from "geojson";
-  import { gjScheme, routeInfo } from "../../stores";
-  import { FormElement, Radio, SecondaryButton, TextArea } from "../govuk";
-  import { prettyPrintMeters } from "../maplibre";
+  import { FormElement, Radio, SecondaryButton, TextArea } from "lib/govuk";
+  import { prettyPrintMeters } from "lib/maplibre";
+  import { gjScheme, routeInfo } from "stores";
   import RouteInfoLayers from "./RouteInfoLayers.svelte";
 
   export let id: number;

--- a/src/lib/forms/FormV2.svelte
+++ b/src/lib/forms/FormV2.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import schemaJson from "../../schemas/v2.json";
-  import type { InterventionProps } from "../../types";
+  import schemaJson from "schemas/v2.json";
+  import type { InterventionProps } from "types";
   import AutogenerateForm from "./AutogenerateForm.svelte";
   import type { Field } from "./types";
 

--- a/src/lib/forms/PlanningForm.svelte
+++ b/src/lib/forms/PlanningForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import schemaJson from "../../schemas/planning.json";
-  import type { InterventionProps } from "../../types";
+  import schemaJson from "schemas/planning.json";
+  import type { InterventionProps } from "types";
   import AutogenerateForm from "./AutogenerateForm.svelte";
   import type { Field } from "./types";
 

--- a/src/lib/forms/RouteInfoLayers.svelte
+++ b/src/lib/forms/RouteInfoLayers.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { routeInfo } from "../../stores";
-  import { Select } from "../govuk";
+  import { Select } from "lib/govuk";
+  import { routeInfo } from "stores";
   import LaneDetails from "../layers/LaneDetails.svelte";
   import SpeedLimits from "../layers/SpeedLimits.svelte";
 

--- a/src/lib/govuk/Select.svelte
+++ b/src/lib/govuk/Select.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FormElement } from "../govuk";
+  import { FormElement } from "lib/govuk";
 
   export let label: string;
   // A unique (per page) ID

--- a/src/lib/layers/ContextualLayers.svelte
+++ b/src/lib/layers/ContextualLayers.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { formOpen, routeInfo } from "../../stores";
-  import { Select } from "../govuk";
+  import { Select } from "lib/govuk";
+  import { formOpen, routeInfo } from "stores";
   import SpeedLimits from "./SpeedLimits.svelte";
 
   let show: "none" | "speed limits" = "none";

--- a/src/lib/layers/LaneDetails.svelte
+++ b/src/lib/layers/LaneDetails.svelte
@@ -2,10 +2,10 @@
   // This component can only be created once routeInfo is ready
 
   import type { GeoJSON, LineString } from "geojson";
+  import { HelpButton } from "lib/common";
+  import { gjScheme, routeInfo } from "stores";
   import { onMount } from "svelte";
-  import { gjScheme, routeInfo } from "../../stores";
-  import type { Feature } from "../../types";
-  import { HelpButton } from "../common";
+  import type { Feature } from "types";
   import IntersectionMarkings from "./lane_details/IntersectionMarkings.svelte";
   import IntersectionPolygons from "./lane_details/IntersectionPolygons.svelte";
   import LaneMarkings from "./lane_details/LaneMarkings.svelte";

--- a/src/lib/layers/SpeedLimits.svelte
+++ b/src/lib/layers/SpeedLimits.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
   // This component can only be created once routeInfo is ready
 
+  import { lineWidth } from "colors";
   import type { LineString } from "geojson";
+  import { DiscreteLegend, HelpButton, InteractiveLayer } from "lib/common";
+  import {
+    emptyGeojson,
+    overwriteLineLayer,
+    overwriteSource,
+  } from "lib/maplibre";
   import type {
     DataDrivenPropertyValueSpecification,
     GeoJSONSource,
     MapGeoJSONFeature,
   } from "maplibre-gl";
+  import { gjScheme, map, routeInfo } from "stores";
   import { onDestroy, onMount } from "svelte";
-  import { lineWidth } from "../../colors";
-  import { gjScheme, map, routeInfo } from "../../stores";
-  import type { Feature } from "../../types";
-  import { DiscreteLegend, HelpButton, InteractiveLayer } from "../common";
-  import {
-    emptyGeojson,
-    overwriteLineLayer,
-    overwriteSource,
-  } from "../maplibre";
+  import type { Feature } from "types";
 
   // Show along a route if specified, or show all otherwise
   export let id: number | undefined;

--- a/src/lib/layers/lane_details/IntersectionMarkings.svelte
+++ b/src/lib/layers/lane_details/IntersectionMarkings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
-  import { constructMatchExpression } from "../../maplibre";
+  import { constructMatchExpression } from "lib/maplibre";
   import Layer from "./Layer.svelte";
 
   export let gj: GeoJSON;

--- a/src/lib/layers/lane_details/IntersectionPolygons.svelte
+++ b/src/lib/layers/lane_details/IntersectionPolygons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
-  import { constructMatchExpression } from "../../maplibre";
+  import { constructMatchExpression } from "lib/maplibre";
   import Layer from "./Layer.svelte";
 
   export let gj: GeoJSON;

--- a/src/lib/layers/lane_details/LaneMarkings.svelte
+++ b/src/lib/layers/lane_details/LaneMarkings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
-  import { constructMatchExpression } from "../../maplibre";
+  import { constructMatchExpression } from "lib/maplibre";
   import Layer from "./Layer.svelte";
 
   export let gj: GeoJSON;

--- a/src/lib/layers/lane_details/LanePolygons.svelte
+++ b/src/lib/layers/lane_details/LanePolygons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
-  import { constructMatchExpression } from "../../maplibre";
+  import { constructMatchExpression } from "lib/maplibre";
   import Layer from "./Layer.svelte";
 
   export let gj: GeoJSON;

--- a/src/lib/layers/lane_details/Layer.svelte
+++ b/src/lib/layers/lane_details/Layer.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { GeoJSON } from "geojson";
+  import { overwriteLayer, overwriteSource } from "lib/maplibre";
+  import { map } from "stores";
   import { onDestroy } from "svelte";
-  import { map } from "../../../stores";
-  import { overwriteLayer, overwriteSource } from "../../maplibre";
 
   // This component manages a source with exactly one layer. Both are torn down
   // when this component is destroyed.

--- a/src/lib/maplibre/layer_helper_utils.ts
+++ b/src/lib/maplibre/layer_helper_utils.ts
@@ -1,5 +1,5 @@
+import { map as mapStore } from "stores";
 import { get } from "svelte/store";
-import { map as mapStore } from "../../stores";
 import { LayerHelper } from "./layer_helper";
 
 // Each MapTiler basemap style uses different layer IDs for roads and paths

--- a/src/lib/sidebar/About.svelte
+++ b/src/lib/sidebar/About.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExternalLink, Modal } from "../common";
+  import { ExternalLink, Modal } from "lib/common";
 
   export let open: boolean;
 </script>

--- a/src/lib/sidebar/AccordionItem.svelte
+++ b/src/lib/sidebar/AccordionItem.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
-  import { slide } from "svelte/transition";
   // TODO Make this more generic by taking some of these as props too or forwarding events
-  import {
-    formOpen,
-    mapHover,
-    openFromSidebar,
-    sidebarHover,
-  } from "../../stores.js";
+  import { formOpen, mapHover, openFromSidebar, sidebarHover } from "stores";
+  import { slide } from "svelte/transition";
 
   export let id: number;
   export let label: string;

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import length from "@turf/length";
-  import { onMount } from "svelte";
-  import { schemaPluralNoun } from "../../schemas";
+  import { ConfirmationModal, FileInput } from "lib/common";
+  import {
+    ErrorMessage,
+    SecondaryButton,
+    TextInput,
+    WarningButton,
+  } from "lib/govuk";
+  import { schemaPluralNoun } from "schemas";
   import {
     formOpen,
     gjScheme,
@@ -9,15 +15,9 @@
     mapHover,
     openFromSidebar,
     sidebarHover,
-  } from "../../stores";
-  import type { Schema, Scheme } from "../../types";
-  import { ConfirmationModal, FileInput } from "../common";
-  import {
-    ErrorMessage,
-    SecondaryButton,
-    TextInput,
-    WarningButton,
-  } from "../govuk";
+  } from "stores";
+  import { onMount } from "svelte";
+  import type { Schema, Scheme } from "types";
 
   export let authorityName: string;
   export let schema: Schema;

--- a/src/lib/sidebar/Instructions.svelte
+++ b/src/lib/sidebar/Instructions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { schemaPluralNoun } from "../../schemas";
-  import type { Schema } from "../../types";
-  import { Modal } from "../common";
+  import { Modal } from "lib/common";
+  import { schemaPluralNoun } from "schemas";
+  import type { Schema } from "types";
 
   export let open: boolean;
   export let schema: Schema;

--- a/src/lib/sidebar/InterventionList.svelte
+++ b/src/lib/sidebar/InterventionList.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { deleteIntervention, formOpen, gjScheme } from "../../stores";
-  import type { FeatureUnion, Schema } from "../../types";
-  import ATF4Form from "../forms/ATF4Form.svelte";
-  import CriticalsForm from "../forms/CriticalsForm.svelte";
-  import FormV1 from "../forms/FormV1.svelte";
-  import FormV2 from "../forms/FormV2.svelte";
-  import PlanningForm from "../forms/PlanningForm.svelte";
-  import { SecondaryButton, WarningButton } from "../govuk";
+  import ATF4Form from "lib/forms/ATF4Form.svelte";
+  import CriticalsForm from "lib/forms/CriticalsForm.svelte";
+  import FormV1 from "lib/forms/FormV1.svelte";
+  import FormV2 from "lib/forms/FormV2.svelte";
+  import PlanningForm from "lib/forms/PlanningForm.svelte";
+  import { SecondaryButton, WarningButton } from "lib/govuk";
+  import { deleteIntervention, formOpen, gjScheme } from "stores";
+  import type { FeatureUnion, Schema } from "types";
   import AccordionItem from "./AccordionItem.svelte";
 
   export let schema: Schema;

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -4,8 +4,7 @@
   import "../style/main.css";
   import * as Comlink from "comlink";
   import type { FeatureCollection, Polygon } from "geojson";
-  import { onMount } from "svelte";
-  import BoundaryLayer from "../lib/BoundaryLayer.svelte";
+  import BoundaryLayer from "lib/BoundaryLayer.svelte";
   import {
     BaselayerSwitcher,
     CollapsibleCard,
@@ -13,24 +12,25 @@
     Legend,
     MapLibreMap,
     ZoomOutMap,
-  } from "../lib/common";
-  import { getAuthoritiesGeoJson } from "../lib/common/data_getter";
-  import HoverLayer from "../lib/draw/HoverLayer.svelte";
-  import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
-  import Toolbox from "../lib/draw/Toolbox.svelte";
-  import { SecondaryButton } from "../lib/govuk";
-  import ContextualLayers from "../lib/layers/ContextualLayers.svelte";
-  import About from "../lib/sidebar/About.svelte";
-  import EntireScheme from "../lib/sidebar/EntireScheme.svelte";
-  import Instructions from "../lib/sidebar/Instructions.svelte";
-  import InterventionList from "../lib/sidebar/InterventionList.svelte";
+  } from "lib/common";
+  import { getAuthoritiesGeoJson } from "lib/common/data_getter";
+  import HoverLayer from "lib/draw/HoverLayer.svelte";
+  import InterventionLayer from "lib/draw/InterventionLayer.svelte";
+  import Toolbox from "lib/draw/Toolbox.svelte";
+  import { SecondaryButton } from "lib/govuk";
+  import ContextualLayers from "lib/layers/ContextualLayers.svelte";
+  import About from "lib/sidebar/About.svelte";
+  import EntireScheme from "lib/sidebar/EntireScheme.svelte";
+  import Instructions from "lib/sidebar/Instructions.svelte";
+  import InterventionList from "lib/sidebar/InterventionList.svelte";
   import {
     colorInterventionsBySchema,
     schemaLegend,
     schemaTitle,
-  } from "../schemas";
-  import { routeInfo } from "../stores";
-  import type { Schema } from "../types";
+  } from "schemas";
+  import { routeInfo } from "stores";
+  import { onMount } from "svelte";
+  import type { Schema } from "types";
   import { type RouteInfo } from "../worker";
   import workerWrapper from "../worker?worker";
 

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -2,28 +2,28 @@
   // @ts-ignore no declarations
   import { initAll } from "govuk-frontend";
   import "../style/main.css";
+  import { processInput, type Scheme } from "lib/browse/data";
+  import Filters from "lib/browse/Filters.svelte";
+  import LayerControls from "lib/browse/LayerControls.svelte";
+  import SchemeCard from "lib/browse/SchemeCard.svelte";
   import authorityNamesList from "../../assets/authority_names.json";
-  import { processInput, type Scheme } from "../lib/browse/data";
-  import Filters from "../lib/browse/Filters.svelte";
-  import LayerControls from "../lib/browse/LayerControls.svelte";
-  import SchemeCard from "../lib/browse/SchemeCard.svelte";
   import "../style/main.css";
-  import type { MapGeoJSONFeature } from "maplibre-gl";
-  import { onDestroy, onMount } from "svelte";
   import {
     FileInput,
     InteractiveLayer,
     Layout,
     MapLibreMap,
     ZoomOutMap,
-  } from "../lib/common";
-  import PmTiles from "../lib/common/PmTiles.svelte";
-  import InterventionLayer from "../lib/draw/InterventionLayer.svelte";
-  import { ErrorMessage } from "../lib/govuk";
-  import { emptyGeojson, prettyPrintMeters } from "../lib/maplibre";
-  import { colorInterventionsBySchema } from "../schemas";
-  import { gjScheme } from "../stores";
-  import type { Scheme as GjScheme } from "../types";
+  } from "lib/common";
+  import PmTiles from "lib/common/PmTiles.svelte";
+  import InterventionLayer from "lib/draw/InterventionLayer.svelte";
+  import { ErrorMessage } from "lib/govuk";
+  import { emptyGeojson, prettyPrintMeters } from "lib/maplibre";
+  import type { MapGeoJSONFeature } from "maplibre-gl";
+  import { colorInterventionsBySchema } from "schemas";
+  import { gjScheme } from "stores";
+  import { onDestroy, onMount } from "svelte";
+  import type { Scheme as GjScheme } from "types";
 
   // TODO Remove after the input data is fixed to plumb correct authority names.
   let authorityNames: Set<string> = new Set(authorityNamesList);

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -3,22 +3,22 @@
   import type { FeatureCollection } from "geojson";
   // @ts-ignore no declarations
   import { initAll } from "govuk-frontend";
-  import { Map, type MapGeoJSONFeature } from "maplibre-gl";
-  import { onMount } from "svelte";
   import {
     DefaultButton,
     ErrorMessage,
     FormElement,
     Radio,
     SecondaryButton,
-  } from "../lib/govuk";
+  } from "lib/govuk";
+  import { Map, type MapGeoJSONFeature } from "maplibre-gl";
+  import { onMount } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
-  import { FileInput, InteractiveLayer } from "../lib/common";
-  import { getAuthoritiesGeoJson } from "../lib/common/data_getter";
-  import { bbox, hoveredToggle } from "../lib/maplibre";
-  import About from "../lib/sidebar/About.svelte";
-  import { map as mapStore } from "../stores";
-  import type { Schema } from "../types";
+  import { FileInput, InteractiveLayer } from "lib/common";
+  import { getAuthoritiesGeoJson } from "lib/common/data_getter";
+  import { bbox, hoveredToggle } from "lib/maplibre";
+  import About from "lib/sidebar/About.svelte";
+  import { map as mapStore } from "stores";
+  import type { Schema } from "types";
 
   let showAbout = false;
   const params = new URLSearchParams(window.location.search);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,6 @@
+import { constructMatchExpression } from "lib/maplibre";
 import type { DataDrivenPropertyValueSpecification } from "maplibre-gl";
 import { colors } from "./colors";
-import { constructMatchExpression } from "./lib/maplibre/utils";
 import type { Schema } from "./types";
 
 export function schemaTitle(schema: Schema): string {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,7 +1,7 @@
 import { type Remote } from "comlink";
+import { emptyGeojson } from "lib/maplibre";
 import type { Map } from "maplibre-gl";
 import { writable, type Writable } from "svelte/store";
-import { emptyGeojson } from "./lib/maplibre/utils";
 import {
   isStreetViewImagery,
   type Mode,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "strict": true,
     /* Necessary for Playwright tests */
     "allowImportingTsExtensions": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "baseUrl": "./src"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "tests/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import wasmPack from "vite-plugin-wasm-pack";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   build: {
@@ -13,5 +14,5 @@ export default defineConfig({
       },
     },
   },
-  plugins: [svelte(), wasmPack(["./route_info"], ["route-snapper"])],
+  plugins: [svelte(), tsconfigPaths(), wasmPack(["./route_info"], ["route-snapper"])],
 });


### PR DESCRIPTION
@yongrenjie pointed me at this awesome trick, which'll let us stop using relative paths for imports and instead treat `src/` as our root. This would make changing directory structure _way_ easier. Pete, if this sample change looks good and it works in your IDE, I'll make it everywhere!