### PR TITLE
Split stores.ts

### DIFF
--- a/src/lib/common/MapLibreMap.svelte
+++ b/src/lib/common/MapLibreMap.svelte
@@ -48,7 +48,14 @@
 
 <div class="map">
   {#if styleSpec}
-    <MapLibre style={styleSpec} bounds={startBounds} hash bind:loaded bind:map on:error={onError}>
+    <MapLibre
+      style={styleSpec}
+      bounds={startBounds}
+      hash
+      bind:loaded
+      bind:map
+      on:error={onError}
+    >
       {#if loaded}
         <ScaleControl />
         <NavigationControl position="bottom-right" visualizePitch />

--- a/src/lib/draw/EditGeometryMode.svelte
+++ b/src/lib/draw/EditGeometryMode.svelte
@@ -3,20 +3,20 @@
   import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
   import { interventionName } from "lib/sidebar/scheme_data";
-  import {
-    gjSchemeCollection,
-    mode,
-    pointTool,
-    polygonTool,
-    routeTool,
-    schema,
-  } from "stores";
+  import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature, FeatureUnion } from "types";
   import PointControls from "./point/PointControls.svelte";
   import PolygonControls from "./polygon/PolygonControls.svelte";
   import RouteControls from "./route/RouteControls.svelte";
   import SnapPolygonControls from "./snap_polygon/SnapPolygonControls.svelte";
+  import {
+    gjSchemeCollection,
+    mode,
+    pointTool,
+    polygonTool,
+    routeTool,
+  } from "./stores";
 
   export let id: number;
 

--- a/src/lib/draw/EditGeometryMode.svelte
+++ b/src/lib/draw/EditGeometryMode.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
   import type { LineString, Point, Polygon } from "geojson";
+  import {
+    gjSchemeCollection,
+    mode,
+    pointTool,
+    polygonTool,
+    routeTool,
+  } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
   import { interventionName } from "lib/sidebar/scheme_data";
@@ -10,13 +17,6 @@
   import PolygonControls from "./polygon/PolygonControls.svelte";
   import RouteControls from "./route/RouteControls.svelte";
   import SnapPolygonControls from "./snap_polygon/SnapPolygonControls.svelte";
-  import {
-    gjSchemeCollection,
-    mode,
-    pointTool,
-    polygonTool,
-    routeTool,
-  } from "./stores";
 
   export let id: number;
 

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { circleRadius, colors, lineWidth } from "colors";
+  import { gjSchemeCollection, sidebarHover } from "lib/draw/stores";
   import {
     emptyGeojson,
     isLine,
@@ -8,7 +9,6 @@
     layerId,
   } from "lib/maplibre";
   import { CircleLayer, GeoJSON, LineLayer } from "svelte-maplibre";
-  import { gjSchemeCollection, sidebarHover } from "./stores";
 
   // Use a layer that only ever has zero or one features for hovering.
   $: gj =

--- a/src/lib/draw/HoverLayer.svelte
+++ b/src/lib/draw/HoverLayer.svelte
@@ -7,8 +7,8 @@
     isPolygon,
     layerId,
   } from "lib/maplibre";
-  import { gjSchemeCollection, sidebarHover } from "stores";
   import { CircleLayer, GeoJSON, LineLayer } from "svelte-maplibre";
+  import { gjSchemeCollection, sidebarHover } from "./stores";
 
   // Use a layer that only ever has zero or one features for hovering.
   $: gj =

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { circleRadius, colors, lineWidth } from "colors";
   import type { Feature } from "geojson";
+  import { gjSchemeCollection, hideSchemes, mode } from "lib/draw/stores";
   import {
     addLineStringEndpoints,
     constructMatchExpression,
@@ -26,7 +27,6 @@
     type LayerClickInfo,
   } from "svelte-maplibre";
   import type { FeatureUnion, SchemeCollection } from "types";
-  import { gjSchemeCollection, hideSchemes, mode } from "./stores";
 
   $: gj = addLineStringEndpoints($gjSchemeCollection);
 

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -16,7 +16,7 @@
     DataDrivenPropertyValueSpecification,
     ExpressionSpecification,
   } from "maplibre-gl";
