### PR TITLE
A few UX fixes

### DIFF
--- a/src/lib/browse/InterventionLayer.svelte
+++ b/src/lib/browse/InterventionLayer.svelte
@@ -42,6 +42,7 @@
     {...layerId("interventions-points")}
     filter={["all", isPoint, hideWhileEditing, notEndpoint]}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "circle-color": colorInterventions,
       "circle-radius": circleRadius,
@@ -60,6 +61,7 @@
     {...layerId("interventions-lines")}
     filter={["all", isLine, hideWhileEditing]}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "line-color": colorInterventions,
       "line-width": lineWidth,
@@ -91,6 +93,7 @@
     {...layerId("interventions-polygons")}
     filter={["all", isPolygon, hideWhileEditing]}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "fill-color": colorInterventions,
       "fill-opacity": hoverStateFilter(0.2, 0.5),

--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -3,9 +3,9 @@
     appVersion,
     BaselayerSwitcher,
     CollapsibleCard,
+    LineMeasureController,
     StreetViewController,
   } from "lib/common";
-  import LineMeasureController from "lib/common/LineMeasureController.svelte";
   import { CheckboxGroup } from "lib/govuk";
   import { interactiveMapLayersEnabled } from "stores";
   import CensusOutputAreaLayerControl from "./layers/areas/CensusOutputAreas.svelte";

--- a/src/lib/browse/layers/areas/CensusOutputAreas.svelte
+++ b/src/lib/browse/layers/areas/CensusOutputAreas.svelte
@@ -196,6 +196,7 @@
     layout={{
       visibility: colorBy != "" ? "visible" : "none",
     }}
+    eventsIfTopMost
     manageHoverState
     hoverCursor="pointer"
     on:click={onClick}

--- a/src/lib/browse/layers/areas/CombinedAuthorities.svelte
+++ b/src/lib/browse/layers/areas/CombinedAuthorities.svelte
@@ -61,6 +61,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
     on:click={onClick}
     hoverCursor="pointer"
   >

--- a/src/lib/browse/layers/areas/IMD.svelte
+++ b/src/lib/browse/layers/areas/IMD.svelte
@@ -69,6 +69,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
   >
     <Popup let:props>
       <p>

--- a/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
+++ b/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
@@ -61,6 +61,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
     on:click={onClick}
     hoverCursor="pointer"
   >

--- a/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
+++ b/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
@@ -82,6 +82,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
   >
     <Popup let:props>
       <p>{props.name}</p>

--- a/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
+++ b/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
@@ -69,6 +69,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
     on:click={onClick}
     hoverCursor="pointer"
   >

--- a/src/lib/browse/layers/areas/Wards.svelte
+++ b/src/lib/browse/layers/areas/Wards.svelte
@@ -61,6 +61,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
     on:click={onClick}
     hoverCursor="pointer"
   >

--- a/src/lib/browse/layers/lines/BusRoutes.svelte
+++ b/src/lib/browse/layers/lines/BusRoutes.svelte
@@ -63,6 +63,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
   >
     <Popup let:props>
       {#if props.has_bus_lane}

--- a/src/lib/browse/layers/lines/CyclePaths.svelte
+++ b/src/lib/browse/layers/lines/CyclePaths.svelte
@@ -124,6 +124,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
     hoverCursor="pointer"
     on:click={onClick}
   >

--- a/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
+++ b/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
@@ -46,6 +46,7 @@
     {...layerId(name)}
     sourceLayer={name}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "line-color": color,
       "line-width": 7,

--- a/src/lib/browse/layers/lines/PCT.svelte
+++ b/src/lib/browse/layers/lines/PCT.svelte
@@ -126,6 +126,7 @@
     {...layerId(nameSchool)}
     sourceLayer={nameSchool}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "line-color": makeColorRamp(["get", scenario], limits, colorScale),
       "line-width": denseLineWidth,

--- a/src/lib/browse/layers/lines/RoadSpeeds.svelte
+++ b/src/lib/browse/layers/lines/RoadSpeeds.svelte
@@ -87,6 +87,7 @@
     {...layerId(name)}
     sourceLayer={name}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "line-color": makeColorRamp(["get", showSpeed], limits, colorScale),
       "line-width": denseLineWidth,

--- a/src/lib/browse/layers/lines/RoadWidths.svelte
+++ b/src/lib/browse/layers/lines/RoadWidths.svelte
@@ -55,6 +55,7 @@
     {...layerId(name)}
     sourceLayer={name}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "line-color": makeColorRamp(["get", "average"], limits, colorScale),
       // TODO Try showing the actual width, in meters and not pixels

--- a/src/lib/browse/layers/points/CriticalIssues.svelte
+++ b/src/lib/browse/layers/points/CriticalIssues.svelte
@@ -110,6 +110,7 @@
     {...layerId(`${source}-points`)}
     applyToClusters={false}
     manageHoverState
+    eventsIfTopMost
     paint={{
       "circle-color": color,
       "circle-opacity": hoverStateFilter(0.9, 0.5),

--- a/src/lib/browse/layers/points/Crossings.svelte
+++ b/src/lib/browse/layers/points/Crossings.svelte
@@ -90,6 +90,7 @@
       visibility: show ? "visible" : "none",
     }}
     hoverCursor="pointer"
+    eventsIfTopMost
     on:click={onClick}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/points/CycleParking.svelte
+++ b/src/lib/browse/layers/points/CycleParking.svelte
@@ -60,6 +60,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
   >
     <Popup let:props>
       <p>

--- a/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
@@ -55,6 +55,7 @@
       visibility: show ? "visible" : "none",
     }}
     manageHoverState
