### PR TITLE
Update route-snappers package and use new files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "js-cookie": "^3.0.5",
         "maplibre-gl": "^3.5.1",
         "read-excel-file": "^5.6.1",
-        "route-snapper": "^0.2.5",
+        "route-snapper": "^0.3.0",
         "svelte": "^4.0.0",
         "svelte-maplibre": "^0.7.3",
         "uuid": "^9.0.1"
@@ -2985,9 +2985,9 @@
       }
     },
     "node_modules/route-snapper": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.2.5.tgz",
-      "integrity": "sha512-u259FNKShwiOZOGR0/y/OplvpLnGZp7Iz07QCXr+94KO+DasBIO26LkQimZQQu/0pMdnAnZLb+QxxVDfLoVEHg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.3.0.tgz",
+      "integrity": "sha512-5a9fMq05zftlFCp8Smnw+5k6CP871sYgEaD30o9KX4VARUaACkJDWCCq76KZ3tmP/Vv/KupZOVHnPtxcDWSmpQ=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-cookie": "^3.0.5",
     "maplibre-gl": "^3.5.1",
     "read-excel-file": "^5.6.1",
-    "route-snapper": "^0.2.5",
+    "route-snapper": "^0.3.0",
     "svelte": "^4.0.0",
     "svelte-maplibre": "^0.7.3",
     "uuid": "^9.0.1"

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -41,7 +41,7 @@
   // releases.
   let routeSnapperUrl = `${
     import.meta.env.VITE_RESOURCE_BASE
-  }/route-snappers/v2.3/${authorityName}.bin.gz`;
+  }/route-snappers/v2.5/${authorityName}.bin.gz`;
 
   function toggleAbout() {
     showAbout = !showAbout;

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -4,7 +4,7 @@ import { clickMap } from "./shared.js";
 // This is separate from modes.spec.ts to avoid the common beforeAll
 test("other tools work when route tool doesn't load", async ({ page }) => {
   await page.route(
-    "https://atip.uk/route-snappers/v2.3/LAD_Adur.bin.gz",
+    "https://atip.uk/route-snappers/v2.5/LAD_Adur.bin.gz",
     (route) =>
       route.fulfill({
         status: 404,

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -127,7 +127,7 @@ test("adding interventions, then deleting one, then adding another", async () =>
 
   await expect(
     page.getByRole("link", {
-      name: "Route from Burnside Crescent and Carnforth Road to ??? and Brighton Road",
+      name: "Route from Burnside Crescent and Carnforth Road to Prince Avenue and West Way",
     })
   ).toBeVisible();
 });


### PR DESCRIPTION
I made a new route-snapper release recently (https://github.com/dabreegster/route_snapper/pull/47) that avoids unnecessary coordinate projection and produces more accurate lengths. This updates ATIP to use it. I've generated and uploaded the v2.5 files for everywhere with https://github.com/acteng/atip-data-prep/pull/43.

Manual tests in different areas all work fine