-  import { gjSchemeCollection, hideSchemes, map, mode } from "stores";
+  import { map } from "stores";
   import {
     CircleLayer,
     FillLayer,
@@ -26,6 +26,7 @@
     type LayerClickInfo,
   } from "svelte-maplibre";
   import type { FeatureUnion, SchemeCollection } from "types";
+  import { gjSchemeCollection, hideSchemes, mode } from "./stores";
 
   $: gj = addLineStringEndpoints($gjSchemeCollection);
 

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { StreetViewHelp, StreetViewTool } from "lib/common";
   import { DefaultButton, Radio } from "lib/govuk";
-  import { mode, userSettings } from "stores";
+  import { userSettings } from "stores";
+  import { mode } from "./stores";
 
   let enabled = true;
   $: if (!enabled) {

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { StreetViewHelp, StreetViewTool } from "lib/common";
+  import { mode } from "lib/draw/stores";
   import { DefaultButton, Radio } from "lib/govuk";
   import { userSettings } from "stores";
-  import { mode } from "./stores";
 
   let enabled = true;
   $: if (!enabled) {

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { mode, pointTool, polygonTool, routeTool } from "lib/draw/stores";
   import { SecondaryButton } from "lib/govuk";
   import imageIcon from "../../../assets/image.svg";
   import pointIcon from "../../../assets/point.svg";
@@ -8,7 +9,6 @@
   import splitRouteIcon from "../../../assets/split_route.svg";
   import streetViewIcon from "../../../assets/street_view.svg";
   import HoverLayer from "./HoverLayer.svelte";
-  import { mode, pointTool, polygonTool, routeTool } from "./stores";
 </script>
 
 <HoverLayer />

--- a/src/lib/draw/Toolbox.svelte
+++ b/src/lib/draw/Toolbox.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { SecondaryButton } from "lib/govuk";
-  import { mode, pointTool, polygonTool, routeTool } from "stores";
   import imageIcon from "../../../assets/image.svg";
   import pointIcon from "../../../assets/point.svg";
   import polygonFreehandIcon from "../../../assets/polygon_freehand.svg";
@@ -9,6 +8,7 @@
   import splitRouteIcon from "../../../assets/split_route.svg";
   import streetViewIcon from "../../../assets/street_view.svg";
   import HoverLayer from "./HoverLayer.svelte";
+  import { mode, pointTool, polygonTool, routeTool } from "./stores";
 </script>
 
 <HoverLayer />

--- a/src/lib/draw/image/ImageLayer.svelte
+++ b/src/lib/draw/image/ImageLayer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { mode } from "lib/draw/stores";
   import { layerId } from "lib/maplibre";
-  import { map, mode } from "stores";
+  import { map } from "stores";
   import { ImageSource, Marker, RasterLayer } from "svelte-maplibre";
   import { imgSrc, opacity } from "./stores";
 

--- a/src/lib/draw/image/ImageMode.svelte
+++ b/src/lib/draw/image/ImageMode.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  import { mode } from "lib/draw/stores";
   import {
     ButtonGroup,
     DefaultButton,
     FormElement,
     WarningButton,
   } from "lib/govuk";
-  import { mode } from "stores";
   import { imgSrc, opacity } from "./stores";
 
   let fileInput: HTMLInputElement;

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import type { Point } from "geojson";
+  import {
+    gjSchemeCollection,
+    mode,
+    newFeatureId,
+    pointTool,
+  } from "lib/draw/stores";
   import { SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
   import { getArbitraryScheme } from "lib/sidebar/scheme_data";
-  import { gjSchemeCollection, mode, newFeatureId, pointTool } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PointControls from "./PointControls.svelte";

--- a/src/lib/draw/polygon/PolygonControls.svelte
+++ b/src/lib/draw/polygon/PolygonControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { polygonTool } from "lib/draw/stores";
   import { SecondaryButton } from "lib/govuk";
-  import { polygonTool } from "stores";
   import { undoLength } from "./stores";
 
   function undo() {

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import type { Polygon } from "geojson";
+  import {
+    gjSchemeCollection,
+    mode,
+    newFeatureId,
+    polygonTool,
+  } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
   import { getArbitraryScheme } from "lib/sidebar/scheme_data";
-  import { gjSchemeCollection, mode, newFeatureId, polygonTool } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PolygonControls from "./PolygonControls.svelte";

--- a/src/lib/draw/route/GeocoderControls.svelte
+++ b/src/lib/draw/route/GeocoderControls.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import type { FeatureCollection } from "@maptiler/geocoding-control/types";
   import type { Position } from "geojson";
+  import { routeTool } from "lib/draw/stores";
   import { TextInput } from "lib/govuk";
   import { emptyGeojson } from "lib/maplibre";
-  import { map, routeTool } from "stores";
+  import { map } from "stores";
   import { geocoderGj } from "./stores";
 
   let query = "";

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { routeTool } from "lib/draw/stores";
   import { Checkbox, CheckboxGroup, SecondaryButton } from "lib/govuk";
-  import { routeTool, userSettings } from "stores";
+  import { userSettings } from "stores";
   import GeocoderControls from "./GeocoderControls.svelte";
   import { snapMode, undoLength } from "./stores";
 

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import type { LineString, Polygon } from "geojson";
-  import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
-  import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import {
     gjSchemeCollection,
     mode,
     newFeatureId,
     routeTool,
-    schema,
-  } from "stores";
+  } from "lib/draw/stores";
+  import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
+  import type { FeatureWithProps } from "lib/maplibre";
+  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
+  import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import RouteControls from "./RouteControls.svelte";

--- a/src/lib/draw/route/RouteSnapperLoader.svelte
+++ b/src/lib/draw/route/RouteSnapperLoader.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { routeTool } from "lib/draw/stores";
   import { ErrorMessage } from "lib/govuk";
   import init from "route-snapper";
-  import { map, routeTool } from "stores";
+  import { map } from "stores";
   import { onMount } from "svelte";
   import { RouteTool } from "./route_tool";
 

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -9,9 +9,10 @@
   import nearestPointOnLine from "@turf/nearest-point-on-line";
   // Note we don't use our specialization of Feature here
   import type { Feature, LineString, Point, Position } from "geojson";
+  import { gjSchemeCollection, mode, newFeatureId } from "lib/draw/stores";
   import { emptyGeojson, layerId, setPrecision } from "lib/maplibre";
   import type { MapMouseEvent } from "maplibre-gl";
-  import { gjSchemeCollection, map, mode, newFeatureId } from "stores";
+  import { map } from "stores";
   import { onDestroy, onMount } from "svelte";
   import { CircleLayer, GeoJSON } from "svelte-maplibre";
   import type { Feature as OurFeature } from "types";

--- a/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { routeTool } from "lib/draw/stores";
   import { SecondaryButton } from "lib/govuk";
-  import { routeTool } from "stores";
   import { undoLength } from "../route/stores";
 
   function undo() {

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import type { LineString, Polygon } from "geojson";
+  import {
+    gjSchemeCollection,
+    mode,
+    newFeatureId,
+    routeTool,
+  } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "lib/govuk";
   import type { FeatureWithProps } from "lib/maplibre";
   import { getArbitraryScheme } from "lib/sidebar/scheme_data";
-  import { gjSchemeCollection, mode, newFeatureId, routeTool } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";

--- a/src/lib/draw/stores.ts
+++ b/src/lib/draw/stores.ts
@@ -1,0 +1,62 @@
+import { emptyCollection } from "lib/sidebar/scheme_data";
+import { writable, type Writable } from "svelte/store";
+import type { Mode, SchemeCollection } from "types";
+import { PointTool } from "./point/point_tool";
+import { PolygonTool } from "./polygon/polygon_tool";
+import { RouteTool } from "./route/route_tool";
+
+// TODO Should we instead store a map from ID to feature?
+export const gjSchemeCollection: Writable<SchemeCollection> = writable(
+  emptyCollection()
+);
+
+export const pointTool: Writable<PointTool | null> = writable(null);
+export const polygonTool: Writable<PolygonTool | null> = writable(null);
+// A global singleton, with the route tool loaded for the current map. It's
+// null before it's loaded.
+export const routeTool: Writable<RouteTool | null> = writable(null);
+
+// scheme_references to hide
+export const hideSchemes: Writable<Set<string>> = writable(new Set());
+
+// The optional ID of a feature currently hovered from the sidebar.
+export const sidebarHover: Writable<number | null> = writable(null);
+
+export const mode: Writable<Mode> = writable({ mode: "list" });
+
+// All feature IDs must:
+//
+// - be unique
+// - be numeric; parts of maplibre can't handle string IDs
+//   (https://github.com/mapbox/mapbox-gl-js/issues/2716)
+// - not be 0; some libraries treat this as a missing ID
+//
+// Although this implementation may appear to ID features in order (1, 2, 3,
+// etc), this is NOT an invariant. Do not assume this; it will not be true as
+// soon as a user deletes or reorders an intervention.
+//
+// NOTE! If you call this twice in a row in a `gjScheme.update` transaction
+// without adding one of the new features, then this'll return the same ID
+// twice!
+export function newFeatureId(gj: SchemeCollection): number {
+  let ids = new Set();
+  for (let f of gj.features) {
+    ids.add(f.id);
+  }
+  // Always start with ID 1
+  let id = ids.size + 1;
+  while (ids.has(id)) {
+    id++;
+  }
+  return id;
+}
+
+export function deleteIntervention(id: number) {
+  console.log(`Deleting intervention ${id}`);
+  gjSchemeCollection.update((gj) => {
+    gj.features = gj.features.filter((f) => f.id != id);
+    return gj;
+  });
+  sidebarHover.set(null);
+  mode.set({ mode: "list" });
+}

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { gjSchemeCollection, routeTool } from "lib/draw/stores";
   import {
     FormElement,
     Radio,
@@ -7,7 +8,6 @@
     TextArea,
   } from "lib/govuk";
   import { prettyPrintMeters } from "lib/maplibre";
-  import { gjSchemeCollection, routeTool } from "stores";
   import type { InterventionProps } from "types";
 
   export let id: number;

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { gjSchemeCollection, routeTool } from "lib/draw/stores";
   import {
     Checkbox,
     FormElement,
@@ -8,7 +9,6 @@
     TextArea,
   } from "lib/govuk";
   import { prettyPrintMeters } from "lib/maplibre";
-  import { gjSchemeCollection, routeTool } from "stores";
   import type { InterventionProps } from "types";
   import PipelineType from "./PipelineType.svelte";
 

--- a/src/lib/sidebar/EditForm.svelte
+++ b/src/lib/sidebar/EditForm.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+  import {
+    deleteIntervention,
+    gjSchemeCollection,
+    mode,
+  } from "lib/draw/stores";
   import FormV1 from "lib/forms/FormV1.svelte";
   import PipelineForm from "lib/forms/PipelineForm.svelte";
   import {
@@ -9,13 +14,7 @@
     WarningButton,
   } from "lib/govuk";
   import type { MapMouseEvent } from "maplibre-gl";
-  import {
-    deleteIntervention,
-    gjSchemeCollection,
-    map,
-    mode,
-    schema,
-  } from "stores";
+  import { map, schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { FeatureUnion } from "types";
   import { interventionName, interventionWarning } from "./scheme_data";

--- a/src/lib/sidebar/FileManagement.svelte
+++ b/src/lib/sidebar/FileManagement.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import { CollapsibleCard, FileInput, Modal } from "lib/common";
   import {
+    gjSchemeCollection,
+    hideSchemes,
+    mode,
+    sidebarHover,
+  } from "lib/draw/stores";
+  import {
     ButtonGroup,
     ErrorMessage,
     SecondaryButton,
     WarningButton,
   } from "lib/govuk";
-  import {
-    gjSchemeCollection,
-    hideSchemes,
-    mode,
-    schema,
-    sidebarHover,
-  } from "stores";
+  import { schema } from "stores";
   import { onMount } from "svelte";
   import type { SchemeCollection } from "types";
   import deleteIcon from "../../../assets/delete.svg?url";

--- a/src/lib/sidebar/GenericSchemeForm.svelte
+++ b/src/lib/sidebar/GenericSchemeForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Modal } from "lib/common";
+  import { gjSchemeCollection } from "lib/draw/stores";
   import { DefaultButton, SecondaryButton, TextInput } from "lib/govuk";
-  import { gjSchemeCollection } from "stores";
 
   export let scheme_reference: string;
 

--- a/src/lib/sidebar/LeftSidebar.svelte
+++ b/src/lib/sidebar/LeftSidebar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { BaselayerSwitcher } from "lib/common";
+  import { mode, pointTool, polygonTool, routeTool } from "lib/draw/stores";
   import { DefaultButton } from "lib/govuk";
-  import { map, mode, pointTool, polygonTool, routeTool } from "stores";
+  import { map } from "stores";
   import { onDestroy } from "svelte";
   import EditGeometryMode from "../draw/EditGeometryMode.svelte";
   import ImageMode from "../draw/image/ImageMode.svelte";

--- a/src/lib/sidebar/ListMode.svelte
+++ b/src/lib/sidebar/ListMode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { FileInput } from "lib/common";
+  import { gjSchemeCollection } from "lib/draw/stores";
   import { ErrorMessage, SecondaryButton } from "lib/govuk";
-  import { gjSchemeCollection } from "stores";
   import PerSchemeControls from "./PerSchemeControls.svelte";
   import { addEmptyScheme, backfill } from "./scheme_data";
 

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { Modal, WarningIcon } from "lib/common";
   import {
+    gjSchemeCollection,
+    hideSchemes,
+    mode,
+    sidebarHover,
+  } from "lib/draw/stores";
+  import {
     ButtonGroup,
     Checkbox,
     ErrorMessage,
@@ -9,14 +15,7 @@
     WarningButton,
   } from "lib/govuk";
   import { bbox } from "lib/maplibre";
-  import {
-    gjSchemeCollection,
-    hideSchemes,
-    map,
-    mode,
-    schema,
-    sidebarHover,
-  } from "stores";
+  import { map, schema } from "stores";
   import { onDestroy } from "svelte";
   import deleteIcon from "../../../assets/delete.svg?url";
   import GenericSchemeForm from "./GenericSchemeForm.svelte";

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Modal } from "lib/common";
+  import { gjSchemeCollection } from "lib/draw/stores";
   import {
     Checkbox,
     CheckboxGroup,
@@ -11,7 +12,6 @@
     TextArea,
     TextInput,
   } from "lib/govuk";
-  import { gjSchemeCollection } from "stores";
   import type { FundingSources } from "types";
   import PipelineType from "../forms/PipelineType.svelte";
 

--- a/src/lib/sidebar/UnexpectedProperties.svelte
+++ b/src/lib/sidebar/UnexpectedProperties.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Modal } from "lib/common";
+  import { gjSchemeCollection } from "lib/draw/stores";
   import { ButtonGroup, SecondaryButton, WarningButton } from "lib/govuk";
-  import { gjSchemeCollection } from "stores";
   import { getUnexpectedProperties } from "./scheme_data";
 
   export let id: number;

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -17,13 +17,14 @@
   import PolygonToolLayer from "lib/draw/polygon/PolygonToolLayer.svelte";
   import RouteSnapperLayer from "lib/draw/route/RouteSnapperLayer.svelte";
   import SplitRouteMode from "lib/draw/route/SplitRouteMode.svelte";
+  import { mode } from "lib/draw/stores";
   import Toolbox from "lib/draw/Toolbox.svelte";
   import { ButtonGroup, SecondaryButton } from "lib/govuk";
   import About from "lib/sidebar/About.svelte";
   import FileManagement from "lib/sidebar/FileManagement.svelte";
   import Instructions from "lib/sidebar/Instructions.svelte";
   import LeftSidebar from "lib/sidebar/LeftSidebar.svelte";
-  import { mapStyle, mode, schema } from "stores";
+  import { mapStyle, schema } from "stores";
   import { onMount } from "svelte";
 
   let showAbout = false;

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,43 +1,18 @@
+// These stores are used in both the draw and browse pages.
+
 import type { Map } from "maplibre-gl";
 import { writable, type Writable } from "svelte/store";
-import { PointTool } from "./lib/draw/point/point_tool";
-import { PolygonTool } from "./lib/draw/polygon/polygon_tool";
-import { RouteTool } from "./lib/draw/route/route_tool";
-import { emptyCollection } from "./lib/sidebar/scheme_data";
-import {
-  isStreetViewImagery,
-  type Mode,
-  type Schema,
-  type SchemeCollection,
-  type UserSettings,
-} from "./types";
+import { isStreetViewImagery, type Schema, type UserSettings } from "./types";
+
+// Note this must be set before gjSchemeCollection in lib/draw/stores.ts
+export const schema: Writable<Schema> = writable(defaultSchema());
 
 // A global singleton, containing a loaded map
 // @ts-ignore TODO By construction, no components using the store should be
 // mounted before this is populated.
 export const map: Writable<Map> = writable(null);
 
-// Note this must be set before gjSchemeCollection
-export const schema: Writable<Schema> = writable(defaultSchema());
-
 export const mapStyle: Writable<string> = writable("dataviz");
-
-export const pointTool: Writable<PointTool | null> = writable(null);
-export const polygonTool: Writable<PolygonTool | null> = writable(null);
-// A global singleton, with the route tool loaded for the current map. It's
-// null before it's loaded.
-export const routeTool: Writable<RouteTool | null> = writable(null);
-
-// TODO Should we instead store a map from ID to feature?
-export const gjSchemeCollection: Writable<SchemeCollection> = writable(
-  emptyCollection()
-);
-
-// scheme_references to hide
-export const hideSchemes: Writable<Set<string>> = writable(new Set());
-
-// The optional ID of a feature currently hovered from the sidebar.
-export const sidebarHover: Writable<number | null> = writable(null);
 
 export const userSettings: Writable<UserSettings> = writable(
   loadUserSettings()
@@ -45,45 +20,6 @@ export const userSettings: Writable<UserSettings> = writable(
 userSettings.subscribe((value) =>
   window.localStorage.setItem("userSettings", JSON.stringify(value))
 );
-
-export const mode: Writable<Mode> = writable({ mode: "list" });
-
-// All feature IDs must:
-//
-// - be unique
-// - be numeric; parts of maplibre can't handle string IDs
-//   (https://github.com/mapbox/mapbox-gl-js/issues/2716)
-// - not be 0; some libraries treat this as a missing ID
-//
-// Although this implementation may appear to ID features in order (1, 2, 3,
-// etc), this is NOT an invariant. Do not assume this; it will not be true as
-// soon as a user deletes or reorders an intervention.
-//
-// NOTE! If you call this twice in a row in a `gjScheme.update` transaction
-// without adding one of the new features, then this'll return the same ID
-// twice!
-export function newFeatureId(gj: SchemeCollection): number {
-  let ids = new Set();
-  for (let f of gj.features) {
-    ids.add(f.id);
-  }
-  // Always start with ID 1
-  let id = ids.size + 1;
-  while (ids.has(id)) {
-    id++;
-  }
-  return id;
-}
-
-export function deleteIntervention(id: number) {
-  console.log(`Deleting intervention ${id}`);
-  gjSchemeCollection.update((gj) => {
-    gj.features = gj.features.filter((f) => f.id != id);
-    return gj;
-  });
-  sidebarHover.set(null);
-  mode.set({ mode: "list" });
-}
 
 function loadUserSettings(): UserSettings {
   let settings = {


### PR DESCRIPTION
The browse and draw pages (and some of the other smaller pages like critical entry) do different things, sharing some code but not all. The directory structure is already reasonably clear, but we today mostly have one shared `stores.ts`. This splits out stores specific to the drawing page, to make things a little more clear.

Diffbased on #425, review that first please