### PR TITLE
Prototype scheme- and intervention-level fields for a new pipeline sc…

### DIFF
--- a/src/lib/common/Modal.svelte
+++ b/src/lib/common/Modal.svelte
@@ -34,6 +34,7 @@
 <style>
   .background {
     position: fixed;
+    /* TODO The geocoder is still on top */
     z-index: 10;
     left: 0;
     top: 0;
@@ -54,6 +55,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    max-height: 80%;
     overflow: scroll;
   }
 

--- a/src/lib/forms/ATF4Type.svelte
+++ b/src/lib/forms/ATF4Type.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Select } from "lib/govuk";
+  import type { ATF4Type } from "types";
+
+  export let label: string;
+  export let id: string;
+  export let value: ATF4Type;
+
+  // Keep in sync with intervention_type_short in scheme_data
+  // TODO That has more than the 11...
+
+  function repeat(x: string): [string, string] {
+    return [x, x];
+  }
+</script>
+
+<Select
+  {label}
+  {id}
+  choices={[
+    repeat("New segregated cycling facility"),
+    repeat("New junction treatment"),
+    repeat("New permanent footway"),
+    [
+      "New shared use facilities",
+      "New shared use (walking and cycling) facilities",
+    ],
+    [
+      "Improvements to existing route",
+      "Improvements to make an existing walking/cycle route safer",
+    ],
+    [
+      "Area-wide traffic management",
+      "Area-wide traffic management (including by TROs - both permanent and experimental)",
+    ],
+    [
+      "Bus priority measures",
+      "Bus priority measures that also enable active travel (for example, bus gates)",
+    ],
+    ["Secure cycle parking", "Provision of secure cycle parking facilities"],
+    repeat("New road crossings"),
+    repeat("Restriction or reduction of car parking availability"),
+    repeat("School streets"),
+  ]}
+  emptyOption
+  bind:value
+/>

--- a/src/lib/forms/ATF4Type.svelte
+++ b/src/lib/forms/ATF4Type.svelte
@@ -4,7 +4,7 @@
 
   export let label: string;
   export let id: string;
-  export let value: ATF4Type;
+  export let value: ATF4Type | "";
 
   // Keep in sync with intervention_type_short in scheme_data
   // TODO That has more than the 11...

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -38,6 +38,7 @@
     ["other", "Other"],
   ]}
   inlineSmall
+  required
   bind:value={props.intervention_type}
 />
 

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import {
+    Checkbox,
+    FormElement,
+    Radio,
+    SecondaryButton,
+    TextArea,
+  } from "lib/govuk";
+  import { prettyPrintMeters } from "lib/maplibre";
+  import { routeTool } from "stores";
+  import type { InterventionProps } from "types";
+  import ATF4Type from "./ATF4Type.svelte";
+
+  export let id: number;
+  export let props: InterventionProps;
+
+  props.pipeline ||= {
+    is_alternative: false,
+  };
+
+  // Sets the intervention name to "From {road1 and road2} to {road3 and
+  // road4}". Only meant to be useful for routes currently.
+  function autoFillName() {
+    try {
+      props.name = $routeTool!.inner.routeNameForWaypoints(props.waypoints);
+    } catch (e) {
+      window.alert(`Couldn't auto-name route: ${e}`);
+    }
+  }
+</script>
+
+<FormElement label="Name" id={"name-" + id}>
+  <input type="text" class="govuk-input" bind:value={props.name} />
+  <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
+  {#if props.length_meters}
+    <SecondaryButton on:click={() => autoFillName()} disabled={!$routeTool}>
+      Auto-fill
+    </SecondaryButton>
+  {/if}
+</FormElement>
+
+<TextArea label="Description" bind:value={props.description} />
+
+{#if props.length_meters}
+  <p>Length: {prettyPrintMeters(props.length_meters)}</p>
+{/if}
+
+<ATF4Type
+  label="Type"
+  id={"atf4-type-" + id}
+  bind:value={props.pipeline.atf4_type}
+/>
+
+<Radio
+  legend="Accuracy of mapped data"
+  id={"accuracy-" + id}
+  choices={[
+    ["high", "High"],
+    ["medium", "Medium"],
+    ["low", "Low"],
+  ]}
+  inlineSmall
+  bind:value={props.pipeline.accuracy}
+/>
+
+<Checkbox id={"alternative-" + id} bind:checked={props.pipeline.is_alternative}>
+  Is this an alternative route and not the default option?
+</Checkbox>

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -15,8 +15,12 @@
   export let props: InterventionProps;
 
   props.pipeline ||= {
+    atf4_type: "",
+    accuracy: "",
     is_alternative: false,
   };
+  // Guaranteed to exist
+  let pipelineProps = props.pipeline;
 
   // Sets the intervention name to "From {road1 and road2} to {road3 and
   // road4}". Only meant to be useful for routes currently.
@@ -48,7 +52,7 @@
 <ATF4Type
   label="Type"
   id={"atf4-type-" + id}
-  bind:value={props.pipeline.atf4_type}
+  bind:value={pipelineProps.atf4_type}
 />
 
 <Radio
@@ -60,9 +64,9 @@
     ["low", "Low"],
   ]}
   inlineSmall
