### PR TITLE
Use new route-snappers, revamping how auto-named routes work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "js-cookie": "^3.0.5",
         "maplibre-gl": "^3.3.1",
         "read-excel-file": "^5.6.1",
-        "route-snapper": "^0.1.15",
+        "route-snapper": "^0.2.1",
         "svelte": "^4.0.0",
         "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
       },
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.1.15.tgz",
-      "integrity": "sha512-1pSc5EqLEIOdX5XVeNGaGGDbOExxqRxj65uwrZv/llyX9vmyrJrHezz5pqx9ZWyGaDJLNLuTg4tJixPve677tw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.2.1.tgz",
+      "integrity": "sha512-p9DTRyp3CJ2kblygXDoL78nZMhiMRc7vRYrrvxYXOo7HeBvaY+PH1evzUN94zmUqEU6oPQFI6rJ9rA8pSk8brQ=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-cookie": "^3.0.5",
     "maplibre-gl": "^3.3.1",
     "read-excel-file": "^5.6.1",
-    "route-snapper": "^0.1.15",
+    "route-snapper": "^0.2.1",
     "svelte": "^4.0.0",
     "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
   }

--- a/src/lib/draw/GeometryMode.svelte
+++ b/src/lib/draw/GeometryMode.svelte
@@ -261,6 +261,13 @@
     if (source.properties.waypoints) {
       destination.properties.waypoints = source.properties.waypoints;
     }
+    // Only copy route_name if the user hasn't set it. It's not simple to
+    // distinguish the user manually editing the name from it being auto-filled
+    // previously, so be safe and don't overwrite anything. The user can always
+    // use the auto-fill button explicitly.
+    if (source.properties.route_name && !destination.properties.name) {
+      destination.properties.name = source.properties.route_name;
+    }
   }
 </script>
 

--- a/src/lib/draw/common.ts
+++ b/src/lib/draw/common.ts
@@ -27,6 +27,10 @@ export function setupEventListeners(
       gjScheme.update((gj) => {
         feature.id = newFeatureId(gj);
         feature.properties.intervention_type = intervention_type;
+        if (feature.properties.route_name) {
+          feature.properties.name = feature.properties.route_name;
+          delete feature.properties.route_name;
+        }
         gj.features.push(feature as FeatureUnion);
         return gj;
       });
@@ -62,6 +66,10 @@ export function handleUnsavedFeature(
       let feature = unsavedFeature.value!;
       feature.id = newFeatureId(gj);
       feature.properties.intervention_type = intervention_type;
+      if (feature.properties.route_name) {
+        feature.properties.name = feature.properties.route_name;
+        delete feature.properties.route_name;
+      }
       gj.features.push(feature as FeatureUnion);
       return gj;
     });

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -2,7 +2,7 @@
   import type { LineString } from "geojson";
   import type { FeatureWithProps } from "lib/maplibre";
   import init from "route-snapper";
-  import { currentMode, map } from "stores";
+  import { currentMode, jsRouteSnapper, map } from "stores";
   import { onMount } from "svelte";
   import type { Mode } from "types";
   import { handleUnsavedFeature, setupEventListeners } from "../common";
@@ -53,6 +53,7 @@
         (percentLoaded) => (progress = percentLoaded)
       );
       routeTool = new RouteTool($map, graphBytes, routeToolInitialised);
