### PR TITLE
Allow reordering of schemes in list

### DIFF
--- a/src/lib/sidebar/ListMode.svelte
+++ b/src/lib/sidebar/ListMode.svelte
@@ -40,6 +40,56 @@
       errorFromFile = `Couldn't load scheme from a file: ${err}`;
     }
   }
+
+  function moveSchemeInList(scheme_reference: string, direction: number) {
+    return function () {
+      const currentSchemeOrder = JSON.parse(
+        JSON.stringify(Object.keys($gjSchemeCollection.schemes))
+      );
+      const currentIndex = currentSchemeOrder.indexOf(scheme_reference);
+      if (
+        currentIndex + direction >= 0 &&
+        currentIndex + direction < currentSchemeOrder.length
+      ) {
+        const newSchemeOrder = swapArrayValues(
+          currentSchemeOrder,
+          currentIndex,
+          currentIndex + direction
+        );
+        const newSchemesObject = getReorderedSchemesObject(
+          newSchemeOrder,
+          $gjSchemeCollection.schemes
+        );
+        $gjSchemeCollection.schemes = newSchemesObject;
+        $gjSchemeCollection = $gjSchemeCollection;
+      }
+    };
+  }
+
+  function swapArrayValues(
+    array: any[],
+    firstIndex: number,
+    secondIndex: number
+  ) {
+    const firstValue = array[firstIndex];
+    const secondValue = array[secondIndex];
+    array[secondIndex] = firstValue;
+    array[firstIndex] = secondValue;
+
+    return array;
+  }
+
+  function getReorderedSchemesObject(
+    newSchemeOrder: string[],
+    currentSchemesObject: { [reference: string]: any }
+  ) {
+    const result: { [reference: string]: any } = {};
+    newSchemeOrder.forEach((scheme_reference) => {
+      result[scheme_reference] = currentSchemesObject[scheme_reference];
+    });
+
+    return result;
+  }
 </script>
 
 <SecondaryButton on:click={newBlankScheme}>
@@ -55,6 +105,15 @@
 <hr />
 
 {#each Object.keys($gjSchemeCollection.schemes) as scheme_reference}
-  <PerSchemeControls {scheme_reference} />
+  <PerSchemeControls {scheme_reference}>
+    {#if Object.keys($gjSchemeCollection.schemes).length > 1}
+      <SecondaryButton on:click={moveSchemeInList(scheme_reference, -1)}>
+        Move Up
+      </SecondaryButton>
+      <SecondaryButton on:click={moveSchemeInList(scheme_reference, 1)}>
+        Move Down
+      </SecondaryButton>
+    {/if}
+  </PerSchemeControls>
   <hr />
 {/each}

--- a/src/lib/sidebar/ListMode.svelte
+++ b/src/lib/sidebar/ListMode.svelte
@@ -51,13 +51,13 @@
         currentIndex + direction >= 0 &&
         currentIndex + direction < currentSchemeOrder.length
       ) {
-        const newSchemeOrder = swapArrayValues(
+        swapArrayValuesInPlace(
           currentSchemeOrder,
           currentIndex,
           currentIndex + direction
         );
         const newSchemesObject = getReorderedSchemesObject(
-          newSchemeOrder,
+          currentSchemeOrder,
           $gjSchemeCollection.schemes
         );
         $gjSchemeCollection.schemes = newSchemesObject;
@@ -66,17 +66,12 @@
     };
   }
 
-  function swapArrayValues(
+  function swapArrayValuesInPlace(
     array: any[],
     firstIndex: number,
     secondIndex: number
   ) {
-    const firstValue = array[firstIndex];
-    const secondValue = array[secondIndex];
-    array[secondIndex] = firstValue;
-    array[firstIndex] = secondValue;
-
-    return array;
+    [array[firstIndex], array[secondIndex]] = [array[secondIndex], array[firstIndex]];
   }
 
   function getReorderedSchemesObject(

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -119,6 +119,7 @@
     Delete
   </WarningButton>
 </h3>
+<slot />
 {#if $schema == "pipeline"}
   <PipelineSchemeForm {scheme_reference} />
 {:else}


### PR DESCRIPTION
Currently have logic lifted to ListMode because it feels like that's what should be managing the order of schemes but I don't mind putting it in PerSchemeControls if we prefer