### PR TITLE
Don't forget about scheme name

### DIFF
--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -10,7 +10,12 @@
   import { onMount } from "svelte";
   import type { FeatureUnion } from "types";
   import InterventionColorSelector from "./InterventionColorSelector.svelte";
-  import { filterText, schemes, schemesGj } from "./stores";
+  import {
+    filterInterventionText,
+    filterSchemeText,
+    schemes,
+    schemesGj,
+  } from "./stores";
 
   // NOTE: If schemesGj changes, re-create this component
 
@@ -55,24 +60,33 @@
 
   // When any filters change, update schemesToBeShown
   function filtersUpdated(
-    filterTextCopy: string,
+    filterInterventionTextCopy: string,
+    filterSchemeTextCopy: string,
     filterAuthority: string,
     filterFundingProgramme: string,
-    filterCurrentMilestone: string,
+    filterCurrentMilestone: string
   ) {
-    let filterNormalized = filterTextCopy.toLowerCase();
+    let filterInterventionNormalized = filterInterventionTextCopy.toLowerCase();
+    let filterSchemeNormalized = filterSchemeTextCopy.toLowerCase();
     let filterFeatures = (feature: FeatureUnion) => {
       // Only the name and description fields have anything worth filtering
       if (
-        filterNormalized &&
-        !feature.properties.name?.toLowerCase().includes(filterNormalized) &&
+        filterInterventionNormalized &&
+        !feature.properties.name
+          ?.toLowerCase()
+          .includes(filterInterventionNormalized) &&
         !feature.properties.description
           ?.toLowerCase()
-          .includes(filterNormalized)
+          .includes(filterInterventionNormalized)
       ) {
         return false;
       }
-      if (filterAuthority || filterFundingProgramme || filterCurrentMilestone) {
+      if (
+        filterSchemeNormalized ||
+        filterAuthority ||
+        filterFundingProgramme ||
+        filterCurrentMilestone
+      ) {
         let scheme = $schemes.get(feature.properties.scheme_reference!)!;
         if (
           filterAuthority &&
@@ -89,6 +103,17 @@
         if (
           filterCurrentMilestone &&
           scheme.browse?.current_milestone != filterCurrentMilestone
+        ) {
+          return false;
+        }
+        if (
+          filterSchemeNormalized &&
+          !scheme.scheme_reference
+            .toLowerCase()
+            .includes(filterSchemeNormalized) &&
+          !(scheme.scheme_name ?? "")
+            .toLowerCase()
+            .includes(filterSchemeNormalized)
         ) {
           return false;
         }
@@ -109,11 +134,13 @@
       }
       // If there's free-text, only show interventions matching it within a scheme
       if (
-        filterNormalized &&
-        !feature.properties.name?.toLowerCase().includes(filterNormalized) &&
+        filterInterventionNormalized &&
+        !feature.properties.name
+          ?.toLowerCase()
+          .includes(filterInterventionNormalized) &&
         !feature.properties.description
           ?.toLowerCase()
-          .includes(filterNormalized)
+          .includes(filterInterventionNormalized)
       ) {
         return false;
       }
@@ -136,7 +163,13 @@
     $schemesGj = $schemesGj;
     counts = counts;
   }
-  $: filtersUpdated($filterText, filterAuthority, filterFundingProgramme, filterCurrentMilestone);
+  $: filtersUpdated(
+    $filterInterventionText,
+    $filterSchemeText,
+    filterAuthority,
+    filterFundingProgramme,
+    filterCurrentMilestone
+  );
 
   function metersToMiles(x: number): number {
     return x * 0.000621371;
@@ -165,14 +198,30 @@
     emptyOption
     bind:value={filterCurrentMilestone}
   />
-  <FormElement label="Intervention name or description" id="filterText">
+  <FormElement
+    label="Intervention name or description"
+    id="filterInterventionText"
+  >
     <input
       type="text"
       class="govuk-input govuk-input--width-10"
-      id="filterText"
-      bind:value={$filterText}
+      id="filterInterventionText"
+      bind:value={$filterInterventionText}
     />
-    <SecondaryButton on:click={() => ($filterText = "")}>Clear</SecondaryButton>
+    <SecondaryButton on:click={() => ($filterInterventionText = "")}>
+      Clear
+    </SecondaryButton>
+  </FormElement>
+  <FormElement label="Scheme name or reference" id="filterSchemeText">
+    <input
+      type="text"
+      class="govuk-input govuk-input--width-10"
+      id="filterSchemeText"
+      bind:value={$filterSchemeText}
+    />
+    <SecondaryButton on:click={() => ($filterSchemeText = "")}>
+      Clear
+    </SecondaryButton>
   </FormElement>
   <InterventionColorSelector />
 </CollapsibleCard>

--- a/src/lib/browse/InterventionPopup.svelte
+++ b/src/lib/browse/InterventionPopup.svelte
@@ -27,7 +27,7 @@
     <p>{@html highlightFilter(props.description)}</p>
   {/if}
   <hr />
-  <p>Part of scheme: {props.scheme_reference}</p>
+  <p>Part of scheme: {scheme.scheme_name} ({props.scheme_reference})</p>
   <p>Authority or region: {scheme.browse?.authority_or_region}</p>
   <p>Capital scheme ID: {scheme.browse?.capital_scheme_id}</p>
   <p>Funding programme: {scheme.browse?.funding_programme}</p>

--- a/src/lib/browse/InterventionPopup.svelte
+++ b/src/lib/browse/InterventionPopup.svelte
@@ -1,33 +1,40 @@
 <script lang="ts">
   import { prettyPrintMeters } from "lib/maplibre";
-  import { filterText, schemes } from "./stores";
+  import { filterInterventionText, filterSchemeText, schemes } from "./stores";
 
   export let props: { [name: string]: any };
 
   $: scheme = $schemes.get(props.scheme_reference)!;
 
   // When the user is filtering name/description by freeform text, highlight the matching pieces.
-  function highlightFilter(input: string): string {
-    if (!$filterText) {
+  function highlightFilter(input: string, filter: string): string {
+    if (!filter) {
       return input;
     }
     return input.replace(
-      new RegExp($filterText, "gi"),
+      new RegExp(filter, "gi"),
       (match) => `<mark>${match}</mark>`
     );
   }
 </script>
 
 <div style="max-width: 30vw;">
-  <h2>{@html highlightFilter(props.name)} ({props.intervention_type})</h2>
+  <h2>
+    {@html highlightFilter(props.name, $filterInterventionText)} ({props.intervention_type})
+  </h2>
   {#if props.length_meters}
     <p>Length: {prettyPrintMeters(props.length_meters)}</p>
   {/if}
   {#if props.description}
-    <p>{@html highlightFilter(props.description)}</p>
+    <p>{@html highlightFilter(props.description, $filterInterventionText)}</p>
   {/if}
   <hr />
-  <p>Part of scheme: {scheme.scheme_name} ({props.scheme_reference})</p>
+  <p>
+    Part of scheme: {@html highlightFilter(
+      scheme.scheme_name ?? "",
+      $filterSchemeText
+    )} ({@html highlightFilter(props.scheme_reference, $filterSchemeText)})
+  </p>
   <p>Authority or region: {scheme.browse?.authority_or_region}</p>
   <p>Capital scheme ID: {scheme.browse?.capital_scheme_id}</p>
   <p>Funding programme: {scheme.browse?.funding_programme}</p>

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -40,8 +40,9 @@
 </script>
 
 <CollapsibleCard
-  label={`${scheme.scheme_reference}: ${scheme.browse?.num_features} features`}
+  label={`${scheme.scheme_name}`}
 >
+  <p>Scheme reference: {scheme.scheme_reference}</p>
   <p>Authority or region: {scheme.browse?.authority_or_region}</p>
   <p>Capital scheme ID: {scheme.browse?.capital_scheme_id}</p>
   <p>Funding programme: {scheme.browse?.funding_programme}</p>

--- a/src/lib/browse/SchemeCard.svelte
+++ b/src/lib/browse/SchemeCard.svelte
@@ -39,9 +39,7 @@
   }
 </script>
 
-<CollapsibleCard
-  label={`${scheme.scheme_name}`}
->
+<CollapsibleCard label={`${scheme.scheme_name}`}>
   <p>Scheme reference: {scheme.scheme_reference}</p>
   <p>Authority or region: {scheme.browse?.authority_or_region}</p>
   <p>Capital scheme ID: {scheme.browse?.capital_scheme_id}</p>

--- a/src/lib/browse/data.ts
+++ b/src/lib/browse/data.ts
@@ -21,11 +21,6 @@ export function processInput(gj: SchemeCollection): Map<string, SchemeData> {
   for (let feature of gj.features) {
     let scheme: SchemeData = schemes.get(feature.properties!.scheme_reference);
     if (scheme.browse) {
-      scheme.browse.num_features =
-        scheme.browse.num_features !== undefined
-          ? scheme.browse.num_features + 1
-          : 1;
-
       // TODO For easy styling, copy one field from scheme to all its features.
       // As we have more cases like this, revisit what's most performant.
       // @ts-ignore Extend InterventionProps with scheme_reference, current_milestone, and this

--- a/src/lib/browse/stores.ts
+++ b/src/lib/browse/stores.ts
@@ -9,4 +9,5 @@ export const schemesGj: Writable<SchemeCollection> = writable({
 export const schemes: Writable<Map<string, SchemeData>> = writable(new Map());
 
 export const interactiveMapLayersEnabled: Writable<boolean> = writable(true);
-export const filterText: Writable<string> = writable("");
+export const filterInterventionText: Writable<string> = writable("");
+export const filterSchemeText: Writable<string> = writable("");

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,6 @@ export interface FundingSources {
 }
 
 export interface BrowseSchemeData {
-  num_features: number;
   authority_or_region: string;
   capital_scheme_id: string;
   funding_programme: string;


### PR DESCRIPTION
A few requested changes:

- Emphasize scheme name, not the reference, in the sidebar. Most people don't know the reference offhand.
- Stop showing "scheme X has 4 features." That's not useful to anyone.
- Add a free-text filter for scheme name or reference

**Before merging**, I want to see if scheme name is ever blank, because then the SchemeCard title will be hard to click. We could fallback to the reference? Or maybe this never happens; we can assert in aatip-scheme-data and update the TS if so.

Demo: https://acteng.github.io/atip/browse_show_diff_stuff/browse.html