### PR TITLE
Add a geocoder using MapTiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "atip",
       "version": "0.0.0",
       "dependencies": {
+        "@maptiler/geocoding-control": "^0.0.99",
         "@turf/bbox": "^6.5.0",
         "@turf/boolean-contains": "^6.5.0",
         "@turf/boolean-point-in-polygon": "^6.5.0",
@@ -938,6 +939,36 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
+    "node_modules/@maptiler/geocoding-control": {
+      "version": "0.0.99",
+      "resolved": "https://registry.npmjs.org/@maptiler/geocoding-control/-/geocoding-control-0.0.99.tgz",
+      "integrity": "sha512-ehJD12JnUXzLbpISiAhj7hEQQObXecbqIXYVf265Un2TT9yJFbMDBiP2dGMROCYOGjrBMh4npaPoMt6v6v1D8g==",
+      "peerDependencies": {
+        "@maptiler/sdk": "^1",
+        "leaflet": "^1.9 || ^1.8",
+        "maplibre-gl": "^2 || ^3.0.0-alpha || ^3",
+        "ol": "^7.4.0",
+        "react": "^17 || ^18",
+        "svelte": "^4.2"
+      },
+      "peerDependenciesMeta": {
+        "@maptiler/sdk": {
+          "optional": true
+        },
+        "leaflet": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        },
+        "ol": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1381,9 +1412,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3198,15 +3229,15 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.1.tgz",
+      "integrity": "sha512-LpLqY2Jr7cRxkrTc796/AaaoMLF/1ax7cto8Ot76wrvKQhrPmZ0JgajiWPmg9mTSDqO16SSLiD17r9MsvAPTmw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
+    "@maptiler/geocoding-control": "^0.0.99",
     "@turf/bbox": "^6.5.0",
     "@turf/boolean-contains": "^6.5.0",
     "@turf/boolean-point-in-polygon": "^6.5.0",

--- a/src/lib/common/Geocoder.svelte
+++ b/src/lib/common/Geocoder.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { createMapLibreGlMapController } from "@maptiler/geocoding-control/maplibregl";
+  import GeocodingControl from "@maptiler/geocoding-control/svelte/GeocodingControl.svelte";
+  import type { MapController } from "@maptiler/geocoding-control/types";
+  import maplibregl from "maplibre-gl";
+  import { map } from "stores";
+  import { onMount } from "svelte";
+
+  let mapController: MapController;
+
+  // TODO HMR is broken
+  onMount(() => {
+    mapController = createMapLibreGlMapController($map, maplibregl);
+  });
+
+  // TODO Show markers
+  // TODO Set the flyTo duration
+</script>
+
+{#if mapController}
+  <div>
+    <GeocodingControl
+      {mapController}
+      apiKey={import.meta.env.VITE_MAPTILER_API_KEY}
+      country="gb"
+    />
+  </div>
+{/if}
+
+<style>
+  div {
+    position: absolute;
+    top: 20px;
+    left: 50px;
+  }
+</style>

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -7,6 +7,7 @@ export { default as ColorLegend } from "./ColorLegend.svelte";
 export { default as DiscreteLegend } from "./DiscreteLegend.svelte";
 export { default as ExternalLink } from "./ExternalLink.svelte";
 export { default as FileInput } from "./FileInput.svelte";
+export { default as Geocoder } from "./Geocoder.svelte";
 export { default as HelpButton } from "./HelpButton.svelte";
 export { default as Layout } from "./Layout.svelte";
 export { default as Legend } from "./Legend.svelte";

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -13,6 +13,7 @@
   import {
     appVersion,
     FileInput,
+    Geocoder,
     Layout,
     LoggedIn,
     MapLibreMap,
@@ -89,6 +90,7 @@
   </div>
   <div slot="main">
     <MapLibreMap style={$mapStyle} startBounds={[-5.96, 49.89, 2.31, 55.94]}>
+      <Geocoder />
       <InterventionLayer {schemesGj} {filterText} {showSchemes} />
       <div class="top-right">
         <LayerControls />


### PR DESCRIPTION
#288 

I started with maplibre-gl-geocoder and Nominatim API, following https://maplibre.org/maplibre-gl-js/docs/examples/geocoder/, but the plugin's UX was clunky and results from Nominatim are not great. Since we're using MapTiler for some basemaps anyway and already have an API key, I decided to try their plugin + API instead, and I think it works much more smoothly.

Try at https://acteng.github.io/atip/geocoder_maptiler/browse.html. It's still imperfect, but I think this is enough to start.