+    eventsIfTopMost
   >
     <Popup let:props>
       <p>{props.name ?? `Unnamed ${singularNoun}`}</p>

--- a/src/lib/browse/layers/points/VehicleCounts.svelte
+++ b/src/lib/browse/layers/points/VehicleCounts.svelte
@@ -96,6 +96,7 @@
       visibility: show ? "visible" : "none",
     }}
     hoverCursor="pointer"
+    eventsIfTopMost
     on:click={onClick}
   >
     <Popup let:props>

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -11,6 +11,7 @@ export { default as Geocoder } from "./Geocoder.svelte";
 export { default as HelpButton } from "./HelpButton.svelte";
 export { default as Layout } from "./Layout.svelte";
 export { default as Legend } from "./Legend.svelte";
+export { default as LineMeasureController } from "./LineMeasureController.svelte";
 export { default as LoggedIn } from "./LoggedIn.svelte";
 export { default as Popup } from "./Popup.svelte";
 export { default as MapLibreMap } from "./MapLibreMap.svelte";

--- a/src/pages/CriticalIssueEntry.svelte
+++ b/src/pages/CriticalIssueEntry.svelte
@@ -8,7 +8,9 @@
   import {
     appVersion,
     BaselayerSwitcher,
+    Geocoder,
     Layout,
+    LineMeasureController,
     LoggedIn,
     MapLibreMap,
     StreetViewController,
@@ -52,6 +54,7 @@
   </div>
   <div slot="main">
     <MapLibreMap style={$mapStyle} startBounds={[-5.96, 49.89, 2.31, 55.94]}>
+      <Geocoder />
       <Pin bind:markerPosition enableAdding={streetviewOff} />
       <div class="top-right">
         <BaselayerSwitcher disabled={!streetviewOff} />
@@ -60,6 +63,7 @@
           displayEnableButton
           bind:isInactive={streetviewOff}
         />
+        <div><LineMeasureController /></div>
       </div>
     </MapLibreMap>
   </div>

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -6,6 +6,7 @@
   import BoundaryLayer from "lib/BoundaryLayer.svelte";
   import {
     appVersion,
+    Geocoder,
     getAuthoritiesGeoJson,
     Layout,
     LoggedIn,
@@ -96,6 +97,7 @@
   </div>
   <div slot="main">
     <MapLibreMap style={$mapStyle}>
+      <Geocoder />
       <BoundaryLayer {boundaryGeojson} />
       <InterventionLayer
         colorInterventions={colorInterventionsBySchema(schema)}


### PR DESCRIPTION
- When there are overlapping layers, only let the topmost one have interactions. (I accidentally lost this behavior during the svelte-maplibre shuffle, when switching from my fork to the upstream)
- Add the geocoder to critical entry and sketch pages
- Add the line measure tool to the critical entry page (but it partly breaks / conflicts with the main tool there)

Demo at https://acteng.github.io/atip/topmost/browse.html