### PR TITLE
Add a maptiler basemap with more labels

### DIFF
--- a/src/lib/maplibre/layer_helper_utils.ts
+++ b/src/lib/maplibre/layer_helper_utils.ts
@@ -42,7 +42,11 @@ export function getRoadLayerHelpers(): LayerHelper[] {
   return get(mapStore)
     .getStyle()
     .layers.filter((layer) => {
-      return roadLayerIds.includes(layer.id);
+      // uk-openzoomstack-light has many relevant layers, best identified by source-layer
+      return (
+        // @ts-ignore source-layer sometimes exists
+        roadLayerIds.includes(layer.id) || layer["source-layer"] == "roads"
+      );
     })
     .map((layer) => {
       return new LayerHelper(layer);

--- a/src/lib/maplibre/utils.ts
+++ b/src/lib/maplibre/utils.ts
@@ -127,6 +127,7 @@ export function getStyleChoices(): [string, string][] {
     ["streets", "MapTiler Streets"],
     ["hybrid", "MapTiler Satellite"],
     ["dataviz", "MapTiler Dataviz"],
+    ["uk-openzoomstack-light", "OS Open Zoomstack"],
   ]);
 }
 
@@ -134,7 +135,12 @@ export async function getStyleSpecification(
   style: string
 ): Promise<string | StyleSpecification> {
   // MapTiler vector styles
-  if (style == "streets" || style == "hybrid" || style == "dataviz") {
+  if (
+    style == "streets" ||
+    style == "hybrid" ||
+    style == "dataviz" ||
+    style == "uk-openzoomstack-light"
+  ) {
     return `https://api.maptiler.com/maps/${style}/style.json?key=${
       import.meta.env.VITE_MAPTILER_API_KEY
     }`;


### PR DESCRIPTION
On the browse page especially, we've had many times during demos where people have trouble just orienting on the map. I think part of the problem is too few POI / place labels, and rail stations not popping out. Inspired by https://urban-analytics-technology-platform.github.io/demoland-web/tyne_and_wear/, here's another basemap option that's still unintrusive for displaying lots of data on top, but has more context.

We can ask different users if this should be the new default for sketch and browse.

Examples before with dataviz -- where are we?
![Screenshot from 2024-01-19 10-45-07](https://github.com/acteng/atip/assets/1664407/e9dfdb91-0afe-40e7-bcb5-4d8fdd7fa9c1)
![Screenshot from 2024-01-19 10-43-57](https://github.com/acteng/atip/assets/1664407/562464f2-9f10-4d59-83eb-a590a849a108)
After with zoomstack:
![Screenshot from 2024-01-19 10-45-15](https://github.com/acteng/atip/assets/1664407/2dd18371-eb16-4d2a-92f9-8521a3fce2df)
![Screenshot from 2024-01-19 10-44-11](https://github.com/acteng/atip/assets/1664407/9b9a2824-d984-42b0-a3c0-c7abc80cb0d5)