-  bind:value={props.pipeline.accuracy}
+  bind:value={pipelineProps.accuracy}
 />
 
-<Checkbox id={"alternative-" + id} bind:checked={props.pipeline.is_alternative}>
+<Checkbox id={"alternative-" + id} bind:checked={pipelineProps.is_alternative}>
   Is this an alternative route and not the default option?
 </Checkbox>

--- a/src/lib/govuk/FormElement.svelte
+++ b/src/lib/govuk/FormElement.svelte
@@ -7,6 +7,6 @@
 </script>
 
 <div class="govuk-form-group">
-  <label class="govuk-label" for={id}>{label}</label>
+  <label class="govuk-label govuk-label--m" for={id}>{label}</label>
   <slot />
 </div>

--- a/src/lib/govuk/FormElement.svelte
+++ b/src/lib/govuk/FormElement.svelte
@@ -7,6 +7,6 @@
 </script>
 
 <div class="govuk-form-group">
-  <label class="govuk-label govuk-label--m" for={id}>{label}</label>
+  <label class="govuk-label" for={id}>{label}</label>
   <slot />
 </div>

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -20,7 +20,7 @@
 
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend">
       {legend}
     </legend>
     <ErrorMessage {errorMessage} />

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ErrorMessage from "./ErrorMessage.svelte";
+
   // A label for the entire group of radio buttons
   export let legend: string;
   // A unique (per page) ID of the radio group
@@ -7,14 +9,21 @@
   export let choices: [string, string][];
   // Lay out radio buttons horizontally and decrease font size
   export let inlineSmall = false;
+  // Show an error if no option is chosen
+  export let required = false;
 
   // The current value
   export let value: string;
+
+  $: errorMessage = required && value == "" ? "Required" : "";
 </script>
 
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">{legend}</legend>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      {legend}
+    </legend>
+    <ErrorMessage {errorMessage} />
     <div
       class="govuk-radios"
       class:govuk-radios--inline={inlineSmall}

--- a/src/lib/sidebar/EditForm.svelte
+++ b/src/lib/sidebar/EditForm.svelte
@@ -2,6 +2,7 @@
   import ATF4Form from "lib/forms/ATF4Form.svelte";
   import FormV1 from "lib/forms/FormV1.svelte";
   import FormV2 from "lib/forms/FormV2.svelte";
+  import PipelineForm from "lib/forms/PipelineForm.svelte";
   import PlanningForm from "lib/forms/PlanningForm.svelte";
   import {
     ButtonGroup,
@@ -108,4 +109,6 @@
   <PlanningForm bind:props={feature.properties} />
 {:else if schema == "atf4"}
   <ATF4Form bind:props={feature.properties} />
+{:else if schema == "pipeline"}
+  <PipelineForm id={feature.id} bind:props={feature.properties} />
 {/if}

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -10,6 +10,7 @@
   import { gjScheme, mode, sidebarHover } from "stores";
   import { onMount } from "svelte";
   import type { Schema, Scheme } from "types";
+  import PipelineSchemeForm from "./PipelineSchemeForm.svelte";
   import { backfill, interventionWarning } from "./scheme_data";
 
   export let authorityName: string;
@@ -155,6 +156,9 @@
         </SecondaryButton>
       </ButtonGroup>
     </Modal>
+    {#if schema == "pipeline"}
+      <PipelineSchemeForm />
+    {/if}
   </CollapsibleCard>
 
   {#if numErrors == 1}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -10,7 +10,17 @@
   import { gjScheme } from "stores";
   import ATF4Type from "../forms/ATF4Type.svelte";
 
-  $gjScheme.pipeline ||= {};
+  $gjScheme.pipeline ||= {
+    scheme_type: "",
+    status: "",
+    timescale: "",
+    atf4_lead_type: "",
+    scheme_description: "",
+    funding_source: "",
+    funded: false,
+  };
+  // Guaranteed to exist
+  let pipelineProps = $gjScheme.pipeline;
 
   let showModal = false;
 
@@ -34,13 +44,14 @@
       ["intersection", "Intersection/junction scheme"],
     ]}
     inlineSmall
-    bind:value={$gjScheme.pipeline.scheme_type}
+    required
+    bind:value={pipelineProps.scheme_type}
   />
 
   <ATF4Type
     label="Type of the main intervention"
     id="atf4-lead-type"
-    bind:value={$gjScheme.pipeline.atf4_lead_type}
+    bind:value={pipelineProps.atf4_lead_type}
   />
 
   <fieldset class="govuk-fieldset">
@@ -56,7 +67,8 @@
         ["completed", "Completed"],
       ]}
       inlineSmall
