### PR TITLE
Add pollution layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "read-excel-file": "^5.6.1",
         "route-snapper": "^0.2.1",
         "svelte": "^4.0.0",
-        "svelte-maplibre": "^0.5.0"
+        "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
@@ -3286,14 +3286,14 @@
       }
     },
     "node_modules/svelte-maplibre": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/svelte-maplibre/-/svelte-maplibre-0.5.0.tgz",
-      "integrity": "sha512-g/Q+uV2SImSQoLSb6heDZ8zzr3lk9YBRIICMVJ+sfrw5EYf9qKZK+ixj8SpwZIJYyMyrMEEnoQp8Rn1aJGdX5Q==",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/dabreegster/svelte-maplibre.git#3f1992324e949d79b73ece255dca449812a47261",
+      "license": "MIT",
       "dependencies": {
         "d3-geo": "^3.1.0",
         "just-compare": "^2.3.0",
         "just-flush": "^2.3.0",
-        "maplibre-gl": "^3.0.0",
+        "maplibre-gl": "^3.5.0",
         "pmtiles": "^2.10.0"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "govuk-frontend": "^4.6.0",
         "humanize-string": "^3.0.0",
         "js-cookie": "^3.0.5",
-        "maplibre-gl": "^3.3.1",
+        "maplibre-gl": "^3.5.1",
         "read-excel-file": "^5.6.1",
         "route-snapper": "^0.2.1",
         "svelte": "^4.0.0",
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.1.tgz",
-      "integrity": "sha512-ss5+b3/a8I1wD5PYmAYPYxg0Nag0cxvw4GGOnQroTP59sobTPI3KeHP9OjUr/es7uNtYEodr54fgoEnCBF6gaQ==",
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -1353,9 +1353,9 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA=="
     },
     "node_modules/@types/js-cookie": {
       "version": "3.0.3",
@@ -1364,14 +1364,14 @@
       "dev": true
     },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.3.tgz",
+      "integrity": "sha512-2W46IOXlu7vC8m3+M5rDqSnuY22GFxxx3xhkoyqyPWrD+eP2iAwNst0A1+umLYjCTJMJTSpiofphn9h9k+Kw+w=="
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.3.tgz",
+      "integrity": "sha512-d263B3KCQtXKVZMHpMJrEW5EeLBsQ8jvAS9nhpUKC5hHIlQaACG9PWkW8qxEeNuceo9120AwPjeS91uNa4ltqA==",
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -1385,9 +1385,9 @@
       "dev": true
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.4.tgz",
+      "integrity": "sha512-SOFlLGZkLbEXJRwcWCqeP/Koyaf/uAqLXHUsdo/nMfjLsNd8kqauwHe9GBOljSmpcHp/LC6kOjo3SidGjNirVA=="
     },
     "node_modules/@types/pug": {
       "version": "2.0.6",
@@ -1396,9 +1396,9 @@
       "dev": true
     },
     "node_modules/@types/supercluster": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.0.tgz",
-      "integrity": "sha512-6JapQ2GmEkH66r23BK49I+u6zczVDGTtiJEVvKDYZVSm/vepWaJuTq6BXzJ6I4agG5s8vA1KM7m/gXWDg03O4Q==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.2.tgz",
+      "integrity": "sha512-qMhofL945Z4njQUuntadexAgPtpiBC014WvVqU70Prj42LC77Xgmz04us7hSMmwjs7KbgAwGBmje+FSOvDbP0Q==",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -2492,9 +2492,9 @@
       "dev": true
     },
     "node_modules/maplibre-gl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.3.1.tgz",
-      "integrity": "sha512-SfRq9bT68GytDzCOG0IoTGg2rASbgdYunW/6xhnp55QuLmwG1M/YOlXxqHaphwia7kZbMvBOocvY0fp5yfTjZA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.5.1.tgz",
+      "integrity": "sha512-XFpqAKjpm7Y6cV3B1MDZ3FGUCXyrfeM2QkXloKc4x2QK9/e6/BEHdVebtxXcTrwdzpQexKrMqzdYCbaobJRNrw==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -2503,12 +2503,12 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.0",
-        "@types/geojson": "^7946.0.10",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
+        "@types/geojson": "^7946.0.11",
         "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "@types/supercluster": "^7.1.0",
