### PR TITLE
Fix bug detecting schema

### DIFF
--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -100,7 +100,10 @@
         }
       }
     }
-    return "v1";
+
+    // The file itself doesn't have any data saying what schema it belongs to.
+    // Trust the URL instead.
+    return $schemaStore;
   }
 
   function onClick(e: CustomEvent<LayerClickInfo>) {

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -32,3 +32,15 @@ test("schema is plumbed along to the sketch page", async ({ page }) => {
     /.*scheme.html\?authority=LAD_Adur&schema=pipeline/
   );
 });
+
+test("a v1 file with a pipeline hint redirects to pipeline mode", async ({
+  page,
+}) => {
+  await page.goto("/index.html?schema=pipeline");
+  await page
+    .getByLabel("Or upload an ATIP GeoJSON file")
+    .setInputFiles("tests/data/LAD_Adur.geojson");
+  await expect(page).toHaveURL(
+    /.*scheme.html\?authority=LAD_Adur&schema=pipeline/
+  );
+});

--- a/tests/pipeline.spec.ts
+++ b/tests/pipeline.spec.ts
@@ -86,8 +86,6 @@ test("file started with v1 can be edited by adding", async () => {
     .getByRole("group", { name: "Scheme type" })
     .getByText("Shared-use route")
     .click();
-  //await page.getByRole('group', { name: 'Scheme type' }).locator('[id="scheme-typeshared-use\\ route"]').check();
-  //await page.getByLabel("In development").click();
 });
 
 test("file started with v1 can be edited by loading", async () => {

--- a/tests/pipeline.spec.ts
+++ b/tests/pipeline.spec.ts
@@ -73,3 +73,28 @@ test("scheme validations are updated", async () => {
   await checkPageLoaded(page);
   await expect(page.getByText("Missing some required data")).not.toBeVisible();
 });
+
+test("file started with v1 can be edited by adding", async () => {
+  // Load a file with no pipeline data, using the v1 schema
+  await page
+    .getByLabel("Add scheme from file")
+    .setInputFiles("tests/data/LAD_Adur.geojson");
+  // The first is for the blank default scheme; the second is the file we just loaded
+  await page.getByRole("button", { name: "Scheme details" }).nth(1).click();
+  // Make sure a pipeline-specific form shows up
+  await page
+    .getByRole("group", { name: "Scheme type" })
+    .getByText("Shared-use route")
+    .click();
+  //await page.getByRole('group', { name: 'Scheme type' }).locator('[id="scheme-typeshared-use\\ route"]').check();
+  //await page.getByLabel("In development").click();
+});
+
+test("file started with v1 can be edited by loading", async () => {
+  await page.getByText("Manage files").click();
+  await page
+    .getByLabel("Load GeoJSON file")
+    .setInputFiles("tests/data/LAD_Adur.geojson");
+  await page.getByRole("button", { name: "Scheme details" }).click();
+  await page.getByText("Shared-use route").click();
+});


### PR DESCRIPTION
The problem our user hit:

1) They sketched geometry using the v1 tool, somehow messing up the URL to not be in pipeline mode
2) They loaded the file with the correct pipeline mode URL, but then the pipeline forms didn't show up