### PR TITLE
Toggle cycle layers individually

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -65,17 +65,21 @@
     </CheckboxGroup>
   </CollapsibleCard>
   <CollapsibleCard label="Census">
-    <CensusOutputAreaLayerControl />
-    <ImdLayerControl />
+    <CheckboxGroup small>
+      <CensusOutputAreaLayerControl />
+      <ImdLayerControl />
+    </CheckboxGroup>
   </CollapsibleCard>
   <CollapsibleCard label="Other">
-    <VehicleCountsLayerControl />
-    <PctLayerControl />
-    {#if appVersion() == "Private (development)"}
-      <RoadWidthsLayerControl />
-      <RoadSpeedsLayerControl />
-    {/if}
-    <PollutionLayerControl />
+    <CheckboxGroup small>
+      <VehicleCountsLayerControl />
+      <PctLayerControl />
+      {#if appVersion() == "Private (development)"}
+        <RoadWidthsLayerControl />
+        <RoadSpeedsLayerControl />
+      {/if}
+      <PollutionLayerControl />
+    </CheckboxGroup>
   </CollapsibleCard>
   <CollapsibleCard label="Tools">
     <StreetViewTool bind:enabled={streetviewEnabled} />


### PR DESCRIPTION
As requested in the demo last week:

https://github.com/acteng/atip/assets/1664407/76f8d7db-0553-478b-a4e3-0a6fcb5736f8

Also fixed the checkbox size for the last two groups, because it was inconsistent:
![Screenshot from 2024-01-15 11-42-06](https://github.com/acteng/atip/assets/1664407/e23c4d98-d3ce-403b-9ae7-4018515ca7bd)