+        "@types/mapbox__vector-tile": "^1.3.1",
+        "@types/pbf": "^3.0.3",
+        "@types/supercluster": "^7.1.1",
         "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "read-excel-file": "^5.6.1",
     "route-snapper": "^0.2.1",
     "svelte": "^4.0.0",
-    "svelte-maplibre": "^0.5.0"
+    "svelte-maplibre": "github:dabreegster/svelte-maplibre#changes_for_atip"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "govuk-frontend": "^4.6.0",
     "humanize-string": "^3.0.0",
     "js-cookie": "^3.0.5",
-    "maplibre-gl": "^3.3.1",
+    "maplibre-gl": "^3.5.1",
     "read-excel-file": "^5.6.1",
     "route-snapper": "^0.2.1",
     "svelte": "^4.0.0",

--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -14,6 +14,7 @@
   import LocalAuthorityDistrictsLayerControl from "./layers/areas/LocalAuthorityDistricts.svelte";
   import LocalPlanningAuthoritiesLayerControl from "./layers/areas/LocalPlanningAuthorities.svelte";
   import ParliamentaryConstituenciesLayerControl from "./layers/areas/ParliamentaryConstituencies.svelte";
+  import PollutionLayerControl from "./layers/areas/Pollution.svelte";
   import WardsLayerControl from "./layers/areas/Wards.svelte";
   import BusRoutesLayerControl from "./layers/lines/BusRoutes.svelte";
   import CyclePathsLayerControl from "./layers/lines/CyclePaths.svelte";
@@ -74,6 +75,7 @@
       <RoadWidthsLayerControl />
       <RoadSpeedsLayerControl />
     {/if}
+    <PollutionLayerControl />
   </CollapsibleCard>
   <CollapsibleCard label="Tools">
     <StreetViewTool bind:enabled={streetviewEnabled} />

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { ExternalLink, HelpButton, Popup } from "lib/common";
+  import { Checkbox } from "lib/govuk";
+  import { layerId } from "lib/maplibre";
+  import { map } from "stores";
+  import { onDestroy, onMount } from "svelte";
+  import OsOglLicense from "../OsOglLicense.svelte";
+
+  let name = "pollution";
+
+  let show = false;
+
+  // legend
+  //"https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/NOx_viridis/MapServer/WMSServer?request=GetLegendGraphic%26version=1.3.0%26format=image/png%26layer=21"
+
+  onMount(() => {
+    $map.addSource(name, {
+      type: "raster",
+      tiles: [
+        "https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/NOx_viridis/MapServer/WMSServer?request=GetMap&version=1.3.0&format=image/png&crs=EPSG:3857&width=256&height=256&styles=&bbox={bbox-epsg-3857}&layers=21",
+      ],
+      tileSize: 256,
+    });
+    $map.addLayer({
+      id: "pollution-layer",
+      type: "raster",
+      source: name,
+      paint: {
+        "raster-opacity": 0.5,
+      },
+      layout: {
+        visibility: "none",
+      },
+    });
+  });
+  onDestroy(() => {
+    $map?.removeLayer("pollution-layer");
+    $map?.removeSource(name);
+  });
+
+  $: $map.setLayoutProperty(
+    "pollution-layer",
+    "visibility",
+    show ? "visible" : "none"
+  );
+</script>
+
+<Checkbox id={name} bind:checked={show}>
+  Pollution
+  <span slot="right">
+    <HelpButton>
+      <p>TODO</p>
+      <OsOglLicense />
+    </HelpButton>
+  </span>
+</Checkbox>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
-  import { ExternalLink, HelpButton, Popup } from "lib/common";
-  import { Select, Checkbox } from "lib/govuk";
+  import { ExternalLink, HelpButton } from "lib/common";
+  import { Checkbox, Select } from "lib/govuk";
   import { layerId } from "lib/maplibre";
-  import { map } from "stores";
-  import { onDestroy, onMount } from "svelte";
-  import type { RasterTileSource } from "maplibre-gl";
+  import { RasterLayer, RasterTileSource } from "svelte-maplibre";
   import OsOglLicense from "../OsOglLicense.svelte";
-
-  let source = "pollution";
 
   let show = false;
 
   let pollutant = "PM25_viridis";
 
