### PR TITLE
Improve vehicle counts and cycle parking at low/moderate zooms. #318,…

### DIFF
--- a/src/lib/browse/layers/CycleParkingLayerControl.svelte
+++ b/src/lib/browse/layers/CycleParkingLayerControl.svelte
@@ -25,7 +25,7 @@
     source: name,
     sourceLayer: name,
     color,
-    radius: 5,
+    radius: ["interpolate", ["linear"], ["zoom"], 1, 2, 8, 3, 13, 10],
   });
 
   let show = false;

--- a/src/lib/browse/layers/VehicleCountsLayerControl.svelte
+++ b/src/lib/browse/layers/VehicleCountsLayerControl.svelte
@@ -31,9 +31,9 @@
     sourceLayer: name,
     color: makeColorRamp(["get", "motor_vehicles_2022"], limits, colorScale),
     opacity: 0.9,
-    radius: 15,
+    radius: ["interpolate", ["linear"], ["zoom"], 1, 2, 8, 3, 13, 15],
     strokeColor: "black",
-    strokeWidth: 3,
+    strokeWidth: 0.1,
   });
 
   let show = false;


### PR DESCRIPTION
… #326

See https://acteng.github.io/atip/lowzoom_points/browse.html for the vehicle count and cycle parking layers. I'm happy with the vehicle counts one, but cycle parking is still not great -- some points don't show up at low zoom. I experimented with tippecanoe for a while, including clustering, but couldn't improve on this yet.