### PR TITLE
Superscheme tidy up

### DIFF
--- a/src/lib/sidebar/PipelineListMode.svelte
+++ b/src/lib/sidebar/PipelineListMode.svelte
@@ -2,7 +2,9 @@
   import { DefaultButton } from "lib/govuk";
   import { gjScheme } from "stores";
   import type { Scheme } from "types";
-  import EntireSubscheme from "./EntireSubscheme.svelte";
+  import ListedIntervention from "./ListedIntervention.svelte";
+  import PipelineSchemeDetails from "./PipelineSchemeDetails.svelte";
+  import { interventionWarning } from "./scheme_data";
 
   function addSubscheme() {
     gjScheme.update((gj: any) => {
@@ -51,10 +53,12 @@
   <h2>Subschemes</h2>
   <DefaultButton on:click={addSubscheme}>Add Subscheme</DefaultButton>
   {#each $gjScheme.subschemes as subscheme}
-    <EntireSubscheme
-      {subscheme}
-      {getSubschemeNameUpdater}
-      superscheme={$gjScheme}
-    />
+    <PipelineSchemeDetails {subscheme} {getSubschemeNameUpdater} />
+    <ul style="margin-left: l5px">
+      {#each $gjScheme.features.filter((feature) => feature.properties.pipeline?.schemeId === subscheme.id) as feature}
+        {@const warning = interventionWarning("pipeline", feature)}
+        <ListedIntervention {feature} schema={"pipeline"} {warning} />
+      {/each}
+    </ul>
   {/each}
 {/if}

--- a/src/lib/sidebar/PipelineListMode.svelte
+++ b/src/lib/sidebar/PipelineListMode.svelte
@@ -57,7 +57,7 @@
     <ul style="margin-left: l5px">
       {#each $gjScheme.features.filter((feature) => feature.properties.pipeline?.schemeId === subscheme.id) as feature}
         {@const warning = interventionWarning("pipeline", feature)}
-        <ListedIntervention {feature} schema={"pipeline"} {warning} />
+        <ListedIntervention {feature} schema="pipeline" {warning} />
       {/each}
     </ul>
   {/each}

--- a/src/lib/sidebar/PipelineListMode.svelte
+++ b/src/lib/sidebar/PipelineListMode.svelte
@@ -51,7 +51,7 @@
 
 {#if $gjScheme.subschemes}
   <h2>Subschemes</h2>
-  <DefaultButton on:click={addSubscheme}>Add Subscheme</DefaultButton>
+  <DefaultButton on:click={addSubscheme}>Add Scheme</DefaultButton>
   {#each $gjScheme.subschemes as subscheme}
     <PipelineSchemeDetails {subscheme} {getSubschemeNameUpdater} />
     <ul style="margin-left: l5px">

--- a/src/lib/sidebar/PipelineSchemeDetails.svelte
+++ b/src/lib/sidebar/PipelineSchemeDetails.svelte
@@ -21,7 +21,7 @@
 
   let numErrors = 0;
 
-  function deleteSubscheme() {
+  function deleteScheme() {
     displayDeleteConfirmation = false;
     const clonedScheme = JSON.parse(JSON.stringify($gjScheme));
     clonedScheme.features = clonedScheme.features.filter(
@@ -50,10 +50,10 @@
       disabled={disabledSubschemeDeletion}
       on:click={() => (displayDeleteConfirmation = true)}
     >
-      Delete subscheme
+      Delete scheme
     </WarningButton>
     <Modal
-      title="Would you like to delete this subscheme?"
+      title="Would you like to delete this scheme?"
       bind:open={displayDeleteConfirmation}
       displayEscapeButton={false}
     >
@@ -61,10 +61,10 @@
       <ButtonGroup>
         <WarningButton
           on:click={() => {
-            deleteSubscheme();
+            deleteScheme();
           }}
         >
-          Delete this subscheme and related interventions
+          Delete this scheme and related interventions
         </WarningButton>
         <SecondaryButton on:click={() => (displayDeleteConfirmation = false)}>
           Cancel

--- a/src/lib/sidebar/PipelineSchemeDetails.svelte
+++ b/src/lib/sidebar/PipelineSchemeDetails.svelte
@@ -8,34 +8,25 @@
     WarningButton,
   } from "lib/govuk";
   import { gjScheme, mode } from "stores";
-  import type { FeatureUnion, Scheme, PipelineScheme } from "types";
-  import ListedIntervention from "./ListedIntervention.svelte";
-  import { interventionWarning } from "./scheme_data";
-    import PipelineSchemeForm from "./PipelineSchemeForm.svelte";
+  import type { FeatureUnion, PipelineScheme } from "types";
+  import PipelineSchemeForm from "./PipelineSchemeForm.svelte";
 
   export let subscheme: PipelineScheme;
-  export let superscheme: Scheme;
   export let getSubschemeNameUpdater: Function;
 
   let displayDeleteConfirmation = false;
-  let features: FeatureUnion[] = superscheme.features.filter((feature) => {
-      return feature.properties.pipeline?.schemeId === subscheme.id;
-    });
 
   // @ts-ignore we know subschemes exists because otherwise this wouldn't be rendered
   $: disabledSubschemeDeletion = $gjScheme.subschemes?.length < 2;
 
   let numErrors = 0;
-    
 
   function deleteSubscheme() {
     displayDeleteConfirmation = false;
     const clonedScheme = JSON.parse(JSON.stringify($gjScheme));
     clonedScheme.features = clonedScheme.features.filter(
       (feature: FeatureUnion) => {
-        return (
-          feature.properties.pipeline?.schemeId !== subscheme.id
-        );
+        return feature.properties.pipeline?.schemeId !== subscheme.id;
       }
     );
     clonedScheme.subschemes = clonedScheme.subschemes?.filter(
@@ -54,7 +45,7 @@
       value={subscheme.name}
       on:change={getSubschemeNameUpdater(subscheme.name)}
     />
-    <PipelineSchemeForm {subscheme}/>
+    <PipelineSchemeForm {subscheme} />
     <WarningButton
       disabled={disabledSubschemeDeletion}
       on:click={() => (displayDeleteConfirmation = true)}
@@ -89,9 +80,5 @@
         errorMessage="There's a problem with {numErrors} interventions below"
       />
     {/if}
-    {#each features as feature}
-      {@const warning = interventionWarning("pipeline", feature)}
-      <ListedIntervention {feature} schema={"pipeline"} {warning} />
-    {/each}
   </CollapsibleCard>
 {/if}

--- a/src/lib/sidebar/Superscheme.svelte
+++ b/src/lib/sidebar/Superscheme.svelte
@@ -71,7 +71,7 @@
     gjScheme.update((gj: any) => {
       delete gj.scheme_name;
       gj.features = [];
-      gj.subschemes = [{ id: 0, name: "Untitled Subscheme" }];
+      gj.subschemes = [{ id: 0, name: "Unnamed Scheme" }];
       return gj;
     });
     sidebarHover.set(null);

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -50,7 +50,7 @@ export function backfillSuperscheme(
   if (!json.scheme_name) {
     json.scheme_name = authorityName
       ? `${authorityName} LCWIP`
-      : "Unnamed Supserscheme";
+      : "Unnamed Superscheme";
   }
 
   json.subschemes = json.subschemes

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -50,7 +50,7 @@ export function backfillSuperscheme(
   if (!json.scheme_name) {
     json.scheme_name = authorityName
       ? `${authorityName} LCWIP`
-      : "Untitled Supserscheme";
+      : "Unnamed Supserscheme";
   }
 
   json.subschemes = json.subschemes
@@ -58,7 +58,7 @@ export function backfillSuperscheme(
     : [
         {
           id: 0,
-          name: "Untitled Subscheme",
+          name: "Unnamed Scheme",
           scheme_type: "",
           status: "",
           timescale: "",

--- a/tests/pipeline_sketching.spec.ts
+++ b/tests/pipeline_sketching.spec.ts
@@ -26,68 +26,68 @@ test("creating a new freehand polygon and canceling doesn't save anything", asyn
   await clickMap(page, 400, 600);
 
   await page.getByRole("button", { name: "Cancel" }).click();
-  await page.getByText("Untitled Subscheme").click();
+  await page.getByText("Unnamed Scheme").click();
 
   await expect(
-    page.getByRole("button", { name: "Delete subscheme" })
+    page.getByRole("button", { name: "Delete scheme" })
   ).toBeVisible();
   await expect(
     page.getByRole("link", { name: "Untitled area" })
   ).not.toBeVisible();
-  await page.getByText("Untitled Subscheme").click();
+  await page.getByText("Unnamed Scheme").click();
 });
 
-test("deleting the last subscheme", async () => {
-  await page.getByText("Untitled Subscheme").click();
+test("deleting the last scheme", async () => {
+  await page.getByText("Unnamed Scheme").click();
 
   await expect(
-    page.getByRole("button", { name: "Delete subscheme" })
+    page.getByRole("button", { name: "Delete scheme" })
   ).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Delete subscheme" })
+    page.getByRole("button", { name: "Delete scheme" })
   ).not.toBeEnabled();
-  await page.getByText("Untitled Subscheme").click();
+  await page.getByText("Unnamed Scheme").click();
 });
 
-test("deleting an empty subscheme", async () => {
-  await page.getByRole("button", { name: "Add Subscheme" }).click();
+test("deleting an empty scheme", async () => {
+  await page.getByRole("button", { name: "Add scheme" }).click();
   await page.getByText("Unnamed Scheme 1").click();
   await expect(
-    page.getByRole("button", { name: "Delete subscheme" })
+    page.getByRole("button", { name: "Delete scheme" })
   ).toBeVisible();
-  await page.getByRole("button", { name: "Delete subscheme" }).click();
+  await page.getByRole("button", { name: "Delete scheme" }).click();
   await page
     .getByRole("button", {
-      name: "Delete this subscheme and related interventions",
+      name: "Delete this scheme and related interventions",
     })
     .click();
 
   await expect(page.getByText("Unnamed Scheme 1")).not.toBeVisible();
 });
 
-test("deleting a non-empty subscheme", async () => {
-  await page.getByRole("button", { name: "Add Subscheme" }).click();
+test("deleting a non-empty scheme", async () => {
+  await page.getByRole("button", { name: "Add scheme" }).click();
 
   await drawPoint(page);
   await drawPoint(page, "Unnamed Scheme 1");
 
-  await page.getByText("Untitled Subscheme").click();
+  await page.getByText("Unnamed Scheme 1").click();
 
   await expect(
-    page.getByRole("button", { name: "Delete subscheme" })
+    page.getByRole("button", { name: "Delete scheme" })
   ).toBeVisible();
-  await page.getByRole("button", { name: "Delete subscheme" }).click();
+  await page.getByRole("button", { name: "Delete scheme" }).click();
   await page
     .getByRole("button", {
-      name: "Delete this subscheme and related interventions",
+      name: "Delete this scheme and related interventions",
     })
     .click();
 
-  await expect(page.getByText("Untitled Subscheme")).not.toBeVisible();
+  await expect(page.getByText("Unnamed Scheme 1")).not.toBeVisible();
 });
 
-test("split route within subscheme", async () => {
-  await page.getByRole("button", { name: "Add Subscheme" }).click();
+test("split route within scheme", async () => {
+  await page.getByRole("button", { name: "Add scheme" }).click();
 
   await page.getByRole("button", { name: "New route" }).click();
   await clickMap(page, 522, 468);
@@ -117,13 +117,12 @@ test("split route within subscheme", async () => {
   await page.getByText("Unnamed Scheme 1").click();
 });
 
-test("renaming a subscheme which contains features", async () => {
-  await page.getByRole("button", { name: "Add Subscheme" }).click();
+test("renaming a scheme which contains features", async () => {
+  await page.getByRole("button", { name: "Add scheme" }).click();
 
   const defaultName = "Unnamed Scheme 1";
   const newName = "Renamed Scheme 1";
 
-  await drawPoint(page);
   await drawPoint(page, defaultName);
 
   await page.getByText(defaultName).click();
@@ -131,8 +130,6 @@ test("renaming a subscheme which contains features", async () => {
   await page.getByRole("textbox").first().fill(newName);
   await page.keyboard.down("Tab");
 
-  await page.getByText(newName).click();
-  await page.getByText(newName).click();
   await expect(
     page.getByRole("link", {
       name: "Untitled point",


### PR DESCRIPTION
Change subscheme to scheme when giving default name to "sub"schemes
Don't require user to expand 'sub'scheme to see its interventions