-      bind:value={$gjScheme.pipeline.status}
+      required
+      bind:value={pipelineProps.status}
     />
 
     <Radio
@@ -68,7 +80,8 @@
         ["long", "Long (6-10 years)"],
       ]}
       inlineSmall
-      bind:value={$gjScheme.pipeline.timescale}
+      required
+      bind:value={pipelineProps.timescale}
     />
     <div>
       <label>
@@ -77,7 +90,7 @@
           type="number"
           min="2023"
           max="2100"
-          bind:value={$gjScheme.pipeline.timescale_year}
+          bind:value={pipelineProps.timescale_year}
         />
       </label>
     </div>
@@ -85,7 +98,7 @@
 
   <TextArea
     label="Scheme description"
-    bind:value={$gjScheme.pipeline.scheme_description}
+    bind:value={pipelineProps.scheme_description}
   />
 
   <fieldset class="govuk-fieldset">
@@ -94,11 +107,7 @@
     <div>
       <label>
         GBP funded
-        <input
-          type="number"
-          min="0"
-          bind:value={$gjScheme.pipeline.budget_funded}
-        />
+        <input type="number" min="0" bind:value={pipelineProps.budget_funded} />
       </label>
     </div>
     <div>
@@ -107,7 +116,7 @@
         <input
           type="number"
           min="0"
-          bind:value={$gjScheme.pipeline.budget_unfunded}
+          bind:value={pipelineProps.budget_unfunded}
         />
       </label>
     </div>
@@ -124,10 +133,10 @@
         repeat("LUF"),
       ]}
       inlineSmall
-      bind:value={$gjScheme.pipeline.funding_source}
+      bind:value={pipelineProps.funding_source}
     />
 
-    <Checkbox id="scheme-funded" bind:checked={$gjScheme.pipeline.funded}>
+    <Checkbox id="scheme-funded" bind:checked={pipelineProps.funded}>
       Is the scheme fully funded?
     </Checkbox>
   </fieldset>
@@ -139,7 +148,7 @@
         type="number"
         min="2010"
         max="2100"
