### PR TITLE
Form changes for pipeline

### DIFF
--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -2,7 +2,6 @@
   import type { Point } from "geojson";
   import { SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { gjSchemeCollection, mode, newFeatureId, pointTool } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -2,6 +2,7 @@
   import type { Point } from "geojson";
   import { SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
+  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { gjSchemeCollection, mode, newFeatureId, pointTool } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -115,10 +115,7 @@
     </Checkbox>
   {/if}
 
-  <TimescaleSubform
-    forIntervention
-    bind:timescale={props.pipeline.intervention_timescale}
-  />
+  <TimescaleSubform bind:timescale={props.pipeline.intervention_timescale} />
   <NumberInput
     label="Cost"
     width={10}

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -6,8 +6,10 @@
     SecondaryButton,
     Select,
     TextArea,
+    NumberInput
   } from "lib/govuk";
   import { prettyPrintMeters } from "lib/maplibre";
+  import TimescaleSubform from "lib/sidebar/pipeline_forms/TimescaleSubform.svelte";
   import { gjSchemeCollection, routeTool } from "stores";
   import type { InterventionProps } from "types";
   import ATF4Type from "./ATF4Type.svelte";
@@ -19,6 +21,16 @@
     atf4_type: "",
     accuracy: "",
     is_alternative: false,
+    cost: 0,
+    intervention_timescale: {
+      status: "",
+      timescale: "",
+    },
+  };
+
+  props.pipeline.intervention_timescale ||= {
+    status: "",
+    timescale: "",
   };
 
   props.is_coverage_polygon ||= false;
@@ -83,6 +95,7 @@
       ["medium", "Medium"],
       ["low", "Low"],
     ]}
+    required
     inlineSmall
     bind:value={props.pipeline.accuracy}
   />
@@ -102,4 +115,15 @@
       while making the scheme)
     </Checkbox>
   {/if}
+
+  <TimescaleSubform
+    forIntervention
+    bind:timescale={props.pipeline.intervention_timescale}
+  />
+  <NumberInput
+    label="Cost"
+    width={10}
+    min={0}
+    bind:value={props.pipeline.cost}
+  />
 {/if}

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -2,11 +2,11 @@
   import {
     Checkbox,
     FormElement,
+    NumberInput,
     Radio,
     SecondaryButton,
     Select,
     TextArea,
-    NumberInput
   } from "lib/govuk";
   import { prettyPrintMeters } from "lib/maplibre";
   import TimescaleSubform from "lib/sidebar/pipeline_forms/TimescaleSubform.svelte";

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -21,7 +21,6 @@
     atf4_type: "",
     accuracy: "",
     is_alternative: false,
-    cost: 0,
     intervention_timescale: {
       status: "",
       timescale: "",

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -117,7 +117,7 @@
 
   <TimescaleSubform bind:timescale={props.pipeline.intervention_timescale} />
   <NumberInput
-    label="Cost"
+    label="Cost (GBP)"
     width={10}
     min={0}
     bind:value={props.pipeline.cost}

--- a/src/lib/govuk/NumberInput.svelte
+++ b/src/lib/govuk/NumberInput.svelte
@@ -43,7 +43,7 @@
 
 <FormElement {label} id={label}>
   {#if hint}
-    <p>{hint}</p>
+    <div class="govuk-hint">{hint}</div>
   {/if}
   <ErrorMessage errorMessage={validate(stringValue)} />
   <input

--- a/src/lib/govuk/NumberInput.svelte
+++ b/src/lib/govuk/NumberInput.svelte
@@ -9,6 +9,7 @@
   // Inclusive
   export let min: number | undefined = undefined;
   export let max: number | undefined = undefined;
+  export let hint: string | undefined = undefined;
 
   let stringValue: string | undefined = value?.toString();
 
@@ -41,6 +42,9 @@
 </script>
 
 <FormElement {label} id={label}>
+  {#if hint}
+    <p>{hint}</p>
+  {/if}
   <ErrorMessage errorMessage={validate(stringValue)} />
   <input
     type="text"

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -26,7 +26,7 @@
       {legend}
     </legend>
     {#if hint}
-      <p>{hint}</p>
+      <div class="govuk-hint">{hint}</div>
     {/if}
     <ErrorMessage {errorMessage} />
     <div

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -12,6 +12,8 @@
   // Show an error if no option is chosen
   export let required = false;
 
+  export let hint: string | undefined = undefined;
+
   // The current value
   export let value: string;
 
@@ -23,6 +25,9 @@
     <legend class="govuk-fieldset__legend govuk-label--s">
       {legend}
     </legend>
+    {#if hint}
+      <p>{hint}</p>
+    {/if}
     <ErrorMessage {errorMessage} />
     <div
       class="govuk-radios"

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -40,6 +40,8 @@
     $gjSchemeCollection.schemes[scheme!.scheme_reference] = scheme!;
     $gjSchemeCollection = $gjSchemeCollection;
     showModal = false;
+    // This resets sub-form components, since an #if block below checks this
+    scheme = null;
   }
 
   // Check for all required values

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -9,10 +9,7 @@
     TextInput,
   } from "lib/govuk";
   import { gjSchemeCollection } from "stores";
-  import type {
-    FeatureUnion,
-    SchemeData,
-  } from "types";
+  import type { FeatureUnion, SchemeData } from "types";
   import ATF4Type from "../forms/ATF4Type.svelte";
   import BudgetSubform from "./pipeline_forms/BudgetSubform.svelte";
   import TimescaleSubform from "./pipeline_forms/TimescaleSubform.svelte";
@@ -22,6 +19,8 @@
 
   let showModal = false;
   let scheme: SchemeData | null = null;
+  let maxTimescale: string | undefined;
+  let summedCost: number | undefined;
 
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
@@ -30,7 +29,14 @@
         return feature.properties.scheme_reference === scheme?.scheme_reference;
       }
     );
-    scheme = getRectifiedPipelineSchemeWithSuggestedValues($gjSchemeCollection.schemes[scheme_reference], schemeFeatures);
+    const [rectifiedScheme, calculatedTimescale, summedSchemeCost] =
+      getRectifiedPipelineSchemeWithSuggestedValues(
+        $gjSchemeCollection.schemes[scheme_reference],
+        schemeFeatures
+      );
+    scheme = rectifiedScheme;
+    maxTimescale = calculatedTimescale;
+    summedCost = summedSchemeCost;
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -97,8 +103,11 @@
       />
     </fieldset>
 
-    <TimescaleSubform bind:timescale={scheme.pipeline.scheme_timescale} />
-    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} />
+    <TimescaleSubform
+      bind:timescale={scheme.pipeline.scheme_timescale}
+      maxTimescaleFromInterventions={maxTimescale}
+    />
+    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} {summedCost} />
 
     <DefaultButton on:click={finish}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -9,11 +9,10 @@
     TextInput,
   } from "lib/govuk";
   import { gjSchemeCollection } from "stores";
