### PR TITLE
Pipeline form updates

### DIFF
--- a/src/lib/common/Geocoder.svelte
+++ b/src/lib/common/Geocoder.svelte
@@ -6,7 +6,9 @@
   import { map } from "stores";
   import { onMount } from "svelte";
 
-  export let position: "top-left" | "bottom-left" = "top-left";
+  // TODO The position for the sketch page is very awkward, but there's
+  // seemingly no option to make the menu appear above the widget
+  export let position: "top-left" | "below-top-bar" = "top-left";
 
   let mapController: MapController;
 
@@ -36,9 +38,9 @@
     left: 50px;
   }
 
-  .bottom-left {
+  .below-top-bar {
     position: absolute;
-    bottom: 40px;
+    top: 150px;
     left: 10px;
   }
 </style>

--- a/src/lib/common/Geocoder.svelte
+++ b/src/lib/common/Geocoder.svelte
@@ -8,7 +8,7 @@
 
   // TODO The position for the sketch page is very awkward, but there's
   // seemingly no option to make the menu appear above the widget
-  export let position: "top-left" | "below-top-bar" = "top-left";
+  export let position: "top-left" | "top-right" = "top-left";
 
   let mapController: MapController;
 
@@ -38,9 +38,9 @@
     left: 50px;
   }
 
-  .below-top-bar {
+  .top-right {
     position: absolute;
     top: 150px;
-    left: 10px;
+    right: 10px;
   }
 </style>

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -19,8 +19,6 @@
     accuracy: "",
     is_alternative: false,
   };
-  // Guaranteed to exist
-  let pipelineProps = props.pipeline;
 
   // Sets the intervention name to "From {road1 and road2} to {road3 and
   // road4}". Only meant to be useful for routes currently.
@@ -49,24 +47,29 @@
   <p>Length: {prettyPrintMeters(props.length_meters)}</p>
 {/if}
 