-        bind:value={$gjScheme.pipeline.source_data_year}
+        bind:value={pipelineProps.source_data_year}
       />
     </label>
   </div>

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { Modal } from "lib/common";
+  import {
+    Checkbox,
+    DefaultButton,
+    Radio,
+    SecondaryButton,
+    TextArea,
+  } from "lib/govuk";
+  import { gjScheme } from "stores";
+  import ATF4Type from "../forms/ATF4Type.svelte";
+
+  $gjScheme.pipeline ||= {};
+
+  let showModal = false;
+
+  function repeat(x: string): [string, string] {
+    return [x, x];
+  }
+</script>
+
+<SecondaryButton on:click={() => (showModal = true)}>
+  Scheme details
+</SecondaryButton>
+<Modal title="Scheme details" bind:open={showModal}>
+  <Radio
+    legend="Scheme type"
+    id="scheme-type"
+    choices={[
+      ["cycling route", "Cycling route"],
+      ["walking route", "Walking route"],
+      ["shared-use route", "Shared-use route"],
+      ["area-based scheme", "Area-based scheme"],
+      ["intersection", "Intersection/junction scheme"],
+    ]}
+    inlineSmall
+    bind:value={$gjScheme.pipeline.scheme_type}
+  />
+
+  <ATF4Type
+    label="Type of the main intervention"
+    id="atf4-lead-type"
+    bind:value={$gjScheme.pipeline.atf4_lead_type}
+  />
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">Timing and status</legend>
+
+    <Radio
+      legend="Status"
+      id="scheme-status"
+      choices={[
+        ["planned", "Planned"],
+        ["in development", "In development"],
+        ["in construction", "In construction"],
+        ["completed", "Completed"],
+      ]}
+      inlineSmall
+      bind:value={$gjScheme.pipeline.status}
+    />
+
+    <Radio
+      legend="Timescale"
+      id="scheme-timescale"
+      choices={[
+        ["short", "Short (1-3 years)"],
+        ["medium", "Medium (3-6 years)"],
+        ["long", "Long (6-10 years)"],
+      ]}
+      inlineSmall
+      bind:value={$gjScheme.pipeline.timescale}
+    />
+    <div>
+      <label>
+        Estimated completion year (if known)
+        <input
+          type="number"
+          min="2023"
+          max="2100"
+          bind:value={$gjScheme.pipeline.timescale_year}
+        />
+      </label>
+    </div>
+  </fieldset>
+
+  <TextArea
+    label="Scheme description"
+    bind:value={$gjScheme.pipeline.scheme_description}
+  />
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">Budget</legend>
+
+    <div>
+      <label>
+        GBP funded
+        <input
+          type="number"
+          min="0"
+          bind:value={$gjScheme.pipeline.budget_funded}
+        />
+      </label>
+    </div>
+    <div>
+      <label>
+        GBP unfunded
+        <input
+          type="number"
+          min="0"
+          bind:value={$gjScheme.pipeline.budget_unfunded}
+        />
+      </label>
+    </div>
+
+    <Radio
+      legend="Funding source"
+      id="scheme-funding-source"
+      choices={[
+        repeat("ATF2"),
+        repeat("ATF3"),
+        repeat("ATF4"),
+        repeat("ATF4E"),
+        repeat("CRSTS"),
+        repeat("LUF"),
+      ]}
+      inlineSmall
+      bind:value={$gjScheme.pipeline.funding_source}
+    />
+
+    <Checkbox id="scheme-funded" bind:checked={$gjScheme.pipeline.funded}>
+      Is the scheme fully funded?
+    </Checkbox>
+  </fieldset>
+
+  <div>
+    <label>
+      How current is this scheme? Please enter the year of the plan.
+      <input
+        type="number"
+        min="2010"
+        max="2100"
+        bind:value={$gjScheme.pipeline.source_data_year}
+      />
+    </label>
+  </div>
+
+  <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
+</Modal>
+
+<style>
+  fieldset {
+    /* TODO govuk doesn't style it, but this seems useful */
+    border: 2px solid black;
+    padding: 8px;
+  }
+</style>

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -9,6 +9,8 @@ export function schemaTitle(schema: Schema): string {
     v2: "Experimental Scheme Design",
     planning: "Development Planning",
     atf4: "ATF4 Scheme",
+    // TODO What do we want to call this?
+    pipeline: "Pipeline Scheme",
   }[schema];
 }
 
@@ -19,6 +21,7 @@ export function schemaSingularNoun(schema: Schema): string {
     v2: "an intervention",
     planning: "a development",
     atf4: "an intervention",
+    pipeline: "an intervention",
   }[schema];
 }
 
@@ -29,6 +32,7 @@ export function schemaPluralNoun(schema: Schema): string {
     v2: "interventions",
     planning: "developments",
     atf4: "interventions",
+    pipeline: "interventions",
   }[schema];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,46 +17,46 @@ export interface Scheme {
   pipeline?: PipelineScheme;
 }
 
+// Every field is optional in this type, to match the reality of starting with
+// a blank form. Mandatory fields are marked in the form UI. Optional string
+// types are encoded as "".
 export interface PipelineScheme {
-  // Mandatory fields first
-  // TODO Not sure about the last one
-  // TODO Allow unknown?
+  // TODO "intersection" is unclear
   scheme_type:
     | "cycling route"
     | "walking route"
     | "shared-use route"
     | "area-based scheme"
-    | "intersection";
+    | "intersection"
+    | "";
   // TODO Check with DB schema
-  status: "planned" | "in development" | "in construction" | "completed";
-  timescale: "short" | "medium" | "long";
+  status: "planned" | "in development" | "in construction" | "completed" | "";
+  timescale: "short" | "medium" | "long" | "";
 
-  // Optional fields
-  atf4_lead_type?: ATF4Type;
-  scheme_description?: string;
+  atf4_lead_type: ATF4Type | "";
+  scheme_description: string;
 
   // GBP
   budget_funded?: number;
   budget_unfunded?: number;
 
   timescale_year?: number;
-  funding_source?: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF";
+  funding_source: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF" | "";
   // TODO What about partially? How's this overlap with budget?
-  funded?: boolean;
+  funded: boolean;
 
   source_data_year?: number;
 }
 
-// TODO Abbreviate and use a mapping to describe fully?
 export type ATF4Type =
   | "New segregated cycling facility"
   | "New junction treatment"
   | "New permanent footway"