+      jsRouteSnapper.set(routeTool.inner);
     } catch (err) {
       console.log(`Route tool broke: ${err}`);
       failedToLoadRouteTool = true;

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { Feature, LineString } from "geojson";
+  import type { LineString } from "geojson";
   import { FormElement, Radio, SecondaryButton, TextArea } from "lib/govuk";
   import { prettyPrintMeters } from "lib/maplibre";
-  import { gjScheme, routeInfo } from "stores";
+  import { gjScheme, jsRouteSnapper } from "stores";
+  import type { Feature } from "types";
 
   export let id: number;
   export let name: string;
@@ -12,12 +13,14 @@
 
   // Sets the intervention name to "From {road1 and road2} to {road3 and
   // road4}". Only meant to be useful for routes currently.
-  async function autoFillName() {
-    let linestring = $gjScheme.features.find(
+  function autoFillName() {
+    let feature = $gjScheme.features.find(
       (f) => f.id == id
     ) as Feature<LineString>;
     try {
-      name = await $routeInfo!.nameForRoute(linestring);
+      name = $jsRouteSnapper!.routeNameForWaypoints(
+        feature.properties.waypoints
+      );
     } catch (e) {
       window.alert(`Couldn't auto-name route: ${e}`);
     }
@@ -28,7 +31,10 @@
   <input type="text" class="govuk-input" bind:value={name} />
   <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
   {#if length_meters}
-    <SecondaryButton on:click={() => autoFillName()} disabled={!$routeInfo}>
+    <SecondaryButton
+      on:click={() => autoFillName()}
+      disabled={!$jsRouteSnapper}
+    >
       Auto-fill
     </SecondaryButton>
   {/if}

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -44,7 +44,7 @@
   // releases. The two data releases may also be changed independently.
   let routeSnapperUrl = `${
     import.meta.env.VITE_RESOURCE_BASE
-  }/route-snappers/v2.1/${authorityName}.bin.gz`;
+  }/route-snappers/v2.2/${authorityName}.bin.gz`;
   let routeInfoUrl = `${
     import.meta.env.VITE_RESOURCE_BASE
   }/route-info/v2/${authorityName}.bin.gz`;

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,6 +1,7 @@
 import { type Remote } from "comlink";
 import { emptyGeojson } from "lib/maplibre";
 import type { Map } from "maplibre-gl";
+import { JsRouteSnapper } from "route-snapper";
 import { writable, type Writable } from "svelte/store";
 import {
   isStreetViewImagery,
@@ -19,6 +20,9 @@ export const mapStyle: Writable<string> = writable("dataviz");
 
 // A global singleton, with a RouteInfo web worker. It's null before it's loaded.
 export const routeInfo: Writable<Remote<RouteInfo> | null> = writable(null);
+// A global singleton, with the route snapper loaded for the current map. It's
+// null before it's loaded. This must only be used for read-only methods.
+export const jsRouteSnapper: Writable<JsRouteSnapper | null> = writable(null);
 
 // TODO Should we instead store a map from ID to feature?
 export const gjScheme: Writable<Scheme> = writable(emptyGeojson() as Scheme);

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -3,7 +3,7 @@ import { clickMap } from "./shared.js";
 
 // This is separate from modes.spec.ts to avoid the common beforeAll
 test("other tools work when route tool doesn't load", async ({ page }) => {
-  await page.route("https://atip.uk/route-snappers/v2.1/Adur.bin.gz", (route) =>
+  await page.route("https://atip.uk/route-snappers/v2.2/Adur.bin.gz", (route) =>
     route.fulfill({
       status: 404,
     })

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -102,13 +102,20 @@ test("creating a new route opens a form, and auto-fill sets its name", async () 
   await clickMap(page, 400, 500);
   await page.getByRole("button", { name: "Finish" }).click();
 
+  // The route immediately has a name
   await expect(
-    page.getByRole("button", { name: "1) Untitled route" })
+    page.getByRole("button", {
+      name: "1) Route from ??? and Brighton Road to ???",
+    })
   ).toBeVisible();
-  await page.getByLabel("Description").click();
 
-  // This button only works after RouteInfo is loaded. And note because the
-  // button is located inside a label, getByRole doesn't seem to work.
+  // Change it
+  await page.getByRole("textbox").nth(2).fill("New route name");
+  await expect(
+    page.getByRole("button", { name: "1) New route name" })
+  ).toBeVisible();
+
+  // Then auto-fill to change it back
   await page.getByText("Auto-fill").click();
   await expect(
     page.getByRole("button", {
@@ -151,7 +158,11 @@ test("adding interventions, then deleting one, then adding another", async () =>
   await clickMap(page, 192, 513);
   await page.getByRole("button", { name: "Finish" }).click();
   await page.getByRole("button", { name: "Save" }).click();
-  await page.getByRole("button", { name: "1) Untitled route" }).click();
+  await page
+    .getByRole("button", {
+      name: "1) Route from Old Shoreham Road and Ropetackle to Ullswater Road and Western Road North",
+    })
+    .click();
   await page.getByRole("button", { name: "Delete" }).click();
   await page.getByRole("button", { name: "New route" }).click();
   await clickMap(page, 196, 375);
@@ -159,7 +170,9 @@ test("adding interventions, then deleting one, then adding another", async () =>
   await page.getByRole("button", { name: "Finish" }).click();
 
   await expect(
-    page.getByRole("button", { name: "1) Untitled route" })
+    page.getByRole("button", {
+      name: "1) Route from ???, Bowness Avenue, and Western Road to West Avenue and West Way",
+    })
   ).toBeVisible();
 });
 
@@ -168,12 +181,12 @@ test("add a route and save it", async () => {
   await clickMap(page, 522, 468);
   await clickMap(page, 192, 513);
   await page.getByRole("button", { name: "Finish" }).click();
-  // wait to make sure intervention attributes appear
-  await page.getByRole("button", { name: "Save" }).waitFor();
   await page.getByRole("button", { name: "Save" }).click();
 
   await expect(
-    page.getByRole("button", { name: "1) Untitled route" })
+    page.getByRole("button", {
+      name: "1) Route from Old Shoreham Road and Ropetackle to Ullswater Road and Western Road North",
+    })
   ).toBeVisible();
 });
 


### PR DESCRIPTION
This is a followup to #352. We're going to remove the `route-info` WASM library, which only has one useful working feature: auto-naming routes based on the two intersection endpoints. This PR changes that feature to instead use a new version of the route-snapper library. It also slightly improves the UX, by populating the name automatically when a route is first made. Users can still override the name, or later auto-fill it (to correct things after a split, for instance).

The benefits to dismantling the route-info service are:

- Page load performance: almost half the amount of data to load, because now we only load a route snapper graph, not a second file. The snapper file has grown slightly now that it has names, but it's a small increase when gzipped, and the overall change is way less to download.
- Code simplicity: we don't have two WASM libraries doing confusingly similar things
- Deployment performance: now we don't need to compile any WASM packages in this repo, so CI is going to get way faster.

On that last point, I'm going to remove the old route-info service next. It has to be separate, due to how tricky it is to upload the GH workflow script and handle all outstanding branches.