-<ATF4Type
-  label="Type"
-  id={"atf4-type-" + id}
-  bind:value={pipelineProps.atf4_type}
-/>
+{#if props.pipeline}
+  <ATF4Type
+    label="Type"
+    id={"atf4-type-" + id}
+    bind:value={props.pipeline.atf4_type}
+  />
 
-<Radio
-  legend="Accuracy of mapped data"
-  id={"accuracy-" + id}
-  choices={[
-    ["high", "High"],
-    ["medium", "Medium"],
-    ["low", "Low"],
-  ]}
-  inlineSmall
-  bind:value={pipelineProps.accuracy}
-/>
+  <Radio
+    legend="Accuracy of mapped data"
+    id={"accuracy-" + id}
+    choices={[
+      ["high", "High"],
+      ["medium", "Medium"],
+      ["low", "Low"],
+    ]}
+    inlineSmall
+    bind:value={props.pipeline.accuracy}
+  />
 
-<Checkbox id={"alternative-" + id} bind:checked={pipelineProps.is_alternative}>
-  Is this an alternative route and not the default option?
-</Checkbox>
+  <Checkbox
+    id={"alternative-" + id}
+    bind:checked={props.pipeline.is_alternative}
+  >
+    Is this an alternative route and not the default option?
+  </Checkbox>
+{/if}

--- a/src/lib/govuk/FormElement.svelte
+++ b/src/lib/govuk/FormElement.svelte
@@ -7,6 +7,6 @@
 </script>
 
 <div class="govuk-form-group">
-  <label class="govuk-label" for={id}>{label}</label>
+  <label class="govuk-label govuk-label--s" for={id}>{label}</label>
   <slot />
 </div>

--- a/src/lib/govuk/NumberInput.svelte
+++ b/src/lib/govuk/NumberInput.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  // For integer inputs only
+  import ErrorMessage from "./ErrorMessage.svelte";
+  import FormElement from "./FormElement.svelte";
+
+  export let label: string;
+  export let value: number | undefined;
+  export let width: number;
+  // Inclusive
+  export let min: number | undefined = undefined;
+  export let max: number | undefined = undefined;
+
+  let stringValue: string | undefined = value?.toString();
+
+  function parse() {
+    value = stringValue == undefined ? undefined : parseInt(stringValue, 10);
+  }
+
+  // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
+
+  function validate(stringValue: string | undefined): string {
+    if (stringValue == "" || stringValue == undefined) {
+      return "";
+    }
+    if (stringValue.includes(".")) {
+      return "Please enter a number without decimals";
+    }
+    // parseInt allows trailing letters
+    let n = Number(stringValue);
+    if (isNaN(n)) {
+      return "Please enter a valid number";
+    }
+    if (min != undefined && n < min) {
+      return `Please enter a number that's at least ${min};`;
+    }
+    if (max != undefined && n > max) {
+      return `Please enter a number that's at most ${max};`;
+    }
+    return "";
+  }
+</script>
+
+<FormElement {label} id={label}>
+  <ErrorMessage errorMessage={validate(stringValue)} />
+  <input
+    type="text"
+    inputmode="numeric"
+    class={`govuk-input govuk-input--width-${width}`}
+    id={label}
+    bind:value={stringValue}
+    on:change={parse}
+  />
+</FormElement>

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -20,7 +20,7 @@
 
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">
+    <legend class="govuk-fieldset__legend govuk-label--s">
       {legend}
     </legend>
     <ErrorMessage {errorMessage} />

--- a/src/lib/govuk/TextInput.svelte
+++ b/src/lib/govuk/TextInput.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
+  import ErrorMessage from "./ErrorMessage.svelte";
   import FormElement from "./FormElement.svelte";
 
   export let label: string;
   export let value: string | undefined;
+  // Show an error if input is empty
+  export let required = false;
 
   // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
+
+  $: errorMessage =
+    required && (value == undefined || value == "") ? "Required" : "";
 </script>
 
 <FormElement {label} id={label}>
+  <ErrorMessage {errorMessage} />
   <input type="text" class="govuk-input" id={label} bind:value />
 </FormElement>

--- a/src/lib/govuk/index.ts
+++ b/src/lib/govuk/index.ts
@@ -4,6 +4,7 @@ export { default as Checkbox } from "./Checkbox.svelte";
 export { default as DefaultButton } from "./DefaultButton.svelte";
 export { default as ErrorMessage } from "./ErrorMessage.svelte";
 export { default as FormElement } from "./FormElement.svelte";
+export { default as NumberInput } from "./NumberInput.svelte";
 export { default as Radio } from "./Radio.svelte";
 export { default as SecondaryButton } from "./SecondaryButton.svelte";
 export { default as Select } from "./Select.svelte";

--- a/src/lib/sidebar/EditForm.svelte
+++ b/src/lib/sidebar/EditForm.svelte
@@ -101,7 +101,7 @@
 
 <ErrorMessage errorMessage={warning} />
 {#if schema == "v1"}
-  <UnexpectedProperties id={feature.id} props={feature.properties} />
+  <UnexpectedProperties id={feature.id} props={feature.properties} {schema} />
   <FormV1 id={feature.id} bind:props={feature.properties} />
 {:else if schema == "v2"}
   <FormV2 bind:props={feature.properties} />
@@ -110,5 +110,6 @@
 {:else if schema == "atf4"}
   <ATF4Form bind:props={feature.properties} />
 {:else if schema == "pipeline"}
+  <UnexpectedProperties id={feature.id} props={feature.properties} {schema} />
   <PipelineForm id={feature.id} bind:props={feature.properties} />
 {/if}

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -157,10 +157,10 @@
         </SecondaryButton>
       </ButtonGroup>
     </Modal>
-    {#if schema == "pipeline"}
-      <PipelineSchemeForm />
-    {/if}
   </CollapsibleCard>
+  {#if schema == "pipeline"}
+    <PipelineSchemeForm />
+  {/if}
 
   {#if numErrors == 1}
     <ErrorMessage

--- a/src/lib/sidebar/EntireScheme.svelte
+++ b/src/lib/sidebar/EntireScheme.svelte
@@ -67,6 +67,7 @@
     gjScheme.update((gj) => {
       // Leave origin, authority, and other foreign members alone
       delete gj.scheme_name;
+      delete gj.pipeline;
       gj.features = [];
       return gj;
     });

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -33,6 +33,13 @@
     return [x, x];
   }
 
+  function onKeyDown(e: KeyboardEvent) {
+    if (showModal && e.key == "Escape") {
+      e.stopPropagation();
+      showModal = false;
+    }
+  }
+
   // Check for all required values
   $: errorMessage =
     $gjScheme.scheme_name &&
@@ -42,6 +49,8 @@
       ? ""
       : "Missing some required data";
 </script>
+
+<svelte:window on:keydown={onKeyDown} />
 
 <ErrorMessage {errorMessage} />
 <SecondaryButton on:click={() => (showModal = true)}>

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -4,6 +4,7 @@
     Checkbox,
     DefaultButton,
     ErrorMessage,
+    NumberInput,
     Radio,
     SecondaryButton,
     TextArea,
@@ -96,17 +97,13 @@
         required
         bind:value={$gjScheme.pipeline.timescale}
       />
-      <div>
-        <label>
-          Estimated completion year (if known)
-          <input
-            type="number"
-            min="2023"
-            max="2100"
-            bind:value={$gjScheme.pipeline.timescale_year}
-          />
-        </label>
-      </div>
+      <NumberInput
+        label="Estimated completion year (if known)"
+        width={4}
+        min={2010}
+        max={2100}
+        bind:value={$gjScheme.pipeline.timescale_year}
+      />
     </fieldset>
 
     <TextArea
@@ -117,26 +114,18 @@
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend">Budget</legend>
 
-      <div>
-        <label>
-          GBP funded
-          <input
-            type="number"
-            min="0"
-            bind:value={$gjScheme.pipeline.budget_funded}
-          />
-        </label>
-      </div>
-      <div>
-        <label>
-          GBP unfunded
-          <input
-            type="number"
-            min="0"
-            bind:value={$gjScheme.pipeline.budget_unfunded}
-          />
-        </label>
-      </div>
+      <NumberInput
+        label="GBP funded"
+        width={10}
+        min={0}
+        bind:value={$gjScheme.pipeline.budget_funded}
+      />
+      <NumberInput
+        label="GBP unfunded"
+        width={10}
+        min={0}
+        bind:value={$gjScheme.pipeline.budget_unfunded}
+      />
 
       <Radio
         legend="Funding source"
@@ -158,17 +147,13 @@
       </Checkbox>
     </fieldset>
 
-    <div>
-      <label>
-        How current is this scheme? Please enter the year of the plan.
-        <input
-          type="number"
-          min="2010"
-          max="2100"
-          bind:value={$gjScheme.pipeline.source_data_year}
-        />
-      </label>
-    </div>
+    <NumberInput
+      label="How current is this scheme? Please enter the year of the plan."
+      width={4}
+      min={2010}
+      max={2100}
+      bind:value={$gjScheme.pipeline.source_data_year}
+    />
 
     <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -10,19 +10,21 @@
   import { gjScheme } from "stores";
   import ATF4Type from "../forms/ATF4Type.svelte";
 
-  $gjScheme.pipeline ||= {
-    scheme_type: "",
-    status: "",
-    timescale: "",
-    atf4_lead_type: "",
-    scheme_description: "",
-    funding_source: "",
-    funded: false,
-  };
-  // Guaranteed to exist
-  let pipelineProps = $gjScheme.pipeline;
-
   let showModal = false;
+
+  // This component is only created once, but gjScheme could be cleared
+  // completely multipel times. Set defaults anytime the modal is open.
+  $: if (showModal) {
+    $gjScheme.pipeline ||= {
+      scheme_type: "",
+      status: "",
+      timescale: "",
+      atf4_lead_type: "",
+      scheme_description: "",
+      funding_source: "",
+      funded: false,
+    };
+  }
 
   function repeat(x: string): [string, string] {
     return [x, x];
@@ -33,127 +35,133 @@
   Scheme details
 </SecondaryButton>
 <Modal title="Scheme details" bind:open={showModal}>
-  <Radio
-    legend="Scheme type"
-    id="scheme-type"
-    choices={[
-      ["cycling route", "Cycling route"],
-      ["walking route", "Walking route"],
-      ["shared-use route", "Shared-use route"],
-      ["area-based scheme", "Area-based scheme"],
-      ["intersection", "Intersection/junction scheme"],
-    ]}
-    inlineSmall
-    required
-    bind:value={pipelineProps.scheme_type}
-  />
-
-  <ATF4Type
-    label="Type of the main intervention"
-    id="atf4-lead-type"
-    bind:value={pipelineProps.atf4_lead_type}
-  />
-
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">Timing and status</legend>
-
+  {#if $gjScheme.pipeline}
     <Radio
-      legend="Status"
-      id="scheme-status"
+      legend="Scheme type"
+      id="scheme-type"
       choices={[
-        ["planned", "Planned"],
-        ["in development", "In development"],
-        ["in construction", "In construction"],
-        ["completed", "Completed"],
+        ["cycling route", "Cycling route"],
+        ["walking route", "Walking route"],
+        ["shared-use route", "Shared-use route"],
+        ["area-based scheme", "Area-based scheme"],
+        ["intersection", "Intersection/junction scheme"],
       ]}
       inlineSmall
       required
-      bind:value={pipelineProps.status}
+      bind:value={$gjScheme.pipeline.scheme_type}
     />
 
-    <Radio
-      legend="Timescale"
-      id="scheme-timescale"
-      choices={[
-        ["short", "Short (1-3 years)"],
-        ["medium", "Medium (3-6 years)"],
-        ["long", "Long (6-10 years)"],
-      ]}
-      inlineSmall
-      required
-      bind:value={pipelineProps.timescale}
-    />
-    <div>
-      <label>
-        Estimated completion year (if known)
-        <input
-          type="number"
-          min="2023"
-          max="2100"
-          bind:value={pipelineProps.timescale_year}
-        />
-      </label>
-    </div>
-  </fieldset>
-
-  <TextArea
-    label="Scheme description"
-    bind:value={pipelineProps.scheme_description}
-  />
-
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">Budget</legend>
-
-    <div>
-      <label>
-        GBP funded
-        <input type="number" min="0" bind:value={pipelineProps.budget_funded} />
-      </label>
-    </div>
-    <div>
-      <label>
-        GBP unfunded
-        <input
-          type="number"
-          min="0"
-          bind:value={pipelineProps.budget_unfunded}
-        />
-      </label>
-    </div>
-
-    <Radio
-      legend="Funding source"
-      id="scheme-funding-source"
-      choices={[
-        repeat("ATF2"),
-        repeat("ATF3"),
-        repeat("ATF4"),
-        repeat("ATF4E"),
-        repeat("CRSTS"),
-        repeat("LUF"),
-      ]}
-      inlineSmall
-      bind:value={pipelineProps.funding_source}
+    <ATF4Type
+      label="Type of the main intervention"
+      id="atf4-lead-type"
+      bind:value={$gjScheme.pipeline.atf4_lead_type}
     />
 
-    <Checkbox id="scheme-funded" bind:checked={pipelineProps.funded}>
-      Is the scheme fully funded?
-    </Checkbox>
-  </fieldset>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend">Timing and status</legend>
 
-  <div>
-    <label>
-      How current is this scheme? Please enter the year of the plan.
-      <input
-        type="number"
-        min="2010"
-        max="2100"
-        bind:value={pipelineProps.source_data_year}
+      <Radio
+        legend="Status"
+        id="scheme-status"
+        choices={[
+          ["planned", "Planned"],
+          ["in development", "In development"],
+          ["in construction", "In construction"],
+          ["completed", "Completed"],
+        ]}
+        inlineSmall
+        required
+        bind:value={$gjScheme.pipeline.status}
       />
-    </label>
-  </div>
 
-  <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
+      <Radio
+        legend="Timescale"
+        id="scheme-timescale"
+        choices={[
+          ["short", "Short (1-3 years)"],
+          ["medium", "Medium (3-6 years)"],
+          ["long", "Long (6-10 years)"],
+        ]}
+        inlineSmall
+        required
+        bind:value={$gjScheme.pipeline.timescale}
+      />
+      <div>
+        <label>
+          Estimated completion year (if known)
+          <input
+            type="number"
+            min="2023"
+            max="2100"
+            bind:value={$gjScheme.pipeline.timescale_year}
+          />
+        </label>
+      </div>
+    </fieldset>
+
+    <TextArea
+      label="Scheme description"
+      bind:value={$gjScheme.pipeline.scheme_description}
+    />
+
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend">Budget</legend>
+
+      <div>
+        <label>
+          GBP funded
+          <input
+            type="number"
+            min="0"
+            bind:value={$gjScheme.pipeline.budget_funded}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          GBP unfunded
+          <input
+            type="number"
+            min="0"
+            bind:value={$gjScheme.pipeline.budget_unfunded}
+          />
+        </label>
+      </div>
+
+      <Radio
+        legend="Funding source"
+        id="scheme-funding-source"
+        choices={[
+          repeat("ATF2"),
+          repeat("ATF3"),
+          repeat("ATF4"),
+          repeat("ATF4E"),
+          repeat("CRSTS"),
+          repeat("LUF"),
+        ]}
+        inlineSmall
+        bind:value={$gjScheme.pipeline.funding_source}
+      />
+
+      <Checkbox id="scheme-funded" bind:checked={$gjScheme.pipeline.funded}>
+        Is the scheme fully funded?
+      </Checkbox>
+    </fieldset>
+
+    <div>
+      <label>
+        How current is this scheme? Please enter the year of the plan.
+        <input
+          type="number"
+          min="2010"
+          max="2100"
+          bind:value={$gjScheme.pipeline.source_data_year}
+        />
+      </label>
+    </div>
+
+    <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
+  {/if}
 </Modal>
 
 <style>

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -8,6 +8,7 @@
     Radio,
     SecondaryButton,
     TextArea,
+    TextInput,
   } from "lib/govuk";
   import { gjScheme } from "stores";
   import ATF4Type from "../forms/ATF4Type.svelte";
@@ -34,6 +35,7 @@
 
   // Check for all required values
   $: errorMessage =
+    $gjScheme.scheme_name &&
     $gjScheme.pipeline?.scheme_type &&
     $gjScheme.pipeline?.status &&
     $gjScheme.pipeline?.timescale
@@ -47,26 +49,41 @@
 </SecondaryButton>
 <Modal title="Scheme details" bind:open={showModal}>
   {#if $gjScheme.pipeline}
-    <Radio
-      legend="Scheme type"
-      id="scheme-type"
-      choices={[
-        ["cycling route", "Cycling route"],
-        ["walking route", "Walking route"],
-        ["shared-use route", "Shared-use route"],
-        ["area-based scheme", "Area-based scheme"],
-        ["intersection", "Intersection/junction scheme"],
-      ]}
-      inlineSmall
+    <TextInput
+      label="Scheme name"
       required
-      bind:value={$gjScheme.pipeline.scheme_type}
+      bind:value={$gjScheme.scheme_name}
     />
 
-    <ATF4Type
-      label="Type of the main intervention"
-      id="atf4-lead-type"
-      bind:value={$gjScheme.pipeline.atf4_lead_type}
-    />
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend">Basic information</legend>
+
+      <Radio
+        legend="Scheme type"
+        id="scheme-type"
+        choices={[
+          ["cycling route", "Cycling route"],
+          ["walking route", "Walking route"],
+          ["shared-use route", "Shared-use route"],
+          ["area-based scheme", "Area-based scheme"],
+          ["intersection", "Intersection/junction scheme"],
+        ]}
+        inlineSmall
+        required
+        bind:value={$gjScheme.pipeline.scheme_type}
+      />
+
+      <ATF4Type
+        label="Type of the main intervention"
+        id="atf4-lead-type"
+        bind:value={$gjScheme.pipeline.atf4_lead_type}
+      />
+
+      <TextArea
+        label="Scheme description (150 words max)"
+        bind:value={$gjScheme.pipeline.scheme_description}
+      />
+    </fieldset>
 
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend">Timing and status</legend>
@@ -104,12 +121,23 @@
         max={2100}
         bind:value={$gjScheme.pipeline.timescale_year}
       />
-    </fieldset>
 
-    <TextArea
-      label="Scheme description (150 words max)"
-      bind:value={$gjScheme.pipeline.scheme_description}
-    />
+      <NumberInput
+        label="What year was this scheme most recently published?"
+        width={4}
+        min={2010}
+        max={2100}
+        bind:value={$gjScheme.pipeline.year_published}
+      />
+
+      <NumberInput
+        label="What year was this scheme most recently consulted on?"
+        width={4}
+        min={2010}
+        max={2100}
+        bind:value={$gjScheme.pipeline.year_consulted}
+      />
+    </fieldset>
 
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend">Budget</legend>
@@ -146,14 +174,6 @@
         Is the scheme fully funded?
       </Checkbox>
     </fieldset>
-
-    <NumberInput
-      label="How current is this scheme? Please enter the year of the plan."
-      width={4}
-      min={2010}
-      max={2100}
-      bind:value={$gjScheme.pipeline.source_data_year}
-    />
 
     <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -3,6 +3,7 @@
   import {
     Checkbox,
     DefaultButton,
+    ErrorMessage,
     Radio,
     SecondaryButton,
     TextArea,
@@ -29,8 +30,17 @@
   function repeat(x: string): [string, string] {
     return [x, x];
   }
+
+  // Check for all required values
+  $: errorMessage =
+    $gjScheme.pipeline?.scheme_type &&
+    $gjScheme.pipeline?.status &&
+    $gjScheme.pipeline?.timescale
+      ? ""
+      : "Missing some required data";
 </script>
 
+<ErrorMessage {errorMessage} />
 <SecondaryButton on:click={() => (showModal = true)}>
   Scheme details
 </SecondaryButton>
@@ -100,7 +110,7 @@
     </fieldset>
 
     <TextArea
-      label="Scheme description"
+      label="Scheme description (150 words max)"
       bind:value={$gjScheme.pipeline.scheme_description}
     />
 

--- a/src/lib/sidebar/UnexpectedProperties.svelte
+++ b/src/lib/sidebar/UnexpectedProperties.svelte
@@ -2,12 +2,14 @@
   import { Modal } from "lib/common";
   import { ButtonGroup, SecondaryButton, WarningButton } from "lib/govuk";
   import { gjScheme } from "stores";
+  import type { Schema } from "types";
   import { getUnexpectedProperties } from "./scheme_data";
 
   export let id: number;
   export let props: { [name: string]: any };
+  export let schema: Schema;
 
-  $: unexpected = getUnexpectedProperties(props);
+  $: unexpected = getUnexpectedProperties(props, schema);
   let open = false;
 
   function removeExtraProperties() {

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -109,7 +109,7 @@
   </div>
   <div class="main">
     <MapLibreMap style={$mapStyle}>
-      <Geocoder position="below-top-bar" />
+      <Geocoder position="top-right" />
       <BoundaryLayer {boundaryGeojson} />
       <InterventionLayer {schema} />
       {#if $mode.mode == "list"}

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -109,7 +109,7 @@
   </div>
   <div class="main">
     <MapLibreMap style={$mapStyle}>
-      <Geocoder position="bottom-left" />
+      <Geocoder position="below-top-bar" />
       <BoundaryLayer {boundaryGeojson} />
       <InterventionLayer {schema} />
       {#if $mode.mode == "list"}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,23 +29,22 @@ export interface PipelineScheme {
     | "area-based scheme"
     | "intersection"
     | "";
+  atf4_lead_type: ATF4Type | "";
+  scheme_description: string;
+
   // TODO Check with DB schema
   status: "planned" | "in development" | "in construction" | "completed" | "";
   timescale: "short" | "medium" | "long" | "";
-
-  atf4_lead_type: ATF4Type | "";
-  scheme_description: string;
+  timescale_year?: number;
+  year_published?: number;
+  year_consulted?: number;
 
   // GBP
   budget_funded?: number;
   budget_unfunded?: number;
-
-  timescale_year?: number;
   funding_source: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF" | "";
   // TODO What about partially? How's this overlap with budget?
   funded: boolean;
-
-  source_data_year?: number;
 }
 
 export type ATF4Type =


### PR DESCRIPTION
Demo at https://acteng.github.io/atip/pipeline_form_updates/scheme.html?authority=TA_Portsmouth&schema=pipeline

This fixes some problems from #380:
- Makes sure changes to the scheme fields get saved and cleared properly
- Make the "Scheme details" more prominent and let people know when there's missing data
- Adjusts form field labels (everywhere)
- Improves the numeric input
- Adjusts some of the questions based on latest data doc

Edit: and a few more things pre-workshop:
- Make the geocoder position on the sketch page actually usable
- Escape key for the scheme details modal
- Show per-intervention warnings for pipeline mode