### PR TITLE
Update route-snapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "js-cookie": "^3.0.5",
         "maplibre-gl": "^3.3.1",
         "read-excel-file": "^5.6.1",
-        "route-snapper": "^0.1.14",
+        "route-snapper": "^0.1.15",
         "svelte": "^4.0.0",
         "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
       },
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.14.tgz",
-      "integrity": "sha512-/3zRoRI0VL+aPas+fDQ9lvp5Fqkc5WosRh0gd/JrlJ3dA4nfXCzxZG9l04NsGzvhIYoDPy/2j3ivvost6GW7BA=="
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.15.tgz",
+      "integrity": "sha512-1pSc5EqLEIOdX5XVeNGaGGDbOExxqRxj65uwrZv/llyX9vmyrJrHezz5pqx9ZWyGaDJLNLuTg4tJixPve677tw=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-cookie": "^3.0.5",
     "maplibre-gl": "^3.3.1",
     "read-excel-file": "^5.6.1",
-    "route-snapper": "^0.1.14",
+    "route-snapper": "^0.1.15",
     "svelte": "^4.0.0",
     "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
   }

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -203,11 +203,7 @@ export class RouteTool {
       return;
     }
 
-    this.inner.setConfig({
-      avoid_doubling_back: true,
-      area_mode: true,
-      extend_route: true,
-    });
+    this.inner.setAreaMode();
     this.setActivity(true);
     this.map.boxZoom.disable();
     this.map.doubleClickZoom.disable();
@@ -332,7 +328,7 @@ export class RouteTool {
     avoid_doubling_back: boolean;
     extend_route: boolean;
   }) {
-    this.inner.setConfig({ ...config, area_mode: false });
+    this.inner.setRouteConfig(config);
     this.redraw();
   }
 


### PR DESCRIPTION
I finally published https://github.com/dabreegster/route_snapper/blob/main/CHANGES.md#0115, now updating here. This closes #252, reducing the coordinate precision for everything we produce. It also tightens up the API for starting the snap tool in either linear route or area mode.