### PR TITLE
Undo in route snapper / area tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "js-cookie": "^3.0.5",
         "maplibre-gl": "^3.5.1",
         "read-excel-file": "^5.6.1",
-        "route-snapper": "^0.2.4",
+        "route-snapper": "^0.2.5",
         "svelte": "^4.0.0",
         "svelte-maplibre": "^0.7.0"
       },
@@ -2977,9 +2977,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.2.4.tgz",
-      "integrity": "sha512-yztET7bR1f9FZ08X/Rh31TcMQ0c6fr89A1XQdwSSphqb1WSKhRLgUGkewhoZefPluI/5Us2fKgJXlDo/DfPzzA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.2.5.tgz",
+      "integrity": "sha512-u259FNKShwiOZOGR0/y/OplvpLnGZp7Iz07QCXr+94KO+DasBIO26LkQimZQQu/0pMdnAnZLb+QxxVDfLoVEHg=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-cookie": "^3.0.5",
     "maplibre-gl": "^3.5.1",
     "read-excel-file": "^5.6.1",
-    "route-snapper": "^0.2.4",
+    "route-snapper": "^0.2.5",
     "svelte": "^4.0.0",
     "svelte-maplibre": "^0.7.0"
   }

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Checkbox, CheckboxGroup } from "lib/govuk";
-  import { routeTool, routeToolSnapMode, userSettings } from "stores";
+  import { Checkbox, CheckboxGroup, SecondaryButton } from "lib/govuk";
+  import { routeTool, userSettings } from "stores";
   import GeocoderControls from "./GeocoderControls.svelte";
+  import { snapMode, undoLength } from "./stores";
 
   // Start with this enabled or disabled, based on whether we're drawing a new
   // route or editing an existing.
@@ -12,9 +13,21 @@
     avoid_doubling_back: $userSettings.avoidDoublingBack,
     extend_route: extendRoute,
   });
+
+  function undo() {
+    $routeTool!.undo();
+  }
 </script>
 
-{#if $routeToolSnapMode}
+<SecondaryButton disabled={$undoLength == 0} on:click={undo}>
+  {#if $undoLength == 0}
+    Undo
+  {:else}
+    Undo ({$undoLength})
+  {/if}
+</SecondaryButton>
+
+{#if $snapMode}
   <p style="background: red; color: white; padding: 8px;">
     Snapping to existing roads. Press <b>s</b>
     to draw anywhere
@@ -42,6 +55,10 @@
   <li>
     <b>Click</b>
     a waypoint to delete it
+  </li>
+  <li>
+    Press <b>Control+Z</b>
+    to undo your last change
   </li>
   <li>
     Press <b>Enter</b>

--- a/src/lib/draw/route/RouteSnapperLoader.svelte
+++ b/src/lib/draw/route/RouteSnapperLoader.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { ErrorMessage } from "lib/govuk";
   import init from "route-snapper";
-  import { map, routeTool, routeToolSnapMode } from "stores";
+  import { map, routeTool } from "stores";
   import { onMount } from "svelte";
   import { RouteTool } from "./route_tool";
+  import { snapMode, undoLength } from "./stores";
 
   export let url: string;
 
@@ -18,7 +19,7 @@
     console.log(`Grabbing ${url}`);
     try {
       const graphBytes = await fetchWithProgress(url);
-      routeTool.set(new RouteTool($map, graphBytes, routeToolSnapMode));
+      routeTool.set(new RouteTool($map, graphBytes, snapMode, undoLength));
       progress = 100;
       routeToolReady = true;
     } catch (err) {

--- a/src/lib/draw/route/stores.ts
+++ b/src/lib/draw/route/stores.ts
@@ -2,7 +2,10 @@ import type { FeatureCollection } from "@maptiler/geocoding-control/types";
 import { emptyGeojson } from "lib/maplibre";
 import { writable, type Writable } from "svelte/store";
 
-// This is necessary to communicate between components nested under the sidebar and map
+// These are necessary to communicate between components nested under the sidebar and map
+
 export const geocoderGj: Writable<FeatureCollection> = writable(
   emptyGeojson() as FeatureCollection
 );
+export const snapMode: Writable<boolean> = writable(true);
+export const undoLength: Writable<number> = writable(0);

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -1,3 +1,21 @@
+<script lang="ts">
+  import { SecondaryButton } from "lib/govuk";
+  import { routeTool } from "stores";
+  import { undoLength } from "../route/stores";
+
+  function undo() {
+    $routeTool!.undo();
+  }
+</script>
+
+<SecondaryButton disabled={$undoLength == 0} on:click={undo}>
+  {#if $undoLength == 0}
+    Undo
+  {:else}
+    Undo ({$undoLength})
+  {/if}
+</SecondaryButton>
+
 <ul>
   <li>
     <b>Click</b>
@@ -10,6 +28,10 @@
   <li>
     <b>Click</b>
     a waypoint to delete it
+  </li>
+  <li>
+    Press <b>Control+Z</b>
+    to undo your last change
   </li>
   <li>
     Press <b>Enter</b>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -23,9 +23,6 @@ export const polygonTool: Writable<PolygonTool | null> = writable(null);
 // A global singleton, with the route tool loaded for the current map. It's
 // null before it's loaded.
 export const routeTool: Writable<RouteTool | null> = writable(null);
-// This is used to plumb state from inside RouteTool in a way that Svelte
-// components can use reactively.
-export const routeToolSnapMode: Writable<boolean> = writable(true);
 
 // TODO Should we instead store a map from ID to feature?
 export const gjScheme: Writable<Scheme> = writable(emptyGeojson() as Scheme);


### PR DESCRIPTION


https://github.com/acteng/atip/assets/1664407/01c17c13-4e84-46a2-a817-a63e396ce1bc


https://acteng.github.io/atip/route_snapper_undo/scheme.html?authority=LAD_Adur
#44

Here's a simple first step. We can do the same for the freehand polygon and point tools (or maybe not worth it), then sliiightly harder will be for forms / list mode.