### PR TITLE
Let the user temporarily add an image to the map for georeferencing

### DIFF
--- a/assets/image.svg
+++ b/assets/image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -2,6 +2,7 @@
   import { SecondaryButton } from "lib/govuk";
   import { mode, pointTool, polygonTool, routeTool } from "stores";
   import type { Schema } from "types";
+  import imageIcon from "../../../assets/image.svg";
   import pointIcon from "../../../assets/point.svg";
   import polygonFreehandIcon from "../../../assets/polygon_freehand.svg";
   import polygonSnappedIcon from "../../../assets/polygon_snapped.svg";
@@ -52,6 +53,11 @@
       Split route
     </SecondaryButton>
   {/if}
+  <SecondaryButton on:click={() => mode.set({ mode: "set-image" })}>
+    <!-- svelte-ignore a11y-img-redundant-alt -->
+    <img src={imageIcon} alt="Georeference image" />
+    Georeference image
+  </SecondaryButton>
   <SecondaryButton on:click={() => mode.set({ mode: "streetview" })}>
     <img src={streetViewIcon} alt="StreetView" />
     StreetView

--- a/src/lib/draw/image/ImageLayer.svelte
+++ b/src/lib/draw/image/ImageLayer.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { ImageSource } from "maplibre-gl";
+  import { map, mode } from "stores";
+  import { onDestroy } from "svelte";
+  import { Marker } from "svelte-maplibre";
+  import { imgSrc, opacity } from "./stores";
+
+  // TODO Upstream an ImageLayer component
+
+  $: setupSource($imgSrc);
+
+  let source = "image-source";
+  let layer = "image-layer";
+
+  let topLeft = { lng: 0, lat: 0 };
+  let bottomRight = { lng: 0.1, lat: 0.1 };
+
+  onDestroy(() => {
+    setupSource(null);
+  });
+
+  function setupSource(url: string | null) {
+    if ($map.getLayer(layer)) {
+      $map.removeLayer(layer);
+    }
+    if ($map.getSource(source)) {
+      $map.removeSource(source);
+    }
+    if (!url) {
+      return;
+    }
+
+    // Reset the markers to cover some of the current viewport
+    let bounds = $map.getBounds();
+    topLeft.lng =
+      bounds.getWest() + 0.4 * (bounds.getEast() - bounds.getWest());
+    bottomRight.lng =
+      bounds.getWest() + 0.6 * (bounds.getEast() - bounds.getWest());
+    topLeft.lat =
+      bounds.getNorth() + 0.4 * (bounds.getSouth() - bounds.getNorth());
+    bottomRight.lat =
+      bounds.getNorth() + 0.6 * (bounds.getSouth() - bounds.getNorth());
+
+    $map.addSource(source, {
+      type: "image",
+      url,
+      coordinates: [
+        [topLeft.lng, topLeft.lat],
+        [bottomRight.lng, topLeft.lat],
+        [bottomRight.lng, bottomRight.lat],
+        [topLeft.lng, bottomRight.lat],
+      ],
+    });
+    $map.addLayer({
+      id: layer,
+      source,
+      type: "raster",
+      paint: {
+        "raster-fade-duration": 0,
+        "raster-opacity": $opacity / 100.0,
+      },
+    });
+  }
+
+  $: updateOpacity($opacity);
+  function updateOpacity(opacity: number) {
+    $map.setPaintProperty(layer, "raster-opacity", $opacity / 100.0);
+  }
+
+  function moveImage() {
+    ($map.getSource(source) as ImageSource).setCoordinates([
+      [topLeft.lng, topLeft.lat],
+      [bottomRight.lng, topLeft.lat],
+      [bottomRight.lng, bottomRight.lat],
+      [topLeft.lng, bottomRight.lat],
+    ]);
+  }
+</script>
+
+{#if $imgSrc && $mode.mode == "set-image"}
+  <Marker bind:lngLat={topLeft} draggable on:drag={moveImage}>
+    <span class="dot" style="background-color: red" />
+  </Marker>
+  <Marker bind:lngLat={bottomRight} draggable on:drag={moveImage}>
+    <span class="dot" style="background-color: blue" />
+  </Marker>
+{/if}
+
+<style>
+  .dot {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+</style>

--- a/src/lib/draw/image/ImageMode.svelte
+++ b/src/lib/draw/image/ImageMode.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import {
+    ButtonGroup,
+    DefaultButton,
+    FormElement,
+    WarningButton,
+  } from "lib/govuk";
+  import { mode } from "stores";
+  import { imgSrc, opacity } from "./stores";
+
+  let fileInput: HTMLInputElement;
+
+  async function fileLoaded(e: Event) {
+    let buffer = await fileInput.files![0].arrayBuffer();
+    let blob = new Blob([new Uint8Array(buffer)]);
+    $imgSrc = URL.createObjectURL(blob);
+  }
+
+  function deleteImage() {
+    $imgSrc = null;
+    $opacity = 100;
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key == "Escape") {
+      e.stopPropagation();
+      mode.set({ mode: "list" });
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeyDown} />
+
+<ButtonGroup>
+  <DefaultButton on:click={() => mode.set({ mode: "list" })}>
+    Save
+  </DefaultButton>
+  <WarningButton on:click={deleteImage} disabled={!$imgSrc}>
+    Delete
+  </WarningButton>
+</ButtonGroup>
+
+<FormElement label="Load an image" id="load-image">
+  <input
+    bind:this={fileInput}
+    on:change={fileLoaded}
+    class="govuk-file-upload"
+    id="load-image"
+    type="file"
+  />
+</FormElement>
+
+{#if $imgSrc}
+  <div>
+    <label>
+      <input type="range" min="0" max="100" bind:value={$opacity} />
+      Opacity: {$opacity}%
+    </label>
+  </div>
+{/if}
+
+<p>
+  Note this image isn't saved as part of this scheme. When you close this page,
+  it'll be lost.
+</p>

--- a/src/lib/draw/image/stores.ts
+++ b/src/lib/draw/image/stores.ts
@@ -1,0 +1,6 @@
+import { writable, type Writable } from "svelte/store";
+
+// Use this to share between two components, nested under the sidebar and map
+
+export const imgSrc: Writable<string | null> = writable(null);
+export const opacity: Writable<number> = writable(100);

--- a/src/lib/sidebar/LeftSidebar.svelte
+++ b/src/lib/sidebar/LeftSidebar.svelte
@@ -5,6 +5,7 @@
   import { onDestroy } from "svelte";
   import type { Schema } from "types";
   import EditGeometryMode from "../draw/EditGeometryMode.svelte";
+  import ImageMode from "../draw/image/ImageMode.svelte";
   import { PointTool } from "../draw/point/point_tool";
   import PointMode from "../draw/point/PointMode.svelte";
   import { PolygonTool } from "../draw/polygon/polygon_tool";
@@ -78,6 +79,9 @@ toolbox, but that gets created and destroyed frequently. -->
       to cancel
     </li>
   </ul>
+{:else if $mode.mode == "set-image"}
+  <h2>Georeference image</h2>
+  <ImageMode />
 {:else if $mode.mode == "streetview"}
   <h2>StreetView</h2>
   <StreetViewMode />

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -13,6 +13,7 @@
     MapLibreMap,
     ZoomOutMap,
   } from "lib/common";
+  import ImageLayer from "lib/draw/image/ImageLayer.svelte";
   import InterventionLayer from "lib/draw/InterventionLayer.svelte";
   import PolygonToolLayer from "lib/draw/polygon/PolygonToolLayer.svelte";
   import RouteSnapperLayer from "lib/draw/route/RouteSnapperLayer.svelte";
@@ -114,6 +115,7 @@
       <Geocoder position="top-right" />
       <BoundaryLayer {boundaryGeojson} />
       <InterventionLayer {schema} />
+      <ImageLayer />
       {#if $mode.mode == "list"}
         <Toolbox {schema} />
       {:else if $mode.mode == "split-route"}

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,4 +147,5 @@ export type Mode =
   | { mode: "new-snapped-polygon" }
   | { mode: "new-route" }
   | { mode: "split-route" }
+  | { mode: "set-image" }
   | { mode: "streetview" };


### PR DESCRIPTION
#389 
Demo: https://acteng.github.io/atip/move_images_v3/scheme.html?authority=LAD_Adur

Here's an example from Hackney: https://consultation.hackney.gov.uk/streetscene/butterfield-green/results/butterfieldgreen-delegatedpowersdecision.docx2.pdf

It took me a bit to align things, but here's a demo of how it looks in the end:

https://github.com/acteng/atip/assets/1664407/48490635-7291-4df7-9bf3-a4c92541c65c

This is just a first cut. Next, I'll work on picking any two control points on the raw image, then finding the same places on the map. Going by corners is hard!