### PR TITLE
Disable other layers when streetview is enabled. #359

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -7,6 +7,8 @@
     StreetViewTool,
   } from "lib/common";
   import { CheckboxGroup } from "lib/govuk";
+  import { layerId } from "lib/maplibre";
+  import { FillLayer, GeoJSON } from "svelte-maplibre";
   import CensusOutputAreaLayerControl from "./layers/areas/CensusOutputAreas.svelte";
   import CombinedAuthoritiesLayerControl from "./layers/areas/CombinedAuthorities.svelte";
   import ImdLayerControl from "./layers/areas/IMD.svelte";
@@ -35,6 +37,26 @@
   // Workaround for https://github.com/sveltejs/svelte/issues/7630
   $: streetviewEnabled = !$interactiveMapLayersEnabled;
   $: interactiveMapLayersEnabled.set(!streetviewEnabled);
+
+  // When StreetView is on, disable interactive layers -- no hovering or
+  // clicking behavior. Achieve this by enabling an invisible layer on top of
+  // everything.
+  let coverEverything = {
+    type: "Feature" as const,
+    properties: {},
+    geometry: {
+      type: "Polygon" as const,
+      coordinates: [
+        [
+          [180.0, 90.0],
+          [-180.0, 90.0],
+          [-180.0, -90.0],
+          [180.0, -90.0],
+          [180.0, 90.0],
+        ],
+      ],
+    },
+  };
 </script>
 
 <CollapsibleCard label="Layers" open>
@@ -89,3 +111,16 @@
   </CollapsibleCard>
   <BaselayerSwitcher disabled={!$interactiveMapLayersEnabled} />
 </CollapsibleCard>
+
+<GeoJSON data={coverEverything}>
+  <FillLayer
+    {...layerId("cover-interactive-layers")}
+    paint={{
+      "fill-color": "black",
+      "fill-opacity": 0.0,
+    }}
+    layout={{
+      visibility: $interactiveMapLayersEnabled ? "none" : "visible",
+    }}
+  />
+</GeoJSON>

--- a/src/lib/maplibre/zorder.ts
+++ b/src/lib/maplibre/zorder.ts
@@ -137,4 +137,6 @@ const layerZorder = [
 
   // TODO This might look nicer lower
   "georeferenced-image",
+
+  "cover-interactive-layers",
 ];


### PR DESCRIPTION
My connection is too sad to upload the demo video, so -- enable some layers with tooltips/clicking/etc. Then enable street view and verify that the other layers now aren't interactive. Disable stview, and they're interactive again.

This was a regression when we switched to svelte-maplibre, finally fixing it