### PR TITLE
Actually log Maplibre errors

### DIFF
--- a/src/lib/browse/layers/areas/CensusOutputAreas.svelte
+++ b/src/lib/browse/layers/areas/CensusOutputAreas.svelte
@@ -225,6 +225,7 @@
   </FillLayer>
   <LineLayer
     {...layerId(`${name}-outline`)}
+    sourceLayer={name}
     paint={{
       "line-color": "black",
       "line-width": 0.5,

--- a/src/lib/browse/layers/areas/IMD.svelte
+++ b/src/lib/browse/layers/areas/IMD.svelte
@@ -84,6 +84,7 @@
   </FillLayer>
   <LineLayer
     {...layerId(`${name}-outline`)}
+    sourceLayer={name}
     paint={{
       "line-color": "black",
       "line-width": 0.5,

--- a/src/lib/common/MapLibreMap.svelte
+++ b/src/lib/common/MapLibreMap.svelte
@@ -39,11 +39,16 @@
     window.history.replaceState(null, "", url.toString());
   }
   $: changeStyle(style);
+
+  function onError(e: CustomEvent<any>) {
+    // ErrorEvent isn't exported
+    console.error(`MapLibre error: ${e.detail.error}`);
+  }
 </script>
 
 <div class="map">
   {#if styleSpec}
-    <MapLibre style={styleSpec} bounds={startBounds} hash bind:loaded bind:map>
+    <MapLibre style={styleSpec} bounds={startBounds} hash bind:loaded bind:map on:error={onError}>
       {#if loaded}
         <ScaleControl />
         <NavigationControl position="bottom-right" visualizePitch />


### PR DESCRIPTION
I was looking into why we don't seem to get any style validation errors from maplibre, and it turns out svelte-maplibre is intercepting them and re-dispatching. This prevents maplibre's default behavior of console logging when there are no handlers. So, this PR starts logging errors. There were a few easy bugs on the browse page, now fixed. This logging would've prevented #415 or made it much easier to figure out the problem