### PR TITLE
A few more upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "maplibre-gl": "^3.5.1",
         "read-excel-file": "^5.7.1",
         "route-snapper": "^0.3.0",
-        "svelte": "^4.0.0",
+        "svelte": "^4.2.10",
         "svelte-maplibre": "^0.7.7",
         "uuid": "^9.0.1"
       },
@@ -43,7 +43,7 @@
         "prettier": "^3.2.5",
         "prettier-plugin-svelte": "^3.1.2",
         "sass": "^1.70.0",
-        "svelte-check": "^3.4.4",
+        "svelte-check": "^3.6.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "vite": "^4.1.1",
@@ -1407,9 +1407,9 @@
       "integrity": "sha512-SOFlLGZkLbEXJRwcWCqeP/Koyaf/uAqLXHUsdo/nMfjLsNd8kqauwHe9GBOljSmpcHp/LC6kOjo3SidGjNirVA=="
     },
     "node_modules/@types/pug": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
-      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
+      "integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
       "dev": true
     },
     "node_modules/@types/supercluster": {
@@ -1513,9 +1513,9 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
+      "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2503,15 +2503,20 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/magic-string/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -3259,22 +3264,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.1.tgz",
-      "integrity": "sha512-LpLqY2Jr7cRxkrTc796/AaaoMLF/1ax7cto8Ot76wrvKQhrPmZ0JgajiWPmg9mTSDqO16SSLiD17r9MsvAPTmw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.10.tgz",
+      "integrity": "sha512-Ep06yCaCdgG1Mafb/Rx8sJ1QS3RW2I2BxGp2Ui9LBHSZ2/tO/aGLc5WqPjgiAP6KAnLJGaIr/zzwQlOo1b8MxA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
         "acorn": "^8.9.0",
         "aria-query": "^5.3.0",
-        "axobject-query": "^3.2.1",
+        "axobject-query": "^4.0.0",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
         "estree-walker": "^3.0.3",
         "is-reference": "^3.0.1",
         "locate-character": "^3.0.0",
-        "magic-string": "^0.30.0",
+        "magic-string": "^0.30.4",
         "periscopic": "^3.1.0"
       },
       "engines": {
@@ -3282,9 +3288,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.4.4.tgz",
-      "integrity": "sha512-Uys9+R65cj8TmP8f5UpS7B2xKpNLYNxEWJsA5ZoKcWq/uwvABFF7xS6iPQGLoa7hxz0DS6xU60YFpmq06E4JxA==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.4.tgz",
+      "integrity": "sha512-mY/dqucqm46p72M8yZmn81WPZx9mN6uuw8UVfR3ZKQeLxQg5HDGO3HHm5AZuWZPYNMLJ+TRMn+TeN53HfQ/vsw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -3293,14 +3299,14 @@
         "import-fresh": "^3.2.1",
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
-        "svelte-preprocess": "^5.0.3",
+        "svelte-preprocess": "^5.1.0",
         "typescript": "^5.0.3"
       },
       "bin": {
         "svelte-check": "bin/svelte-check"
       },
       "peerDependencies": {
-        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
+        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/svelte-hmr": {
@@ -3345,32 +3351,33 @@
       }
     },
     "node_modules/svelte-preprocess": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.4.tgz",
-      "integrity": "sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.3.tgz",
+      "integrity": "sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@types/pug": "^2.0.6",
         "detect-indent": "^6.1.0",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.30.5",
         "sorcery": "^0.11.0",
         "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">= 14.10.0"
+        "node": ">= 16.0.0",
+        "pnpm": "^8.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.10.2",
         "coffeescript": "^2.5.1",
         "less": "^3.11.3 || ^4.0.0",
         "postcss": "^7 || ^8",
-        "postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
+        "postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
         "pug": "^3.0.0",
         "sass": "^1.26.8",
         "stylus": "^0.55.0",
         "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0",
+        "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -3404,18 +3411,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-preprocess/node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/svelte/node_modules/@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-svelte": "^3.1.2",
     "sass": "^1.70.0",
-    "svelte-check": "^3.4.4",
+    "svelte-check": "^3.6.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "vite": "^4.1.1",
@@ -52,7 +52,7 @@
     "maplibre-gl": "^3.5.1",
     "read-excel-file": "^5.7.1",
     "route-snapper": "^0.3.0",
-    "svelte": "^4.0.0",
+    "svelte": "^4.2.10",
     "svelte-maplibre": "^0.7.7",
     "uuid": "^9.0.1"
   }


### PR DESCRIPTION
Again no noticeable changes.

I'll stop for now, because blocked or stuck on the last ones.

- Things related to vite break when I upgrade, because `vite-plugin-wasm-pack` (needed for the route snapper) isn't compatible with the new vite. That plugin is pretty unmaintained and causing me headaches in other projects, so eventually I'll try to just fix it upstream, but not now
- `@tsconfig/svelte` stops seeing the TS definitions for all the turf dependencies, and I don't want to struggle through tsconfig right now to figure it out
- maplibre 4 is out, and there's a PR for support in svelte-maplibre. We can wait a few days and then try it out.