### PR TITLE
Hide linestring endpoints when a scheme is hidden in sketch

### DIFF
--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -44,7 +44,6 @@
 
   $: clickable = $mode.mode == "list";
 
-  // TODO Can't use this for the interventions-lines-endpoints layer, for unknown reasons
   $: showSchemes = getShowSchemes($hideSchemes);
   function getShowSchemes(schemesToHide: Set<string>): ExpressionSpecification {
     // TODO Can't get https://maplibre.org/maplibre-style-spec/expressions/#in to work
@@ -159,7 +158,7 @@
   </LineLayer>
   <CircleLayer
     {...layerId("interventions-lines-endpoints")}
-    filter={["==", ["get", "endpoint"], true]}
+    filter={["all", ["==", ["get", "endpoint"], true], showSchemes]}
     paint={{
       "circle-radius": 0.5 * lineWidth,
       "circle-opacity": 0,

--- a/src/lib/maplibre/utils.ts
+++ b/src/lib/maplibre/utils.ts
@@ -197,6 +197,7 @@ export function addLineStringEndpoints(
           type: "Feature",
           properties: {
             endpoint: true,
+            scheme_reference: f.properties.scheme_reference,
           },
           geometry: {
             type: "Point",


### PR DESCRIPTION
It was previously quite weird to hide a scheme, but still see all the endpoint outlines:
![Screenshot from 2024-01-17 13-11-43](https://github.com/acteng/atip/assets/1664407/601608a8-8454-4c93-834d-bd06ccf9ef60)
![Screenshot from 2024-01-17 13-11-39](https://github.com/acteng/atip/assets/1664407/662b9917-4014-4766-a397-4edaccb7c7cd)
The fix was simple; when I tried to do this the first time, I somehow forgot that we're not copying over the `scheme_reference`