### PR TITLE
Automatically deploy App Engine for test environment

### DIFF
--- a/.github/workflows/deploy_appengine.yml
+++ b/.github/workflows/deploy_appengine.yml
@@ -1,0 +1,55 @@
+name: Deploy to app engine
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: dft-rlg-atip-dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Cache WASM build
+        uses: actions/cache@v3
+        with:
+          path: route_info/target
+          key: doesnt-matter-share-everything
+
+      - name: Build
+        run: |
+          npm ci
+          npm run wasm-release
+          npm run setup-govuk
+          npm run generate-schema-ts
+          VITE_RESOURCE_BASE="https://${PROJECT_ID}.ew.r.appspot.com/data" npm run build
+          cd backend
+          rm -rf dist
+          cp -R ../dist .
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GCP_DEV_CREDENTIALS }}'
+
+      - name: Deploy
+        uses: google-github-actions/deploy-appengine@v1
+        with:
+          project_id: ${{ vars.PROJECT_ID }}
+          deliverables: backend/app.yaml

--- a/.github/workflows/deploy_appengine.yml
+++ b/.github/workflows/deploy_appengine.yml
@@ -26,16 +26,9 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
 
-      - name: Cache WASM build
-        uses: actions/cache@v3
-        with:
-          path: route_info/target
-          key: doesnt-matter-share-everything
-
       - name: Build
         run: |
           npm ci
-          npm run wasm-release
           npm run setup-govuk
           npm run generate-schema-ts
           VITE_RESOURCE_BASE="https://${PROJECT_ID}.ew.r.appspot.com/data" npm run build

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,27 @@ To add someone:
 
 After changing this, there's seemingly a propagation delay of about a minute. You might also need to Ctrl+Shift+R or clear your browser cache.
 
+### Automatically deploy from GH Actions
+
+For the test environment, we can automatically deploy App Engine for every push to the `main` branch of the Github repo. One-time setup steps to create a service account with permission to deploy, and a [service account JSON key](https://github.com/google-github-actions/auth#authenticating-via-service-account-key-json):
+
+```
+gcloud services --project=$PROJECT enable appengine.googleapis.com
+
+gcloud iam service-accounts --project=$PROJECT create gh-builder-service-account
+
+# See https://github.com/google-github-actions/deploy-appengine for reference
+for role in roles/appengine.appAdmin roles/storage.admin roles/cloudbuild.builds.editor roles/iam.serviceAccountUser; do
+	gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:gh-builder-v2@$PROJECT.iam.gserviceaccount.com" --role=$role;
+done
+
+gcloud iam service-accounts keys create private_key --iam-account=gh-builder-v2@$PROJECT.iam.gserviceaccount.com
+```
+
+You then need to set the `GCP_DEV_CREDENTIALS` secret in Github. Go to <https://github.com/acteng/atip/settings/secrets/actions> and create/edit it as needed. The contents are the `private_key` file created by the last command, but you need to format it as a one-liner. If you have [jq](https://jqlang.github.io/jq/)`, you can just do `cat private_key | jq - c` and copy that.
+
+**Remove the private_key file after creating the Github secret, and make sure it's never made public**
+
 ## TODO
 
 - Automated setup

--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -3,4 +3,5 @@ env_variables:
   #GCS_BUCKET: "atip-test-2"
   #PROJECT_NUMBER: "29375903718"
   GCS_BUCKET: "dft-rlg-atip-dev"
-  PROJECT_NUMBER: "TODO(pete)"
+  PROJECT_NUMBER: "537912455420"
+        "

--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -4,4 +4,3 @@ env_variables:
   #PROJECT_NUMBER: "29375903718"
   GCS_BUCKET: "dft-rlg-atip-dev"
   PROJECT_NUMBER: "537912455420"
-        "

--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -1,4 +1,6 @@
 runtime: nodejs18
 env_variables:
-  GCS_BUCKET: "atip-test-2"
-  PROJECT_NUMBER: "29375903718"
+  #GCS_BUCKET: "atip-test-2"
+  #PROJECT_NUMBER: "29375903718"
+  GCS_BUCKET: "dft-rlg-atip-dev"
+  PROJECT_NUMBER: "TODO(pete)"


### PR DESCRIPTION
Via following https://github.com/google-github-actions/deploy-appengine. To note, I tried using the newer workload identity federation option, but the documentation is antagonistically dense.

Pete, you'll need to update the project number in this PR please! I tested with my own project, but we won't be able to really try this out for the real test environment without merging (because it's set to only trigger for the main branch).