-  import type { FeatureUnion, SchemeData } from "types";
+  import type { SchemeData } from "types";
   import ATF4Type from "../forms/ATF4Type.svelte";
   import BudgetSubform from "./pipeline_forms/BudgetSubform.svelte";
   import TimescaleSubform from "./pipeline_forms/TimescaleSubform.svelte";
-  import { getBudgetHintValue, getTimescaleHintValue } from "./scheme_data";
 
   export let scheme_reference: string;
 
@@ -25,14 +24,6 @@
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
     scheme = $gjSchemeCollection.schemes[scheme_reference];
-    const schemeFeatures: FeatureUnion[] = $gjSchemeCollection.features.filter(
-      (feature) => {
-        return feature.properties.scheme_reference === scheme?.scheme_reference;
-      }
-    );
-
-    maxTimescale = getTimescaleHintValue(schemeFeatures);
-    summedCost = getBudgetHintValue(schemeFeatures);
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -101,9 +92,9 @@
 
     <TimescaleSubform
       bind:timescale={scheme.pipeline.scheme_timescale}
-      maxTimescaleFromInterventions={maxTimescale}
+      {scheme_reference}
     />
-    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} {summedCost} />
+    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} {scheme_reference} />
 
     <DefaultButton on:click={finish}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -92,7 +92,10 @@
       bind:timescale={scheme.pipeline.scheme_timescale}
       {scheme_reference}
     />
-    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} {scheme_reference} />
+    <BudgetSubform
+      bind:budget={scheme.pipeline.scheme_budget}
+      {scheme_reference}
+    />
 
     <DefaultButton on:click={finish}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -23,7 +23,7 @@
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
     scheme = $gjSchemeCollection.schemes[scheme_reference];
-    if(!scheme.pipeline) {
+    if (!scheme.pipeline) {
       scheme.pipeline = getEmptyPipelineObject();
     }
   }

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -23,9 +23,7 @@
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
     scheme = $gjSchemeCollection.schemes[scheme_reference];
