### PR TITLE
Make it easier to enter GBP in large units

### DIFF
--- a/src/lib/govuk/MoneyInput.svelte
+++ b/src/lib/govuk/MoneyInput.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { ErrorMessage, FormElement, SecondaryButton } from "./";
+
+  export let label: string;
+  export let value: number | undefined;
+
+  let stringValue: string = value == undefined ? "" : prettyprint(value);
+  function update(x: string) {
+    value = parse(x);
+  }
+  $: update(stringValue);
+
+  function parse(x: string): number | undefined {
+    if (x == "") {
+      return undefined;
+    }
+    return parseFloat(x.replaceAll(",", ""));
+  }
+
+  function validate(stringValue: string): string {
+    let n = parse(stringValue);
+    if (n == undefined) {
+      return "";
+    }
+    if (isNaN(n)) {
+      return "Please enter a valid number";
+    }
+    if (n < 0) {
+      return `Please enter a positive number`;
+    }
+    return "";
+  }
+
+  function prettyprint(x: number): string {
+    return x.toLocaleString();
+  }
+
+  function multiply() {
+    stringValue = prettyprint(value! * 1_000_000);
+  }
+
+  // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
+</script>
+
+<FormElement {label} id={label}>
+  <ErrorMessage errorMessage={validate(stringValue)} />
+  {#if value != undefined}
+    <div class="govuk-hint">&#163;{prettyprint(value)}</div>
+  {/if}
+  <input
+    type="text"
+    inputmode="numeric"
+    class={`govuk-input govuk-input--width-10`}
+    id={label}
+    bind:value={stringValue}
+  />
+  <SecondaryButton
+    on:click={multiply}
+    disabled={value == undefined || value > 1000}
+  >
+    multiply by 1 million
+  </SecondaryButton>
+</FormElement>

--- a/src/lib/govuk/index.ts
+++ b/src/lib/govuk/index.ts
@@ -4,6 +4,7 @@ export { default as Checkbox } from "./Checkbox.svelte";
 export { default as DefaultButton } from "./DefaultButton.svelte";
 export { default as ErrorMessage } from "./ErrorMessage.svelte";
 export { default as FormElement } from "./FormElement.svelte";
+export { default as MoneyInput } from "./MoneyInput.svelte";
 export { default as NumberInput } from "./NumberInput.svelte";
 export { default as Radio } from "./Radio.svelte";
 export { default as SecondaryButton } from "./SecondaryButton.svelte";

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -7,6 +7,7 @@
     DefaultButton,
     ErrorMessage,
     NumberInput,
+    MoneyInput,
     Radio,
     SecondaryButton,
     TextArea,
@@ -164,12 +165,7 @@
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend">Budget</legend>
 
-    <NumberInput
-      label="Cost (GBP)"
-      width={10}
-      min={0}
-      bind:value={pipeline.budget}
-    />
+    <MoneyInput label="Cost (GBP)" bind:value={pipeline.budget} />
 
     <Checkbox
       id="development_funded"


### PR DESCRIPTION
Screencasting bit broken right now, but demo at https://acteng.github.io/atip/money_input/scheme.html?schema=pipeline&authority=LAD_Adur
![image](https://github.com/acteng/atip/assets/1664407/b1559db0-5ae5-469f-9243-961d377bef4a)
I would really prefer to not figure out the good UI way of solving this, but https://design-system.service.gov.uk/components/text-input/ is not helpful about large numeric input, so just trying a few ideas to help the problems reported