### PR TITLE
Plumb along schema in URL

### DIFF
--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -91,7 +91,7 @@
     if (geojson["scheme_name"]) {
       filename += "_" + geojson["scheme_name"];
     }
-    filename += ".txt";
+    filename += ".geojson";
     downloadGeneratedFile(filename, JSON.stringify(geojson, null, "  "));
   }
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -39,6 +39,7 @@
 
   let showAbout = false;
   const params = new URLSearchParams(window.location.search);
+  let schema: Schema = (params.get("schema") as Schema) || "v1";
   let pageErrorMessage: string = params.get("error") || "";
   let uploadErrorMessage: string = "";
 
@@ -101,7 +102,7 @@
   function detectSchema(gj: FeatureCollection): Schema {
     if (gj.features.length > 0) {
       let props = gj.features[0].properties;
-      for (let schema of ["planning", "v2"]) {
+      for (let schema of ["planning", "v2", "atf4"]) {
         if (props && schema in props) {
           return schema as Schema;
         }
@@ -113,11 +114,11 @@
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.location.href = `scheme.html?authority=${
       e.detail.features[0].properties!.full_name
-    }`;
+    }&schema=${schema}`;
   }
 
   function start() {
-    window.location.href = `scheme.html?authority=${inputValue}`;
+    window.location.href = `scheme.html?authority=${inputValue}&schema=${schema}`;
   }
 </script>
 

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -91,7 +91,7 @@
       <p>App version: {appVersion()}</p>
       <div style="display: flex; justify-content: space-between">
         <p>{authorityDescription()}</p>
-        <a href="index.html">Change area</a>
+        <a href={`index.html?schema=${schema}`}>Change area</a>
         <ZoomOutMap {boundaryGeojson} />
       </div>
 

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from "@playwright/test";
 
-test("front page has welcome text", async ({ page }) => {
-  await page.goto("/");
-  await expect(
-    page.getByRole("heading", { name: "Welcome to ATIP Scheme Sketcher v2" })
-  ).toBeVisible();
-});
-
 test("choosing a local authority and clicking start changes the url", async ({
   page,
 }) => {
@@ -29,4 +22,11 @@ test("Uploading a valid atip geojson redirects to the appropriate authority sche
     .setInputFiles("tests/data/Adur.json");
 
   await expect(page).toHaveURL(/.*scheme.html\?authority=LAD_Adur/);
+});
+
+test("schema is plumbed along to the sketch page", async ({ page }) => {
+  await page.goto("/index.html?schema=atf4");
+  await page.getByTestId("transport-authority").fill("LAD_Adur");
+  await page.getByRole("button", { name: "Start" }).click();
+  await expect(page).toHaveURL(/.*scheme.html\?authority=LAD_Adur&schema=atf4/);
 });


### PR DESCRIPTION
Two quick fixes:
1) If you go the homepage with ?schema=foo, then we preserve that when you click an area. Otherwise our partner will have to manually add `schema=pipeline` in the near-future
2) Stop using .txt for downloaded files. This was something we did for better compatibility with SmartSurvey. Since we're not using a  new version of the sketch tool anytime soon, let's use .geojson, so people understand what the files are and they work with normal GIS tools