-    if (!scheme.pipeline) {
-      scheme.pipeline = getEmptyPipelineObject();
-    }
+    scheme.pipeline ||= getEmptyPipelineObject();
   }
 
   function onKeyDown(e: KeyboardEvent) {

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -18,8 +18,6 @@
 
   let showModal = false;
   let scheme: SchemeData | null = null;
-  let maxTimescale: string | undefined;
-  let summedCost: number | undefined;
 
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -13,6 +13,7 @@
   import ATF4Type from "../forms/ATF4Type.svelte";
   import BudgetSubform from "./pipeline_forms/BudgetSubform.svelte";
   import TimescaleSubform from "./pipeline_forms/TimescaleSubform.svelte";
+  import { getEmptyPipelineObject } from "./scheme_data";
 
   export let scheme_reference: string;
 
@@ -22,6 +23,9 @@
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
     scheme = $gjSchemeCollection.schemes[scheme_reference];
+    if(!scheme.pipeline) {
+      scheme.pipeline = getEmptyPipelineObject();
+    }
   }
 
   function onKeyDown(e: KeyboardEvent) {

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -13,7 +13,7 @@
   import ATF4Type from "../forms/ATF4Type.svelte";
   import BudgetSubform from "./pipeline_forms/BudgetSubform.svelte";
   import TimescaleSubform from "./pipeline_forms/TimescaleSubform.svelte";
-  import { getRectifiedPipelineSchemeWithSuggestedValues } from "./scheme_data";
+  import { getBudgetHintValue, getTimescaleHintValue } from "./scheme_data";
 
   export let scheme_reference: string;
 
@@ -24,19 +24,15 @@
 
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
+    scheme = $gjSchemeCollection.schemes[scheme_reference];
     const schemeFeatures: FeatureUnion[] = $gjSchemeCollection.features.filter(
       (feature) => {
         return feature.properties.scheme_reference === scheme?.scheme_reference;
       }
     );
-    const [rectifiedScheme, calculatedTimescale, summedSchemeCost] =
-      getRectifiedPipelineSchemeWithSuggestedValues(
-        $gjSchemeCollection.schemes[scheme_reference],
-        schemeFeatures
-      );
-    scheme = rectifiedScheme;
-    maxTimescale = calculatedTimescale;
-    summedCost = summedSchemeCost;
+
+    maxTimescale = getTimescaleHintValue(schemeFeatures);
+    summedCost = getBudgetHintValue(schemeFeatures);
   }
 
   function onKeyDown(e: KeyboardEvent) {

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
   import { Modal } from "lib/common";
   import {
-    Checkbox,
     DefaultButton,
     ErrorMessage,
-    NumberInput,
     Radio,
     SecondaryButton,
     TextArea,
     TextInput,
   } from "lib/govuk";
   import { gjSchemeCollection } from "stores";
-  import type { SchemeData } from "types";
+  import type {
+    FeatureUnion,
+    SchemeData,
+  } from "types";
   import ATF4Type from "../forms/ATF4Type.svelte";
+  import BudgetSubform from "./pipeline_forms/BudgetSubform.svelte";
+  import TimescaleSubform from "./pipeline_forms/TimescaleSubform.svelte";
+  import { getRectifiedPipelineSchemeWithSuggestedValues } from "./scheme_data";
 
   export let scheme_reference: string;
 
@@ -21,20 +25,12 @@
 
   // Lazily set defaults when the modal is opened the first time for a scheme
   $: if (showModal) {
-    scheme = $gjSchemeCollection.schemes[scheme_reference];
-    scheme.pipeline ||= {
-      scheme_type: "",
-      status: "",
-      timescale: "",
-      atf4_lead_type: "",
-      scheme_description: "",
-      funding_source: "",
-      funded: false,
-    };
-  }
-
-  function repeat(x: string): [string, string] {
-    return [x, x];
+    const schemeFeatures: FeatureUnion[] = $gjSchemeCollection.features.filter(
+      (feature) => {
+        return feature.properties.scheme_reference === scheme?.scheme_reference;
+      }
+    );
+    scheme = getRectifiedPipelineSchemeWithSuggestedValues($gjSchemeCollection.schemes[scheme_reference], schemeFeatures);
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -55,8 +51,8 @@
   $: errorMessage =
     scheme &&
     scheme.pipeline?.scheme_type &&
-    scheme.pipeline?.status &&
-    scheme.pipeline?.timescale
+    scheme.pipeline?.scheme_timescale.status &&
+    scheme.pipeline?.scheme_timescale.timescale
       ? ""
       : "Missing some required data";
 </script>
@@ -101,95 +97,8 @@
       />
     </fieldset>
 
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend">Timing and status</legend>
-
-      <Radio
-        legend="Status"
-        id="scheme-status"
-        choices={[
-          ["planned", "Planned"],
-          ["in development", "In development"],
-          ["in construction", "In construction"],
-          ["completed", "Completed"],
-        ]}
-        inlineSmall
-        required
-        bind:value={scheme.pipeline.status}
-      />
-
-      <Radio
-        legend="Timescale"
-        id="scheme-timescale"
-        choices={[
-          ["short", "Short (1-3 years)"],
-          ["medium", "Medium (3-6 years)"],
-          ["long", "Long (6-10 years)"],
-        ]}
-        inlineSmall
-        required
-        bind:value={scheme.pipeline.timescale}
-      />
-      <NumberInput
-        label="Estimated completion year (if known)"
-        width={4}
-        min={2010}
-        max={2100}
-        bind:value={scheme.pipeline.timescale_year}
-      />
-
-      <NumberInput
-        label="What year was this scheme most recently published?"
-        width={4}
-        min={2010}
-        max={2100}
-        bind:value={scheme.pipeline.year_published}
-      />
-
-      <NumberInput
-        label="What year was this scheme most recently consulted on?"
-        width={4}
-        min={2010}
-        max={2100}
-        bind:value={scheme.pipeline.year_consulted}
-      />
-    </fieldset>
-
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend">Budget</legend>
-
-      <NumberInput
-        label="GBP funded"
-        width={10}
-        min={0}
-        bind:value={scheme.pipeline.budget_funded}
-      />
-      <NumberInput
-        label="GBP unfunded"
-        width={10}
-        min={0}
-        bind:value={scheme.pipeline.budget_unfunded}
-      />
-
-      <Radio
-        legend="Funding source"
-        id="scheme-funding-source"
-        choices={[
-          repeat("ATF2"),
-          repeat("ATF3"),
-          repeat("ATF4"),
-          repeat("ATF4E"),
-          repeat("CRSTS"),
-          repeat("LUF"),
-        ]}
-        inlineSmall
-        bind:value={scheme.pipeline.funding_source}
-      />
-
-      <Checkbox id="scheme-funded" bind:checked={scheme.pipeline.funded}>
-        Is the scheme fully funded?
-      </Checkbox>
-    </fieldset>
+    <TimescaleSubform bind:timescale={scheme.pipeline.scheme_timescale} />
+    <BudgetSubform bind:budget={scheme.pipeline.scheme_budget} />
 
     <DefaultButton on:click={finish}>Save</DefaultButton>
   {/if}

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -20,7 +20,7 @@
   <legend class="govuk-fieldset__legend">Budget</legend>
 
   <NumberInput
-    label="Cost"
+    label="Cost GBP"
     width={10}
     min={0}
     bind:value={budget.cost}

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { Checkbox, NumberInput, Radio } from "lib/govuk";
   import type { PipelineBudget } from "types";
+    import { getBudgetHintValue } from "../scheme_data";
 
+  export let scheme_reference: string;
   export let budget: PipelineBudget;
-  export let summedCost: number | undefined = undefined;
-  $: costHint = getSummedCostHint(summedCost);
+  $: costHint = getSummedCostHint();
 
-  function getSummedCostHint(summedCost: number | undefined) {
+  function getSummedCostHint() {
+    const summedCost = getBudgetHintValue(scheme_reference)
+    
     if (summedCost === undefined) return undefined;
     return `The sum of costs of interventions in this scheme is: £${summedCost}`;
   }

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -19,7 +19,7 @@
   <legend class="govuk-fieldset__legend">Budget</legend>
 
   <NumberInput
-    label="Cost GBP"
+    label="Cost (GBP)"
     width={10}
     min={0}
     bind:value={budget.cost}

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { Checkbox, NumberInput, Radio } from "lib/govuk";
   import type { PipelineBudget } from "types";
-    import { getBudgetHintValue } from "../scheme_data";
+  import { getBudgetHintValue } from "../scheme_data";
 
   export let scheme_reference: string;
   export let budget: PipelineBudget;
   $: costHint = getSummedCostHint();
 
   function getSummedCostHint() {
-    const summedCost = getBudgetHintValue(scheme_reference)
-    
+    const summedCost = getBudgetHintValue(scheme_reference);
+
     if (summedCost === undefined) return undefined;
     return `The sum of costs of interventions in this scheme is: £${summedCost}`;
   }

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { Checkbox, NumberInput, Radio } from "lib/govuk";
+  import type { PipelineBudget } from "types";
+
+  export let budget: PipelineBudget;
+
+  function repeat(x: string): [string, string] {
+    return [x, x];
+  }
+</script>
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend">Budget</legend>
+
+  <NumberInput
+    label="Cost"
+    width={10}
+    min={0}
+    bind:value={budget.cost}
+  />
+
+  <Checkbox id="development-funded" bind:checked={budget.development_funded}>
+    Is the development fully funded?
+  </Checkbox>
+
+  <Checkbox id="construction-funded" bind:checked={budget.construction_funded}>
+    Is the construction fully funded?
+  </Checkbox>
+
+  <Radio
+    legend="Funding source"
+    id="scheme-funding-source"
+    choices={[
+      repeat("ATF2"),
+      repeat("ATF3"),
+      repeat("ATF4"),
+      repeat("ATF4E"),
+      repeat("CRSTS"),
+      repeat("LUF"),
+    ]}
+    inlineSmall
+    bind:value={budget.funding_source}
+  />
+</fieldset>
+
+
+<style>
+    fieldset {
+      /* TODO govuk doesn't style it, but this seems useful */
+      border: 2px solid black;
+      padding: 8px;
+    }
+  </style>

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
   import { Checkbox, NumberInput, Radio } from "lib/govuk";
   import type { PipelineBudget } from "types";
-  import { getBudgetHintValue } from "../scheme_data";
+  import { sumBudgetForScheme } from "../scheme_data";
 
   export let scheme_reference: string;
   export let budget: PipelineBudget;
-  $: costHint = getSummedCostHint();
 
-  function getSummedCostHint() {
-    const summedCost = getBudgetHintValue(scheme_reference);
-
-    if (summedCost === undefined) return undefined;
-    return `The sum of costs of interventions in this scheme is: £${summedCost}`;
-  }
+  let costHint = `The sum of intervention costs is: £${sumBudgetForScheme(
+    scheme_reference
+  )}`;
 
   function repeat(x: string): [string, string] {
     return [x, x];

--- a/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/BudgetSubform.svelte
@@ -3,6 +3,13 @@
   import type { PipelineBudget } from "types";
 
   export let budget: PipelineBudget;
+  export let summedCost: number | undefined = undefined;
+  $: costHint = getSummedCostHint(summedCost);
+
+  function getSummedCostHint(summedCost: number | undefined) {
+    if (summedCost === undefined) return undefined;
+    return `The sum of costs of interventions in this scheme is: £${summedCost}`;
+  }
 
   function repeat(x: string): [string, string] {
     return [x, x];
@@ -17,6 +24,7 @@
     width={10}
     min={0}
     bind:value={budget.cost}
+    hint={costHint}
   />
 
   <Checkbox id="development-funded" bind:checked={budget.development_funded}>
@@ -43,11 +51,10 @@
   />
 </fieldset>
 
-
 <style>
-    fieldset {
-      /* TODO govuk doesn't style it, but this seems useful */
-      border: 2px solid black;
-      padding: 8px;
-    }
-  </style>
+  fieldset {
+    /* TODO govuk doesn't style it, but this seems useful */
+    border: 2px solid black;
+    padding: 8px;
+  }
+</style>

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -26,7 +26,6 @@
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend">Timing and status</legend>
-  <p>max time{maxTimescaleFromInterventions}</p>
 
   <Radio
     legend="Status"

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
   import { NumberInput, Radio } from "lib/govuk";
   import type { PipelineTimescale } from "types";
-  import { getTimescaleHintValue } from "../scheme_data";
+  import { getMaxTimescale } from "../scheme_data";
 
   export let timescale: PipelineTimescale;
   export let scheme_reference: string | undefined = undefined;
-  export let forIntervention = false;
 
-  let timescaleHint = getTimescaleHint();
+  let forIntervention = scheme_reference === undefined;
 
-  function getTimescaleHint(): string | undefined {
-    if (scheme_reference === undefined) {
-      return;
+  function timescaleHint(): string | undefined {
+    if (!scheme_reference) {
+      return undefined;
     }
-    const timescaleHintValue = getTimescaleHintValue(scheme_reference);
-    const index = ["short", "medium", "long"].indexOf(timescaleHintValue || "");
-    if (index === -1) return undefined;
-    const humanReadableValues = [
-      "Short (1-3 years)",
-      "Medium (3-6 years)",
-      "Long (6-10 years)",
-    ];
-    return `The longest timescale from interventions in this scheme is: ${humanReadableValues[index]}`;
+    let max = getMaxTimescale(scheme_reference);
+    if (max) {
+      return `The longest timescale from interventions in this scheme is: ${max}`;
+    }
+    return undefined;
   }
 </script>
 
@@ -53,7 +48,7 @@
     inlineSmall
     required={!forIntervention}
     bind:value={timescale.timescale}
-    hint={timescaleHint}
+    hint={timescaleHint()}
   />
   <NumberInput
     label="Estimated completion year (if known)"

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -3,11 +3,30 @@
   import type { PipelineTimescale } from "types";
 
   export let timescale: PipelineTimescale;
+  export let maxTimescaleFromInterventions: string | undefined = undefined;
   export let forIntervention = false;
+
+  $: timescaleHint = getTimescaleHint(maxTimescaleFromInterventions);
+
+  function getTimescaleHint(
+    maxTimescaleFromInterventions: string | undefined
+  ): string | undefined {
+    const index = ["short", "medium", "long"].indexOf(
+      maxTimescaleFromInterventions || ""
+    );
+    if (index === -1) return undefined;
+    const humanReadableValues = [
+      "Short (1-3 years)",
+      "Medium (3-6 years)",
+      "Long (6-10 years)",
+    ];
+    return `The longest timescale from interventions in this scheme is: ${humanReadableValues[index]}`;
+  }
 </script>
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend">Timing and status</legend>
+  <p>max time{maxTimescaleFromInterventions}</p>
 
   <Radio
     legend="Status"
@@ -34,6 +53,7 @@
     inlineSmall
     required={!forIntervention}
     bind:value={timescale.timescale}
+    hint={timescaleHint}
   />
   <NumberInput
     label="Estimated completion year (if known)"

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { NumberInput, Radio } from "lib/govuk";
+  import type { PipelineTimescale } from "types";
+
+  export let timescale: PipelineTimescale;
+  export let forIntervention = false;
+</script>
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend">Timing and status</legend>
+
+  <Radio
+    legend="Status"
+    id="scheme-status"
+    choices={[
+      ["planned", "Planned"],
+      ["in development", "In development"],
+      ["in construction", "In construction"],
+      ["completed", "Completed"],
+    ]}
+    inlineSmall
+    required={!forIntervention}
+    bind:value={timescale.status}
+  />
+
+  <Radio
+    legend="Timescale"
+    id="scheme-timescale"
+    choices={[
+      ["short", "Short (1-3 years)"],
+      ["medium", "Medium (3-6 years)"],
+      ["long", "Long (6-10 years)"],
+    ]}
+    inlineSmall
+    required={!forIntervention}
+    bind:value={timescale.timescale}
+  />
+  <NumberInput
+    label="Estimated completion year (if known)"
+    width={4}
+    min={2010}
+    max={2100}
+    bind:value={timescale.timescale_year}
+  />
+  {#if !forIntervention}
+    <NumberInput
+      label="What year was this scheme most recently published?"
+      width={4}
+      min={2010}
+      max={2100}
+      bind:value={timescale.year_published}
+    />
+
+    <NumberInput
+      label="What year was this scheme most recently consulted on?"
+      width={4}
+      min={2010}
+      max={2100}
+      bind:value={timescale.year_consulted}
+    />
+  {/if}
+</fieldset>
+
+<style>
+  fieldset {
+    /* TODO govuk doesn't style it, but this seems useful */
+    border: 2px solid black;
+    padding: 8px;
+  }
+</style>

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -4,12 +4,15 @@
   import { getTimescaleHintValue } from "../scheme_data";
 
   export let timescale: PipelineTimescale;
-  export let scheme_reference: string;
+  export let scheme_reference: string | undefined = undefined;
   export let forIntervention = false;
 
   let timescaleHint = getTimescaleHint();
 
   function getTimescaleHint(): string | undefined {
+    if(scheme_reference === undefined) {
+        return;
+    }
     const timescaleHintValue = getTimescaleHintValue(scheme_reference);
     const index = ["short", "medium", "long"].indexOf(timescaleHintValue || "");
     if (index === -1) return undefined;

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import { NumberInput, Radio } from "lib/govuk";
   import type { PipelineTimescale } from "types";
+  import { getTimescaleHintValue } from "../scheme_data";
 
   export let timescale: PipelineTimescale;
-  export let maxTimescaleFromInterventions: string | undefined = undefined;
+  export let scheme_reference: string;
   export let forIntervention = false;
 
-  $: timescaleHint = getTimescaleHint(maxTimescaleFromInterventions);
+  let timescaleHint = getTimescaleHint();
 
-  function getTimescaleHint(
-    maxTimescaleFromInterventions: string | undefined
-  ): string | undefined {
-    const index = ["short", "medium", "long"].indexOf(
-      maxTimescaleFromInterventions || ""
-    );
+  function getTimescaleHint(): string | undefined {
+    const timescaleHintValue = getTimescaleHintValue(scheme_reference);
+    const index = ["short", "medium", "long"].indexOf(timescaleHintValue || "");
     if (index === -1) return undefined;
     const humanReadableValues = [
       "Short (1-3 years)",

--- a/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
+++ b/src/lib/sidebar/pipeline_forms/TimescaleSubform.svelte
@@ -10,8 +10,8 @@
   let timescaleHint = getTimescaleHint();
 
   function getTimescaleHint(): string | undefined {
-    if(scheme_reference === undefined) {
-        return;
+    if (scheme_reference === undefined) {
+      return;
     }
     const timescaleHintValue = getTimescaleHintValue(scheme_reference);
     const index = ["short", "medium", "long"].indexOf(timescaleHintValue || "");

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -235,21 +235,12 @@ export function getMaxTimescale(schemeReference: string): string | undefined {
   ][max];
 }
 
-export function getBudgetHintValue(
-  schemeReference: string
-): number | undefined {
-  const features = getFeaturesFromScheme(schemeReference);
-
-  let summedCost;
-  if (features.length > 0) {
-    summedCost = features
-      .map((feature) => {
-        return feature.properties.pipeline?.cost || 0;
-      })
-      .reduce((partialSum, a) => partialSum + a, 0);
+export function sumBudgetForScheme(schemeReference: string): number {
+  let sum = 0;
+  for (let f of getFeaturesFromScheme(schemeReference)) {
+    sum += f.properties.pipeline!.cost ?? 0;
   }
-
-  return summedCost;
+  return sum;
 }
 
 export function getEmptyPipelineObject(): PipelineScheme {

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -3,6 +3,7 @@ import { randomSchemeColor } from "colors";
 import { schema as schemaStore } from "stores";
 import { get } from "svelte/store";
 import type { FeatureUnion, SchemeCollection, SchemeData } from "types";
+import type { FeatureUnion, PipelineBudget, PipelineTimescale, SchemeCollection, SchemeData } from "types";
 import { v4 as uuidv4 } from "uuid";
 
 // TODO This should eventually guarantee the output is a valid Scheme. Only
@@ -173,3 +174,107 @@ export function getArbitraryScheme(
 ): SchemeData {
   return Object.values(schemeCollection.schemes)[0];
 }
+
+export function getRectifiedPipelineSchemeWithSuggestedValues(scheme:SchemeData, features: FeatureUnion[]):SchemeData {
+    let newPipeline = (scheme.pipeline ||= {
+      scheme_type: "",
+      scheme_timescale: { status: "", timescale: "" },
+      atf4_lead_type: "",
+      scheme_description: "",
+      scheme_budget: {
+        funding_source: "",
+        development_funded: false,
+        construction_funded: false,
+      },
+    });
+
+    const schemeFeatures: FeatureUnion[] = features.filter(
+      (feature) => {
+        return feature.properties.scheme_reference === scheme?.scheme_reference;
+      }
+    );
+    newPipeline.scheme_timescale = getTimescale(
+      scheme.pipeline.scheme_timescale,
+      schemeFeatures
+    );
+    newPipeline.scheme_budget = getBudget(scheme.pipeline.scheme_budget, schemeFeatures);
+
+    scheme.pipeline = newPipeline;
+
+    return scheme;
+}
+
+  function getTimescale(
+    timescaleDetails: any,
+    features: FeatureUnion[]
+  ): PipelineTimescale {
+    const result = {
+      status: timescaleDetails.status || "",
+      timescale: timescaleDetails.timescale,
+      timescale_year: timescaleDetails.timescale_year,
+      year_published: timescaleDetails.year_published,
+      year_consulted: timescaleDetails.year_consulted,
+    };
+    if (
+      (result.timescale === "" || result.timescale === undefined) &&
+      features.length > 0
+    ) {
+      console.log;
+      result.timescale =
+        features.reduce(maxTimescale).properties.pipeline
+          ?.intervention_timescale.timescale || "";
+    }
+
+    return result;
+  }
+
+  function getBudget(
+    budgetDetails: any,
+    features: FeatureUnion[]
+  ): PipelineBudget {
+    const result = {
+      cost: budgetDetails.cost,
+      development_funded: budgetDetails.development_funded,
+      construction_funded: budgetDetails.construction_funded,
+      funding_source: budgetDetails.funding_source || "",
+    };
+
+    if (result.cost === undefined && features.length > 0) {
+      result.cost = features
+        .map((feature) => {
+          return feature.properties.pipeline?.cost || 0;
+        })
+        .reduce((partialSum, a) => partialSum + a, 0);
+    }
+
+    return result;
+  }
+
+  function maxTimescale(
+    thisFeature: FeatureUnion,
+    thatFeature: FeatureUnion
+  ): FeatureUnion {
+    const thisTimescale =
+      thisFeature.properties.pipeline?.intervention_timescale.timescale || "";
+    const thatTimescale =
+      thatFeature.properties.pipeline?.intervention_timescale.timescale || "";
+    const permittedStrings = ["short", "medium", "long"];
+    const thisTimescaleIsValid = permittedStrings.indexOf(thisTimescale) !== -1;
+    const thatTimescaleIsValid = permittedStrings.indexOf(thatTimescale) !== -1;
+    const turnToNumber = (timescaleString: string) => {
+      if (timescaleString === "short") return 1;
+      if (timescaleString === "medium") return 2;
+      return 3;
+    };
+
+    if (!thatTimescaleIsValid) {
+      return thisFeature;
+    }
+    if (!thisTimescaleIsValid) {
+      return thatFeature;
+    }
+
+    return turnToNumber(thisTimescale) - turnToNumber(thatTimescale) < 0
+      ? thatFeature
+      : thisFeature;
+  }

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -1,8 +1,13 @@
 import length from "@turf/length";
 import { randomSchemeColor } from "colors";
-import { schema as schemaStore, gjSchemeCollection } from "stores";
+import { gjSchemeCollection, schema as schemaStore } from "stores";
 import { get } from "svelte/store";
-import type { FeatureUnion, PipelineScheme, Schema, SchemeCollection, SchemeData } from "types";
+import type {
+  FeatureUnion,
+  PipelineScheme,
+  SchemeCollection,
+  SchemeData,
+} from "types";
 import { v4 as uuidv4 } from "uuid";
 
 // TODO This should eventually guarantee the output is a valid Scheme. Only
@@ -44,7 +49,7 @@ export function backfill(json: SchemeCollection) {
       // @ts-ignore handling old format
       json.schemes[scheme_reference].scheme_name = json.scheme_name;
 
-      fillBudgetAndTimelineFromSingleSchemeFormat(json, scheme_reference)
+      fillBudgetAndTimelineFromSingleSchemeFormat(json, scheme_reference);
 
       // @ts-ignore handling old format
       delete json.scheme_name;
@@ -53,11 +58,11 @@ export function backfill(json: SchemeCollection) {
     // Some pipeline files have been created; move over attributes.
     // @ts-ignore handling old format
     if (json.pipeline) {
-      console.log("?")
+      console.log("?");
       // @ts-ignore handling old format
       json.schemes[scheme_reference].pipeline = json.pipeline;
 
-      fillBudgetAndTimelineFromSingleSchemeFormat(json, scheme_reference)
+      fillBudgetAndTimelineFromSingleSchemeFormat(json, scheme_reference);
 
       // @ts-ignore handling old format
       delete json.pipeline;
@@ -77,9 +82,12 @@ export function backfill(json: SchemeCollection) {
   return json;
 }
 
-function fillBudgetAndTimelineFromSingleSchemeFormat(json: SchemeCollection, scheme_reference: string) {
+function fillBudgetAndTimelineFromSingleSchemeFormat(
+  json: SchemeCollection,
+  scheme_reference: string
+) {
   // if this is is true we are dealing with a version which contains budge and timeline data
-  console.log("budgetify")
+  console.log("budgetify");
   // @ts-ignore handling old format
   if (json.schemes.pipeline?.status) {
     // @ts-ignore handling old format
@@ -105,20 +113,19 @@ function fillBudgetAndTimelineFromSingleSchemeFormat(json: SchemeCollection, sch
         // @ts-ignore handling old format
         json.pipeline?.development_funded !== undefined
           ? // @ts-ignore handling old format
-          json.pipeline?.development_funded
+            json.pipeline?.development_funded
           : false,
       // @ts-ignore handling old format
       construction_funded:
         // @ts-ignore handling old format
         json.pipeline?.construction_funded !== undefined
           ? // @ts-ignore handling old format
-          json.pipeline?.construction_funded
+            json.pipeline?.construction_funded
           : false,
       // @ts-ignore handling old format
       funding_source: json.pipeline.funding_source || "",
-
-    }
-  };
+    };
+  }
 }
 
 export function emptyCollection(): SchemeCollection {
@@ -291,7 +298,7 @@ function determineMaxTimescale(
     : thisFeature;
 }
 
-export function getEmptyPipelineObject():PipelineScheme {
+export function getEmptyPipelineObject(): PipelineScheme {
   return {
     scheme_type: "",
     atf4_lead_type: "",

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -98,15 +98,9 @@ function fillBudgetAndTimelineFromSingleSchemeFormat(
 
     json.schemes[scheme_reference].pipeline.scheme_budget = {
       cost: json.pipeline?.cost,
-      development_funded:
-        json.pipeline?.development_funded !== undefined
-          ? json.pipeline?.development_funded
-          : false,
-      construction_funded:
-        json.pipeline?.construction_funded !== undefined
-          ? json.pipeline?.construction_funded
-          : false,
-      funding_source: json.pipeline.funding_source || "",
+      development_funded: json.pipeline?.development_funded ?? false,
+      construction_funded: json.pipeline?.construction_funded ?? false,
+      funding_source: json.pipeline.funding_source ?? "",
     };
   }
 }

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -4,8 +4,6 @@ import { schema as schemaStore, gjSchemeCollection } from "stores";
 import { get } from "svelte/store";
 import type {
   FeatureUnion,
-  PipelineBudget,
-  PipelineTimescale,
   Schema,
   SchemeCollection,
   SchemeData,
@@ -82,15 +80,15 @@ export function backfill(json: SchemeCollection) {
         development_funded:
           // @ts-ignore handling old format
           json.pipeline.development_funded !== undefined
-            // @ts-ignore handling old format
-            ? json.pipeline.development_funded
+            ? // @ts-ignore handling old format
+              json.pipeline.development_funded
             : false,
         // @ts-ignore handling old format
         construction_funded:
           // @ts-ignore handling old format
           json.pipeline.construction_funded !== undefined
-            // @ts-ignore handling old format
-            ? json.pipeline.construction_funded
+            ? // @ts-ignore handling old format
+              json.pipeline.construction_funded
             : false,
         // @ts-ignore handling old format
         funding_source: json.pipeline.funding_source || "",
@@ -233,11 +231,9 @@ export function getTimescaleHintValue(
 }
 
 function getFeaturesFromScheme(schemeReference: string): FeatureUnion[] {
-  return get(gjSchemeCollection).features.filter(
-    (feature) => {
-      return feature.properties.scheme_reference === schemeReference;
-    }
-  );
+  return get(gjSchemeCollection).features.filter((feature) => {
+    return feature.properties.scheme_reference === schemeReference;
+  });
 }
 
 export function getBudgetHintValue(

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -80,12 +80,16 @@ export function backfill(json: SchemeCollection) {
         cost: json.pipeline.cost,
         // @ts-ignore handling old format
         development_funded:
+          // @ts-ignore handling old format
           json.pipeline.development_funded !== undefined
+            // @ts-ignore handling old format
             ? json.pipeline.development_funded
             : false,
         // @ts-ignore handling old format
         construction_funded:
+          // @ts-ignore handling old format
           json.pipeline.construction_funded !== undefined
+            // @ts-ignore handling old format
             ? json.pipeline.construction_funded
             : false,
         // @ts-ignore handling old format
@@ -215,7 +219,7 @@ export function getArbitraryScheme(
 }
 
 export function getTimescaleHintValue(
-  schemeReference: string 
+  schemeReference: string
 ): string | undefined {
   const features = getFeaturesFromScheme(schemeReference);
   let maxTimescale;
@@ -229,15 +233,15 @@ export function getTimescaleHintValue(
 }
 
 function getFeaturesFromScheme(schemeReference: string): FeatureUnion[] {
- return get(gjSchemeCollection).features.filter(
-  (feature) => {
-    return feature.properties.scheme_reference === schemeReference;
-  }
-);
+  return get(gjSchemeCollection).features.filter(
+    (feature) => {
+      return feature.properties.scheme_reference === schemeReference;
+    }
+  );
 }
 
 export function getBudgetHintValue(
-  schemeReference: string 
+  schemeReference: string
 ): number | undefined {
   const features = getFeaturesFromScheme(schemeReference);
 

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -86,7 +86,6 @@ function fillBudgetAndTimelineFromSingleSchemeFormat(
   json: any,
   scheme_reference: string
 ) {
-  // if this is is true we are dealing with a version which contains budge and timeline data
   if (json.schemes.pipeline?.status) {
     json.schemes[scheme_reference].pipeline.scheme_timescale = {
       status: json.pipeline?.status,

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -1,6 +1,6 @@
 import length from "@turf/length";
 import { randomSchemeColor } from "colors";
-import { schema as schemaStore } from "stores";
+import { schema as schemaStore, gjSchemeCollection } from "stores";
 import { get } from "svelte/store";
 import type {
   FeatureUnion,
@@ -215,8 +215,9 @@ export function getArbitraryScheme(
 }
 
 export function getTimescaleHintValue(
-  features: FeatureUnion[]
+  schemeReference: string 
 ): string | undefined {
+  const features = getFeaturesFromScheme(schemeReference);
   let maxTimescale;
   if (features.length > 0) {
     maxTimescale =
@@ -227,9 +228,19 @@ export function getTimescaleHintValue(
   return maxTimescale;
 }
 
+function getFeaturesFromScheme(schemeReference: string): FeatureUnion[] {
+ return get(gjSchemeCollection).features.filter(
+  (feature) => {
+    return feature.properties.scheme_reference === schemeReference;
+  }
+);
+}
+
 export function getBudgetHintValue(
-  features: FeatureUnion[]
+  schemeReference: string 
 ): number | undefined {
+  const features = getFeaturesFromScheme(schemeReference);
+
   let summedCost;
   if (features.length > 0) {
     summedCost = features

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -139,11 +139,6 @@ export function interventionName(feature: FeatureUnion): string {
 export function interventionWarning(feature: FeatureUnion): string | null {
   let schema = get(schemaStore);
 
-  // Only worry about some schemas for now.
-  if (schema != "v1" && schema != "pipeline") {
-    return null;
-  }
-
   if (!feature.properties.name) {
     return "No name";
   }
@@ -155,6 +150,12 @@ export function interventionWarning(feature: FeatureUnion): string | null {
     )
   ) {
     return "No intervention type";
+  }
+
+  if (schema == "pipeline") {
+    if (!feature.properties.pipeline?.accuracy) {
+      return "Accuracy not specified";
+    }
   }
 
   let unexpectedProperties = getUnexpectedProperties(feature.properties);
@@ -190,7 +191,14 @@ export function getUnexpectedProperties(props: { [name: string]: any }): {
   }
 
   if (schema == "pipeline" && copy.pipeline) {
-    for (let key of ["atf4_type", "accuracy", "is_alternative"]) {
+    // TODO We could recurse into intervention_timescale if needed
+    for (let key of [
+      "atf4_type",
+      "accuracy",
+      "is_alternative",
+      "cost",
+      "intervention_timescale",
+    ]) {
       delete copy.pipeline[key];
     }
     if (Object.entries(copy.pipeline).length == 0) {

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -58,7 +58,6 @@ export function backfill(json: SchemeCollection) {
     // Some pipeline files have been created; move over attributes.
     // @ts-ignore handling old format
     if (json.pipeline) {
-      console.log("?");
       // @ts-ignore handling old format
       json.schemes[scheme_reference].pipeline = json.pipeline;
 
@@ -83,46 +82,30 @@ export function backfill(json: SchemeCollection) {
 }
 
 function fillBudgetAndTimelineFromSingleSchemeFormat(
-  json: SchemeCollection,
+  // Use any to handle old formats
+  json: any,
   scheme_reference: string
 ) {
   // if this is is true we are dealing with a version which contains budge and timeline data
-  console.log("budgetify");
-  // @ts-ignore handling old format
   if (json.schemes.pipeline?.status) {
-    // @ts-ignore handling old format
     json.schemes[scheme_reference].pipeline.scheme_timescale = {
-      // @ts-ignore handling old format
       status: json.pipeline?.status,
-      // @ts-ignore handling old format
       timescale: json.pipeline?.timescale,
-      // @ts-ignore handling old format
       timescale_year: json.pipeline?.timescale_year,
-      // @ts-ignore handling old format
       year_published: json.pipeline?.year_published,
-      // @ts-ignore handling old format
       year_consulted: json.pipeline?.year_consulted,
     };
 
-    // @ts-ignore handling old format
     json.schemes[scheme_reference].pipeline.scheme_budget = {
-      // @ts-ignore handling old format
       cost: json.pipeline?.cost,
-      // @ts-ignore handling old format
       development_funded:
-        // @ts-ignore handling old format
         json.pipeline?.development_funded !== undefined
-          ? // @ts-ignore handling old format
-            json.pipeline?.development_funded
+          ? json.pipeline?.development_funded
           : false,
-      // @ts-ignore handling old format
       construction_funded:
-        // @ts-ignore handling old format
         json.pipeline?.construction_funded !== undefined
-          ? // @ts-ignore handling old format
-            json.pipeline?.construction_funded
+          ? json.pipeline?.construction_funded
           : false,
-      // @ts-ignore handling old format
       funding_source: json.pipeline.funding_source || "",
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,12 +30,12 @@ export interface SchemeData {
 export interface PipelineScheme {
   // TODO "intersection" is unclear
   scheme_type:
-  | "cycling route"
-  | "walking route"
-  | "shared-use route"
-  | "area-based scheme"
-  | "intersection"
-  | "";
+    | "cycling route"
+    | "walking route"
+    | "shared-use route"
+    | "area-based scheme"
+    | "intersection"
+    | "";
   atf4_lead_type: ATF4Type | "";
   scheme_description: string;
 
@@ -55,10 +55,9 @@ export interface PipelineTimescale {
 export interface PipelineBudget {
   // GBP
   cost?: number;
-  development_funded: boolean,
-  construction_funded: boolean,
+  development_funded: boolean;
+  construction_funded: boolean;
   funding_source: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF" | "";
-
 }
 
 export interface BrowseSchemeData {
@@ -152,16 +151,16 @@ export function isStreetViewImagery(x: string): x is "google" | "bing" {
 
 export type Mode =
   | {
-    mode: "list";
-  }
+      mode: "list";
+    }
   | {
-    mode: "edit-form";
-    id: number;
-  }
+      mode: "edit-form";
+      id: number;
+    }
   | {
-    mode: "edit-geometry";
-    id: number;
-  }
+      mode: "edit-geometry";
+      id: number;
+    }
   | { mode: "new-point" }
   | { mode: "new-freehand-polygon" }
   | { mode: "new-snapped-polygon" }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,28 +30,35 @@ export interface SchemeData {
 export interface PipelineScheme {
   // TODO "intersection" is unclear
   scheme_type:
-    | "cycling route"
-    | "walking route"
-    | "shared-use route"
-    | "area-based scheme"
-    | "intersection"
-    | "";
+  | "cycling route"
+  | "walking route"
+  | "shared-use route"
+  | "area-based scheme"
+  | "intersection"
+  | "";
   atf4_lead_type: ATF4Type | "";
   scheme_description: string;
 
   // TODO Check with DB schema
+  scheme_timescale: PipelineTimescale;
+  scheme_budget: PipelineBudget;
+}
+
+export interface PipelineTimescale {
   status: "planned" | "in development" | "in construction" | "completed" | "";
   timescale: "short" | "medium" | "long" | "";
   timescale_year?: number;
   year_published?: number;
   year_consulted?: number;
+}
 
+export interface PipelineBudget {
   // GBP
-  budget_funded?: number;
-  budget_unfunded?: number;
+  cost?: number;
+  development_funded: boolean,
+  construction_funded: boolean,
   funding_source: "ATF2" | "ATF3" | "ATF4" | "ATF4e" | "CRSTS" | "LUF" | "";
-  // TODO What about partially? How's this overlap with budget?
-  funded: boolean;
+
 }
 
 export interface BrowseSchemeData {
@@ -118,6 +125,8 @@ export interface PipelineIntervention {
   accuracy: "high" | "medium" | "low" | "";
   is_alternative: boolean;
 
+  intervention_timescale: PipelineTimescale;
+  cost?: number;
   // TODO new / existing / upgrade existing?
   // TODO for routes, ltn120 type: fully protected, light segregation, off-carriageway, shared-use, dedicated footpath. minimum width?
 }
@@ -143,16 +152,16 @@ export function isStreetViewImagery(x: string): x is "google" | "bing" {
 
 export type Mode =
   | {
-      mode: "list";
-    }
+    mode: "list";
+  }
   | {
-      mode: "edit-form";
-      id: number;
-    }
+    mode: "edit-form";
+    id: number;
+  }
   | {
-      mode: "edit-geometry";
-      id: number;
-    }
+    mode: "edit-geometry";
+    id: number;
+  }
   | { mode: "new-point" }
   | { mode: "new-freehand-polygon" }
   | { mode: "new-snapped-polygon" }


### PR DESCRIPTION
Handling a couple of aspects of https://github.com/acteng/atip/issues/389#issuecomment-1814961227 :

-  Add optional cost and estimated completion year to per-intervention form. In scheme-wide details, show sum of intervention costs and max year as a hint to fill out the scheme-wide one.
-  Stop autofilling route name in pipeline mode, but keep as an option. Add hint text to say use the LCWIP PDF
-  Accuracy of mapped data needs to be required