### PR TITLE
Fix browse page layer display

### DIFF
--- a/src/lib/browse/InterventionLayer.svelte
+++ b/src/lib/browse/InterventionLayer.svelte
@@ -8,7 +8,7 @@
     isPolygon,
     layerId,
   } from "lib/maplibre";
-  import type { FilterSpecification } from "maplibre-gl";
+  import type { ExpressionSpecification } from "maplibre-gl";
   import { colorInterventionsBySchema } from "schemas";
   import {
     CircleLayer,
@@ -29,12 +29,16 @@
   $: gj = addLineStringEndpoints(schemesGj);
 
   // TODO Abusing this property for filtering
-  const hideWhileEditing: FilterSpecification = [
+  const hideWhileEditing: ExpressionSpecification = [
     "!=",
     ["get", "hide_while_editing"],
     true,
   ];
-  const notEndpoint: FilterSpecification = ["!=", ["get", "endpoint"], true];
+  const notEndpoint: ExpressionSpecification = [
+    "!=",
+    ["get", "endpoint"],
+    true,
+  ];
 </script>
 
 <GeoJSON data={gj}>

--- a/src/lib/browse/InterventionLayer.svelte
+++ b/src/lib/browse/InterventionLayer.svelte
@@ -31,10 +31,10 @@
   // TODO Abusing this property for filtering
   const hideWhileEditing: FilterSpecification = [
     "!=",
-    "hide_while_editing",
+    ["get", "hide_while_editing"],
     true,
   ];
-  const notEndpoint: FilterSpecification = ["!=", "endpoint", true];
+  const notEndpoint: FilterSpecification = ["!=", ["get", "endpoint"], true];
 </script>
 
 <GeoJSON data={gj}>


### PR DESCRIPTION
Oops sorry, broke in #411. We switched to the new maplibre style expressions, but I forgot to update some of the old-style ones in browse. Mixing the two doesn't work. I really wish there was a way to detect the new/old expressions in the static type system or at least with a runtime error, but I don't think maplibre does that.

I've noticed a bug where loading the GJ file in browse doesn't show stuff in the sidebar. I think that predates #411, I'll have a quick look separately