### PR TITLE
Add a border to browse popups

### DIFF
--- a/src/lib/browse/InterventionLayer.svelte
+++ b/src/lib/browse/InterventionLayer.svelte
@@ -55,8 +55,8 @@
     }}
     hoverCursor="pointer"
   >
-    <Popup let:props><p>{props.name}</p></Popup>
-    <Popup let:props openOn="click">
+    <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
+    <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup {props} />
     </Popup>
   </CircleLayer>
@@ -76,8 +76,8 @@
     }}
     hoverCursor="pointer"
   >
-    <Popup let:props><p>{props.name}</p></Popup>
-    <Popup let:props openOn="click">
+    <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
+    <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup {props} />
     </Popup>
   </LineLayer>
@@ -109,8 +109,8 @@
     }}
     hoverCursor="pointer"
   >
-    <Popup let:props><p>{props.name}</p></Popup>
-    <Popup let:props openOn="click">
+    <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
+    <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup {props} />
     </Popup>
   </FillLayer>
@@ -127,3 +127,9 @@
     }}
   />
 </GeoJSON>
+
+<style>
+  :global(.border-popup .maplibregl-popup-content) {
+    border: 1px solid black;
+  }
+</style>

--- a/src/lib/common/Popup.svelte
+++ b/src/lib/common/Popup.svelte
@@ -6,6 +6,7 @@
   import { Popup } from "svelte-maplibre";
 
   export let openOn: "hover" | "click" = "hover";
+  export let popupClass: string | undefined = undefined;
 
   function getProperties(features: Feature[] | null): { [name: string]: any } {
     if (!features) {
@@ -15,7 +16,7 @@
   }
 </script>
 
-<Popup {openOn} openIfTopMost let:features>
+<Popup {openOn} {popupClass} openIfTopMost let:features>
   <div class="govuk-prose">
     <slot props={getProperties(features)} />
   </div>


### PR DESCRIPTION
Before, overlapping popups with the hover-vs-click variations gets hard to read:

https://github.com/acteng/atip/assets/1664407/52ba01bd-4078-4bf2-a888-655112f4c329

Borders help:

https://github.com/acteng/atip/assets/1664407/3fb078d0-4f08-4724-822c-f2449db15a8e