-  function url(): string {
+  function url(pollutant: string): string {
     let params = new URLSearchParams({
       request: "GetMap",
       version: "1.3.0",
@@ -24,63 +20,23 @@
       styles: "",
       layers: {
         // The year
-        "NOx_viridis": "21",
+        NOx_viridis: "21",
         // Still the year, but off by one
-        "PM25_viridis": "20",
+        PM25_viridis: "20",
         // The year
-        "PM10_viridis": "21",
+        PM10_viridis: "21",
       }[pollutant],
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
     return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/${pollutant}/MapServer/WMSServer?bbox={bbox-epsg-3857}&${params}`;
   }
+  $: tiles = [url(pollutant)];
 
   // legend
   //"https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/NOx_viridis/MapServer/WMSServer?request=GetLegendGraphic%26version=1.3.0%26format=image/png%26layer=21"
-
-  // TODO Upstream something nicer in svelte-maplibre
-  onMount(() => {
-    $map.addSource(source, {
-      type: "raster",
-      tiles: [url()],
-      tileSize: 256,
-    });
-    $map.addLayer({
-      id: "pollution-layer",
-      type: "raster",
-      source,
-      paint: {
-        "raster-opacity": 0.5,
-      },
-      layout: {
-        visibility: "none",
-      },
-    });
-  });
-  onDestroy(() => {
-    $map?.removeLayer("pollution-layer");
-    $map?.removeSource(source);
-  });
-
-  $: $map.setLayoutProperty(
-    "pollution-layer",
-    "visibility",
-    show ? "visible" : "none"
-  );
-
-  $: {
-    if (pollutant) {
-      //window.x = $map.getSource(source);
-      //window.alert(pollutant);
-      let x = $map.getSource(source);
-      if (x) {
-        (x as RasterTileSource).setTiles([url()]);
-      }
-    }
-  }
 </script>
 
-<Checkbox id={source} bind:checked={show}>
+<Checkbox id="pollution" bind:checked={show}>
   Pollution
   <span slot="right">
     <HelpButton>
@@ -102,3 +58,15 @@
     bind:value={pollutant}
   />
 {/if}
+
+<RasterTileSource {tiles} tileSize={256}>
+  <RasterLayer
+    {...layerId("pollution")}
+    paint={{
+      "raster-opacity": 0.5,
+    }}
+    layout={{
+      visibility: show ? "visible" : "none",
+    }}
+  />
+</RasterTileSource>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -18,7 +18,13 @@
     PM25Roads_viridis: ["aq_amb_2022", "14", "2022"],
     PM10Roads_viridis: ["aq_amb_2022", "22", "2022"],
   }[pollutant];
-  $: wmsUrl = `https://ukair.maps.rcdo.co.uk/ukairserver/services/${info[0]}/${pollutant}/MapServer/WMSServer`;
+  $: wmsUrl = `https://ukair.maps.rcdo.co.uk/ukairserver/services/${
+    info![0]
+  }/${pollutant}/MapServer/WMSServer`;
+
+  function year(): string {
+    return info![2];
+  }
 
   function tilesUrl(wmsUrl: string): string {
     let params = new URLSearchParams({
@@ -29,7 +35,7 @@
       width: "256",
       height: "256",
       styles: "",
-      layers: info[1],
+      layers: info![1],
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
     return `${wmsUrl}?bbox={bbox-epsg-3857}&${params}`;
@@ -40,7 +46,7 @@
       request: "GetLegendGraphic",
       version: "1.3.0",
       format: "image/png",
-      layer: info[1],
+      layer: info![1],
     }).toString();
     return `${wmsUrl}?${params}`;
   }
@@ -56,8 +62,7 @@
         DEFRA
       </ExternalLink>. The measurements are annual means, in units of &micro;gm
       <sup>3</sup>
-      . Note the particulate matter layers are not corrected for natural
-      sources.
+      . Note the particulate matter layers are not corrected for natural sources.
       <OsOglLicense />
     </HelpButton>
   </span>
@@ -78,7 +83,7 @@
     bind:value={pollutant}
   />
   <p>
-    Data for {info[2]}
+    Data for {year()}
   </p>
 
   <div>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -9,19 +9,16 @@
   let opacity = 50;
   let pollutant = "PM25_viridis";
 
-  // TODO Corrected for natural sources or not?
-
-  // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services
+  // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services and QGIS
   $: info = {
-    NOx_viridis: ["aq_amb_2021", "21"],
-    PM25_viridis: ["aq_amb_2021", "20"],
-    PM10_viridis: ["aq_amb_2021", "21"],
-    NOxRoads_viridis: ["aq_amb_2022", "22"],
-    PM25Roads_viridis: ["aq_amb_2022", "14"],
-    PM10Roads_viridis: ["aq_amb_2022", "21"],
+    NOx_viridis: ["aq_amb_2022", "22", "2022"],
+    PM25_viridis: ["aq_amb_2022", "21", "2022"], // TODO really?
+    PM10_viridis: ["aq_amb_2022", "22", "2022"],
+    NOxRoads_viridis: ["aq_amb_2022", "22", "2022"],
+    PM25Roads_viridis: ["aq_amb_2022", "14", "2022"],
+    PM10Roads_viridis: ["aq_amb_2022", "22", "2022"],
   }[pollutant];
   $: wmsUrl = `https://ukair.maps.rcdo.co.uk/ukairserver/services/${info[0]}/${pollutant}/MapServer/WMSServer`;
-  $: yearLayer = info[1];
 
   function tilesUrl(wmsUrl: string): string {
     let params = new URLSearchParams({
@@ -32,7 +29,7 @@
       width: "256",
       height: "256",
       styles: "",
-      layers: yearLayer,
+      layers: info[1],
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
     return `${wmsUrl}?bbox={bbox-epsg-3857}&${params}`;
@@ -43,8 +40,7 @@
       request: "GetLegendGraphic",
       version: "1.3.0",
       format: "image/png",
-      // Not plural here
-      layer: yearLayer,
+      layer: info[1],
     }).toString();
     return `${wmsUrl}?${params}`;
   }
@@ -54,7 +50,14 @@
   Pollution
   <span slot="right">
     <HelpButton>
-      <p>TODO</p>
+      These layers show air quality data from <ExternalLink
+        href="https://uk-air.defra.gov.uk/data/wms-services"
+      >
+        DEFRA
+      </ExternalLink>. The measurements are annual means, in units of &micro;gm
+      <sup>3</sup>
+      . Note the particulate matter layers are not corrected for natural
+      sources.
       <OsOglLicense />
     </HelpButton>
   </span>
@@ -68,16 +71,15 @@
       ["PM25_viridis", "Background PM2.5"],
       ["PM10_viridis", "Background PM10"],
       ["NOx_viridis", "Background NOx"],
-      [
-        "PM25Roads_viridis",
-        "Roadside PM2.5"
-      ],
+      ["PM25Roads_viridis", "Roadside PM2.5"],
       ["PM10Roads_viridis", "Roadside PM10"],
       ["NOxRoads_viridis", "Roadside NOx"],
     ]}
     bind:value={pollutant}
   />
-  <p>Data for <b>{yearLayer}</b></p>
+  <p>
+    Data for {info[2]}
+  </p>
 
   <div>
     <label>
@@ -86,7 +88,11 @@
     </label>
   </div>
 
-  <img src={legendUrl(wmsUrl)} width={150} alt={`Legend for ${pollutant} layer`} />
+  <img
+    src={legendUrl(wmsUrl)}
+    width={150}
+    alt={`Legend for ${pollutant} layer`}
+  />
 {/if}
 
 <RasterTileSource tiles={[tilesUrl(wmsUrl)]} tileSize={256}>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -10,17 +10,16 @@
   let opacity = 50;
   let pollutant = "PM25_viridis";
 
-  // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services and QGIS
-  // ... except for noise
+  // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services
+  // and QGIS, or http://www.extrium.co.uk/noiseviewer.html for the noise layer
   $: info = {
-    NOx_viridis: ["aq_amb_2022", "22", "Data for 2022"],
-    PM25_viridis: ["aq_amb_2022", "21", "Data for 2022"],
-    PM10_viridis: ["aq_amb_2022", "22", "Data for 2022"],
-    NOxRoads_viridis: ["aq_amb_2022", "22", "Data for 2022"],
-    PM25Roads_viridis: ["aq_amb_2022", "14", "Data for 2022"],
-    PM10Roads_viridis: ["aq_amb_2022", "22", "Data for 2022"],
+    NOx_viridis: ["22", "Data for 2022"],
+    PM25_viridis: ["21", "Data for 2022"],
+    PM10_viridis: ["22", "Data for 2022"],
+    NOxRoads_viridis: ["22", "Data for 2022"],
+    PM25Roads_viridis: ["14", "Data for 2022"],
+    PM10Roads_viridis: ["22", "Data for 2022"],
     Noise: [
-      "",
       "NoiseE:RD_LQ16_R3",
       "Annual average noise level for the 16-hour period between 0700-2300 (dB)",
     ],
@@ -30,14 +29,12 @@
     if (pollutant == "Noise") {
       return `http://wms.extrium.co.uk/geoserver/NoiseE/wms`;
     } else {
-      return `https://ukair.maps.rcdo.co.uk/ukairserver/services/${
-        info![0]
-      }/${pollutant}/MapServer/WMSServer`;
+      return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2022/${pollutant}/MapServer/WMSServer`;
     }
   }
 
   function title(pollutant: string): string {
-    return info![2];
+    return info![1];
   }
 
   function tilesUrl(pollutant: string): string {
@@ -49,7 +46,7 @@
       width: "256",
       height: "256",
       styles: "",
-      layers: info![1],
+      layers: info![0],
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
     return `${wmsUrl()}?bbox={bbox-epsg-3857}&${params}`;
@@ -60,7 +57,7 @@
       request: "GetLegendGraphic",
       version: "1.3.0",
       format: "image/png",
-      layer: info![1],
+      layer: info![0],
     }).toString();
     return `${wmsUrl()}?${params}`;
   }

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -7,30 +7,23 @@
 
   let show = false;
   let opacity = 50;
-
   let pollutant = "PM25_viridis";
 
   // TODO Corrected for natural sources or not?
 
-  // TODO Combo em, also with a title?
-  $: urlBase = {
-    NOx_viridis: "aq_amb_2021",
-    NOxRoads_viridis: "aq_amb_2022",
-    PM25_viridis: "aq_amb_2021",
-    PM25Roads_viridis: "aq_amb_2022",
-    PM10_viridis: "aq_amb_2021",
-    PM10Roads_viridis: "aq_amb_2022",
+  // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services
+  $: info = {
+    NOx_viridis: ["aq_amb_2021", "21"],
+    PM25_viridis: ["aq_amb_2021", "20"],
+    PM10_viridis: ["aq_amb_2021", "21"],
+    NOxRoads_viridis: ["aq_amb_2022", "22"],
+    PM25Roads_viridis: ["aq_amb_2022", "14"],
+    PM10Roads_viridis: ["aq_amb_2022", "21"],
   }[pollutant];
-  $: yearLayer = {
-    NOx_viridis: "21",
-    NOxRoads_viridis: "22",
-    PM25_viridis: "20",
-    PM25Roads_viridis: "14",
-    PM10_viridis: "21",
-    PM10Roads_viridis: "21",
-  }[pollutant];
+  $: wmsUrl = `https://ukair.maps.rcdo.co.uk/ukairserver/services/${info[0]}/${pollutant}/MapServer/WMSServer`;
+  $: yearLayer = info[1];
 
-  function tilesUrl(pollutant: string): string {
+  function tilesUrl(wmsUrl: string): string {
     let params = new URLSearchParams({
       request: "GetMap",
       version: "1.3.0",
@@ -42,11 +35,10 @@
       layers: yearLayer,
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
-    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/${urlBase}/${pollutant}/MapServer/WMSServer?bbox={bbox-epsg-3857}&${params}`;
+    return `${wmsUrl}?bbox={bbox-epsg-3857}&${params}`;
   }
 
-  // TODO Refactor
-  function legendUrl(pollutant: string): string {
+  function legendUrl(wmsUrl: string): string {
     let params = new URLSearchParams({
       request: "GetLegendGraphic",
       version: "1.3.0",
@@ -54,7 +46,7 @@
       // Not plural here
       layer: yearLayer,
     }).toString();
-    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/${urlBase}/${pollutant}/MapServer/WMSServer?${params}`;
+    return `${wmsUrl}?${params}`;
   }
 </script>
 
@@ -73,18 +65,19 @@
     label="Pollutant"
     id="pollutant"
     choices={[
-      ["NOx_viridis", "Background NOx (Oxides of nitrogen)"],
-      ["NOxRoads_viridis", "Roadside NOx (Oxides of nitrogen)"],
-      ["PM25_viridis", "Background PM2.5 (Particulate matter < 2.5 microns)"],
+      ["PM25_viridis", "Background PM2.5"],
+      ["PM10_viridis", "Background PM10"],
+      ["NOx_viridis", "Background NOx"],
       [
         "PM25Roads_viridis",
-        "Roadside PM2.5 (Particulate matter < 2.5 microns)",
+        "Roadside PM2.5"
       ],
-      ["PM10_viridis", "Background PM10 (Particulate matter < 10 microns)"],
-      ["PM10Roads_viridis", "Roadside PM10 (Particulate matter < 10 microns)"],
+      ["PM10Roads_viridis", "Roadside PM10"],
+      ["NOxRoads_viridis", "Roadside NOx"],
     ]}
     bind:value={pollutant}
   />
+  <p>Data for <b>{yearLayer}</b></p>
 
   <div>
     <label>
@@ -93,10 +86,10 @@
     </label>
   </div>
 
-  <img src={legendUrl(pollutant)} />
+  <img src={legendUrl(wmsUrl)} width={150} alt={`Legend for ${pollutant} layer`} />
 {/if}
 
-<RasterTileSource tiles={[tilesUrl(pollutant)]} tileSize={256}>
+<RasterTileSource tiles={[tilesUrl(wmsUrl)]} tileSize={256}>
   <RasterLayer
     {...layerId("pollution")}
     paint={{

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -9,7 +9,7 @@
 
   let pollutant = "PM25_viridis";
 
-  function url(pollutant: string): string {
+  function tilesUrl(pollutant: string): string {
     let params = new URLSearchParams({
       request: "GetMap",
       version: "1.3.0",
@@ -30,10 +30,25 @@
     // Don't escape the {} in the bbox, so specify it manually below
     return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/${pollutant}/MapServer/WMSServer?bbox={bbox-epsg-3857}&${params}`;
   }
-  $: tiles = [url(pollutant)];
 
-  // legend
-  //"https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/NOx_viridis/MapServer/WMSServer?request=GetLegendGraphic%26version=1.3.0%26format=image/png%26layer=21"
+  // TODO Refactor
+  function legendUrl(pollutant: string): string {
+    let params = new URLSearchParams({
+      request: "GetLegendGraphic",
+      version: "1.3.0",
+      format: "image/png",
+      // Not plural here
+      layer: {
+        // The year
+        NOx_viridis: "21",
+        // Still the year, but off by one
+        PM25_viridis: "20",
+        // The year
+        PM10_viridis: "21",
+      }[pollutant],
+    }).toString();
+    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/${pollutant}/MapServer/WMSServer?${params}`;
+  }
 </script>
 
 <Checkbox id="pollution" bind:checked={show}>
@@ -57,9 +72,11 @@
     ]}
     bind:value={pollutant}
   />
+
+  <img src={legendUrl(pollutant)} />
 {/if}
 
-<RasterTileSource {tiles} tileSize={256}>
+<RasterTileSource tiles={[tilesUrl(pollutant)]} tileSize={256}>
   <RasterLayer
     {...layerId("pollution")}
     paint={{

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -6,6 +6,7 @@
   import OsOglLicense from "../OsOglLicense.svelte";
 
   let show = false;
+  let opacity = 50;
 
   let pollutant = "PM25_viridis";
 
@@ -73,6 +74,13 @@
     bind:value={pollutant}
   />
 
+  <div>
+    <label>
+      Opacity
+      <input type="range" min="0" max="100" bind:value={opacity} />
+    </label>
+  </div>
+
   <img src={legendUrl(pollutant)} />
 {/if}
 
@@ -80,7 +88,7 @@
   <RasterLayer
     {...layerId("pollution")}
     paint={{
-      "raster-opacity": 0.5,
+      "raster-opacity": opacity / 100.0,
     }}
     layout={{
       visibility: show ? "visible" : "none",

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -19,6 +19,8 @@
     NOxRoads_viridis: ["22", "Data for 2022"],
     PM25Roads_viridis: ["14", "Data for 2022"],
     PM10Roads_viridis: ["22", "Data for 2022"],
+    // TODO This one is disabled by leaving it out of the dropdown. The WMS
+    // server uses HTTP, not HTTPS, and doesn't work when deployed.
     Noise: [
       "NoiseE:RD_LQ16_R3",
       "Annual average noise level for the 16-hour period between 0700-2300 (dB)",
@@ -104,7 +106,6 @@
       ["PM25Roads_viridis", "Roadside PM2.5"],
       ["PM10Roads_viridis", "Roadside PM10"],
       ["NOxRoads_viridis", "Roadside NOx"],
-      ["Noise", "Noise pollution"],
     ]}
     bind:value={pollutant}
   />

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -10,6 +10,26 @@
 
   let pollutant = "PM25_viridis";
 
+  // TODO Corrected for natural sources or not?
+
+  // TODO Combo em, also with a title?
+  $: urlBase = {
+    NOx_viridis: "aq_amb_2021",
+    NOxRoads_viridis: "aq_amb_2022",
+    PM25_viridis: "aq_amb_2021",
+    PM25Roads_viridis: "aq_amb_2022",
+    PM10_viridis: "aq_amb_2021",
+    PM10Roads_viridis: "aq_amb_2022",
+  }[pollutant];
+  $: yearLayer = {
+    NOx_viridis: "21",
+    NOxRoads_viridis: "22",
+    PM25_viridis: "20",
+    PM25Roads_viridis: "14",
+    PM10_viridis: "21",
+    PM10Roads_viridis: "21",
+  }[pollutant];
+
   function tilesUrl(pollutant: string): string {
     let params = new URLSearchParams({
       request: "GetMap",
@@ -19,17 +39,10 @@
       width: "256",
       height: "256",
       styles: "",
-      layers: {
-        // The year
-        NOx_viridis: "21",
-        // Still the year, but off by one
-        PM25_viridis: "20",
-        // The year
-        PM10_viridis: "21",
-      }[pollutant],
+      layers: yearLayer,
     }).toString();
     // Don't escape the {} in the bbox, so specify it manually below
-    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/${pollutant}/MapServer/WMSServer?bbox={bbox-epsg-3857}&${params}`;
+    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/${urlBase}/${pollutant}/MapServer/WMSServer?bbox={bbox-epsg-3857}&${params}`;
   }
 
   // TODO Refactor
@@ -39,16 +52,9 @@
       version: "1.3.0",
       format: "image/png",
       // Not plural here
-      layer: {
-        // The year
-        NOx_viridis: "21",
-        // Still the year, but off by one
-        PM25_viridis: "20",
-        // The year
-        PM10_viridis: "21",
-      }[pollutant],
+      layer: yearLayer,
     }).toString();
-    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2021/${pollutant}/MapServer/WMSServer?${params}`;
+    return `https://ukair.maps.rcdo.co.uk/ukairserver/services/${urlBase}/${pollutant}/MapServer/WMSServer?${params}`;
   }
 </script>
 
@@ -67,9 +73,15 @@
     label="Pollutant"
     id="pollutant"
     choices={[
-      ["NOx_viridis", "NO2 (Nitrogen dioxide)"],
-      ["PM25_viridis", "PM2.5 (Particulate matter < 2.5 microns)"],
-      ["PM10_viridis", "PM10 (Particulate matter < 10 microns)"],
+      ["NOx_viridis", "Background NOx (Oxides of nitrogen)"],
+      ["NOxRoads_viridis", "Roadside NOx (Oxides of nitrogen)"],
+      ["PM25_viridis", "Background PM2.5 (Particulate matter < 2.5 microns)"],
+      [
+        "PM25Roads_viridis",
+        "Roadside PM2.5 (Particulate matter < 2.5 microns)",
+      ],
+      ["PM10_viridis", "Background PM10 (Particulate matter < 10 microns)"],
+      ["PM10Roads_viridis", "Roadside PM10 (Particulate matter < 10 microns)"],
     ]}
     bind:value={pollutant}
   />

--- a/src/lib/maplibre/zorder.ts
+++ b/src/lib/maplibre/zorder.ts
@@ -73,6 +73,7 @@ const layerZorder = [
   "census_output_areas-outline",
   "imd",
   "imd-outline",
+  "pollution",
   // Then optional linear layers
   "mrn",
   "bus_routes",


### PR DESCRIPTION
#368. Demo at https://acteng.github.io/atip/defra/browse.html.

It would be much nicer to show a value by the mouse as you move around, but these pre-built raster layers served through WMS don't easily support it. We could try out the `GetFeatureInfo` API in the future (maybe on-click; as you hover won't be fast enough). Or we could process the raw data ourselves and produce raster tiles in some format that's easier to query.

It would also be nice to match the NOx metric used by inspections: >40, 40-32, <32. But again with prebuilt raster data, we can't do much.

Note this PR contains an attempt at the noise layer from http://www.extrium.co.uk/noiseviewer.html. It's disabled for two reasons:
1) I'm not sure they mean for it to be used publicly, even though the WMS server happily serves content without CORS problems.
2) They only have an HTTP endpoint. It works with `npm run dev`, but not on GH pages or GCS because of https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content.