### PR TITLE
Add indicator for alternative intervention options

### DIFF
--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -182,6 +182,9 @@
         {/if}
         {interventionName(feature)}
       </a>
+      {#if $schema === "pipeline" && feature.properties.pipeline?.is_alternative}
+        <span>This is an alternative option.</span>
+      {/if}
     </li>
   {/each}
 </ol>

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -183,7 +183,7 @@
         {interventionName(feature)}
       </a>
       {#if $schema === "pipeline" && feature.properties.pipeline?.is_alternative}
-        <span>This is an alternative option.</span>
+        <span> (alternative)</span>
       {/if}
     </li>
   {/each}


### PR DESCRIPTION
Adding an indication of whether a listed intervention in 'an alternative' so that users can easily know if they've set that flag