-  | "New shared use (walking and cycling) facilities"
-  | "Improvements to make an existing walking/cycle route safer"
-  | "Area-wide traffic management (including by TROs - both permanent and experimental)"
-  | "Bus priority measures that also enable active travel (for example, bus gates)"
-  | "Provision of secure cycle parking facilities"
+  | "New shared use facilities"
+  | "Improvements to existing route"
+  | "Area-wide traffic management"
+  | "Bus priority measures"
+  | "Secure cycle parking"
   | "New road crossings"
   | "Restriction or reduction of car parking availability"
   | "School streets";
@@ -102,8 +102,8 @@ export interface InterventionProps {
 }
 
 export interface PipelineIntervention {
-  atf4_type?: ATF4Type;
-  accuracy?: "high" | "medium" | "low";
+  atf4_type: ATF4Type | "";
+  accuracy: "high" | "medium" | "low" | "";
   is_alternative: boolean;
 
   // TODO new / existing / upgrade existing?

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { ATF4Intervention } from "./schemas/atf4";
 import type { Planning } from "./schemas/planning";
 import type { Intervention } from "./schemas/v2";
 
-export type Schema = "v1" | "v2" | "planning" | "atf4";
+export type Schema = "v1" | "v2" | "planning" | "atf4" | "pipeline";
 
 // This describes the full structure of the GeoJSON we manage. We constrain the
 // default GeoJSON types and specify feature properties.
@@ -14,7 +14,52 @@ export interface Scheme {
   scheme_name?: string;
   authority?: string;
   origin?: string;
+  pipeline?: PipelineScheme;
 }
+
+export interface PipelineScheme {
+  // Mandatory fields first
+  // TODO Not sure about the last one
+  // TODO Allow unknown?
+  scheme_type:
+    | "cycling route"
+    | "walking route"
+    | "shared-use route"
+    | "area-based scheme"
+    | "intersection";
+  // TODO Check with DB schema
+  status: "planned" | "in development" | "in construction" | "completed";
+  timescale: "short" | "medium" | "long";
+
+  // Optional fields
+  atf4_lead_type?: ATF4Type;
+  scheme_description?: string;
+
+  // GBP
+  budget_funded?: number;
+  budget_unfunded?: number;
+
+  timescale_year?: number;
+  funding_source?: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF";
+  // TODO What about partially? How's this overlap with budget?
+  funded?: boolean;
+
+  source_data_year?: number;
+}
+
+// TODO Abbreviate and use a mapping to describe fully?
+export type ATF4Type =
+  | "New segregated cycling facility"
+  | "New junction treatment"
+  | "New permanent footway"
+  | "New shared use (walking and cycling) facilities"
+  | "Improvements to make an existing walking/cycle route safer"
+  | "Area-wide traffic management (including by TROs - both permanent and experimental)"
+  | "Bus priority measures that also enable active travel (for example, bus gates)"
+  | "Provision of secure cycle parking facilities"
+  | "New road crossings"
+  | "Restriction or reduction of car parking availability"
+  | "School streets";
 
 // TODO Can we use a wildcard type, like Feature<? extends Geometry>
 export type FeatureUnion =
@@ -48,11 +93,21 @@ export interface InterventionProps {
   planning?: Planning;
   v2?: Intervention;
   atf4?: ATF4Intervention;
+  pipeline?: PipelineIntervention;
   // An extra field present in input for the browse schemes page only
   scheme_reference?: string;
 
   // Temporary state, not meant to be serialized
   hide_while_editing?: boolean;
+}
+
+export interface PipelineIntervention {
+  atf4_type?: ATF4Type;
+  accuracy?: "high" | "medium" | "low";
+  is_alternative: boolean;
+
+  // TODO new / existing / upgrade existing?
+  // TODO for routes, ltn120 type: fully protected, light segregation, off-carriageway, shared-use, dedicated footpath. minimum width?
 }
 
 export interface Waypoint {


### PR DESCRIPTION
…hema. #355 

Demo: https://acteng.github.io/atip/pipeline_forms/scheme.html?authority=LAD_Adur&schema=pipeline

- [x] Use .geojson file extension instead of .txt, at least for this mode, since we're not using SmartSurvey
- [ ] Make the scheme details more prominent -- maybe ask it upfront, or make the button way more obvious
- [ ] Make a component for numeric input (and note https://design-system.service.gov.uk/components/text-input/ recommends against it...)
- [ ] Think through how the "is alternative?" would work
- [ ] Figure out how to ask for the coverage polygon
- [x] Add warnings for the new per-intervention fields
- [x] Mark required vs optional fields, and maybe re-order things