### PR TITLE
prevent scrolling below the map

### DIFF
--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -144,6 +144,7 @@
     left: 0;
     right: 0;
     bottom: 0;
+    overflow-y: hidden;
 
     display: flex;
     flex-flow: row nowrap;


### PR DESCRIPTION
When you have several schemes in sidebar, you can easily scroll to show whitespace and have some of the map, and the tools hidden. This fixes that