### PR TITLE
Fix redirect for bad authority name

### DIFF
--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -68,7 +68,7 @@
       (feature) => feature.properties.full_name == authorityName
     );
     if (geojson.features.length === 0) {
-      window.location.href = `/?error=Authority name not found: ${authorityName}`;
+      window.location.href = `index.html?error=Authority name not found: ${authorityName}`;
     }
     return geojson;
   }


### PR DESCRIPTION
This works fine locally, but when we're hosted on GH, relative URL becomes important.

Test: https://acteng.github.io/atip/scheme.html?authority=oops