### PR TITLE
Don't draw filled polygons for boundary layers, just outlines.

### DIFF
--- a/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/CombinedAuthoritiesLayerControl.svelte
@@ -30,7 +30,7 @@
     id: name,
     source: name,
     color,
-    opacity: hoveredToggle(0.5, 0.1),
+    opacity: hoveredToggle(0.5, 0.0),
   });
   overwriteLineLayer($map, {
     id: outlineLayer,

--- a/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
+++ b/src/lib/browse/layers/LocalAuthorityDistrictsLayerControl.svelte
@@ -30,7 +30,7 @@
     id: name,
     source: name,
     color,
-    opacity: hoveredToggle(0.5, 0.1),
+    opacity: hoveredToggle(0.5, 0.0),
   });
   overwriteLineLayer($map, {
     id: outlineLayer,

--- a/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
+++ b/src/lib/browse/layers/LocalPlanningAuthoritiesLayerControl.svelte
@@ -31,7 +31,7 @@
     source: name,
     sourceLayer: name,
     color,
-    opacity: hoveredToggle(0.5, 0.1),
+    opacity: hoveredToggle(0.5, 0.0),
   });
   overwriteLineLayer($map, {
     id: outlineLayer,
@@ -82,8 +82,8 @@
       </p>
       <p>
         <strong>
-          Note there are overlapping LPAs near Northhamptonshire, shown in a
-          darker shade. Only one authority name is shown when hovering. Use <ExternalLink
+          Note there are overlapping LPAs near Northhamptonshire. Only one
+          authority name is shown when hovering. Use <ExternalLink
             href="https://www.planning.data.gov.uk/map/?dataset=local-planning-authority"
           >
             this map

--- a/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
+++ b/src/lib/browse/layers/ParliamentaryConstituenciesLayerControl.svelte
@@ -31,7 +31,7 @@
     source: name,
     sourceLayer: name,
     color,
-    opacity: hoveredToggle(0.5, 0.1),
+    opacity: hoveredToggle(0.5, 0.0),
   });
   overwriteLineLayer($map, {
     id: outlineLayer,

--- a/src/lib/browse/layers/WardsLayerControl.svelte
+++ b/src/lib/browse/layers/WardsLayerControl.svelte
@@ -31,7 +31,7 @@
     source: name,
     sourceLayer: name,
     color,
-    opacity: hoveredToggle(0.5, 0.1),
+    opacity: hoveredToggle(0.5, 0.0),
   });
   overwriteLineLayer($map, {
     id: outlineLayer,


### PR DESCRIPTION
This is design advice from @stuartlynn. Filling the boundaries with a color doesn't do anything useful, and potentially obscures other layers. Hovering on an area still works the same.
Demo: https://acteng.github.io/atip/hover_boundaries/browse.html

Before (scheme data with wards):
![Screenshot from 2023-09-08 13-09-35](https://github.com/acteng/atip/assets/1664407/4be1250c-b983-4557-9238-bf1d844fe6ea)

After:
![Screenshot from 2023-09-08 13-09-00](https://github.com/acteng/atip/assets/1664407/b2aa0557-7059-43c4-a5ea-c1da5e1e03ee)