### PR TITLE
Include optional budget and timing forms for each intervention

### DIFF
--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { emptyFundingSources } from "lib/sidebar/scheme_data";
   import { gjSchemeCollection, routeTool } from "lib/draw/stores";
   import {
     Checkbox,
@@ -11,6 +12,8 @@
   import { prettyPrintMeters } from "lib/maplibre";
   import type { InterventionProps } from "types";
   import PipelineType from "./PipelineType.svelte";
+  import TimingForm from "lib/sidebar/pipeline/TimingForm.svelte";
+  import BudgetForm from "lib/sidebar/pipeline/BudgetForm.svelte";
 
   export let id: number;
   export let props: InterventionProps;
@@ -20,6 +23,13 @@
     atf4_type: "",
     accuracy: "",
     is_alternative: false,
+
+    development_funded: false,
+    construction_funded: false,
+    funding_sources: emptyFundingSources(),
+
+    status: "",
+    timescale: "",
   };
 
   props.is_coverage_polygon ||= false;
@@ -104,4 +114,8 @@
       while making the scheme)
     </Checkbox>
   {/if}
+
+  <TimingForm data={props.pipeline} required={false} />
+
+  <BudgetForm data={props.pipeline} />
 {/if}

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -115,7 +115,7 @@
     </Checkbox>
   {/if}
 
-  <TimingForm data={props.pipeline} required={false} />
+  <TimingForm data={props.pipeline} required={false} onUpdate={() => {}} />
 
-  <BudgetForm data={props.pipeline} />
+  <BudgetForm data={props.pipeline} onUpdate={() => {}} />
 {/if}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -20,11 +20,16 @@
   // synced to $gjSchemeCollection until finish() is called
   let pipeline = $gjSchemeCollection.schemes[scheme_reference].pipeline!;
 
-  // Check for all required values
-  $: errorMessage =
-    pipeline.scheme_type && pipeline.status && pipeline.timescale
+  // Svelte doesn't see nested updates in BudgetForm and TimingForm, so use a
+  // counter and manual callback to recalculate errorMessage
+  let updateError = 0;
+  $: errorMessage = checkRequiredValues(pipeline, updateError);
+
+  function checkRequiredValues(_: any, updateError: number): string {
+    return pipeline.scheme_type && pipeline.status && pipeline.timescale
       ? ""
       : "Missing some required data";
+  }
 
   function onKeyDown(e: KeyboardEvent) {
     if (showModal && e.key == "Escape") {
@@ -94,9 +99,9 @@
     />
   </fieldset>
 
-  <TimingForm data={pipeline} required />
+  <TimingForm data={pipeline} required onUpdate={() => updateError++} />
 
-  <BudgetForm data={pipeline} />
+  <BudgetForm data={pipeline} onUpdate={() => updateError++} />
 
   <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
 </Modal>

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
+  import TimingForm from "./pipeline/TimingForm.svelte";
+  import BudgetForm from "./pipeline/BudgetForm.svelte";
   import { Modal } from "lib/common";
   import { gjSchemeCollection } from "lib/draw/stores";
   import {
-    Checkbox,
-    CheckboxGroup,
     DefaultButton,
     ErrorMessage,
-    NumberInput,
-    MoneyInput,
     Radio,
     SecondaryButton,
     TextArea,
     TextInput,
   } from "lib/govuk";
-  import type { FundingSources } from "types";
   import PipelineType from "../forms/PipelineType.svelte";
 
   export let scheme_reference: string;
@@ -22,16 +19,6 @@
   // This is just for conveience below, but it means most changes are not
   // synced to $gjSchemeCollection until finish() is called
   let pipeline = $gjSchemeCollection.schemes[scheme_reference].pipeline!;
-
-  // TODO Note below we make sure "other" isn't in this list, just to make TS happy
-  let fundingSources = [
-    "atf2",
-    "atf3",
-    "atf4",
-    "atf4e",
-    "crsts",
-    "luf",
-  ] as Array<keyof FundingSources>;
 
   // Check for all required values
   $: errorMessage =
@@ -107,94 +94,9 @@
     />
   </fieldset>
 
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">Timing and status</legend>
+  <TimingForm data={pipeline} required />
 
-    <Radio
-      legend="Status"
-      id="scheme-status"
-      choices={[
-        ["aspiration", "Aspiration"],
-        ["planned", "Planned"],
-        ["in development", "In development"],
-        ["in construction", "In construction"],
-        ["completed", "Completed"],
-      ]}
-      inlineSmall
-      required
-      bind:value={pipeline.status}
-    />
-
-    <Radio
-      legend="Timescale"
-      id="scheme-timescale"
-      choices={[
-        ["short", "Short (1-3 years)"],
-        ["medium", "Medium (3-6 years)"],
-        ["long", "Long (6-10 years)"],
-      ]}
-      inlineSmall
-      required
-      bind:value={pipeline.timescale}
-    />
-    <NumberInput
-      label="Estimated completion year (if known)"
-      width={4}
-      min={2010}
-      max={2100}
-      bind:value={pipeline.timescale_year}
-    />
-
-    <NumberInput
-      label="What year was this scheme most recently published?"
-      width={4}
-      min={2010}
-      max={2100}
-      bind:value={pipeline.year_published}
-    />
-
-    <NumberInput
-      label="What year was this scheme most recently consulted on?"
-      width={4}
-      min={2010}
-      max={2100}
-      bind:value={pipeline.year_consulted}
-    />
-  </fieldset>
-
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">Budget</legend>
-
-    <MoneyInput label="Cost (GBP)" bind:value={pipeline.budget} />
-
-    <Checkbox
-      id="development_funded"
-      bind:checked={pipeline.development_funded}
-    >
-      Is the development fully funded?
-    </Checkbox>
-    <Checkbox
-      id="construction_funded"
-      bind:checked={pipeline.construction_funded}
-    >
-      Is the construction fully funded?
-    </Checkbox>
-
-    <p>Funding sources</p>
-    <CheckboxGroup>
-      {#each fundingSources as source}
-        {#if source != "other"}
-          <Checkbox id={source} bind:checked={pipeline.funding_sources[source]}>
-            {source.toUpperCase()}
-          </Checkbox>
-        {/if}
-      {/each}
-    </CheckboxGroup>
-    <TextInput
-      label="Other funding sources"
-      bind:value={pipeline.funding_sources.other}
-    />
-  </fieldset>
+  <BudgetForm data={pipeline} />
 
   <DefaultButton on:click={() => (showModal = false)}>Save</DefaultButton>
 </Modal>

--- a/src/lib/sidebar/pipeline/BudgetForm.svelte
+++ b/src/lib/sidebar/pipeline/BudgetForm.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import type { PipelineBudget, FundingSources } from "types";
+  import { Checkbox, CheckboxGroup, MoneyInput, TextInput } from "lib/govuk";
+
+  export let data: PipelineBudget;
+
+  // TODO Note below we make sure "other" isn't in this list, just to make TS happy
+  let fundingSources = [
+    "atf2",
+    "atf3",
+    "atf4",
+    "atf4e",
+    "crsts",
+    "luf",
+  ] as Array<keyof FundingSources>;
+</script>
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend">Budget</legend>
+
+  <MoneyInput label="Cost (GBP)" bind:value={data.budget} />
+
+  <Checkbox id="development_funded" bind:checked={data.development_funded}>
+    Is the development fully funded?
+  </Checkbox>
+  <Checkbox id="construction_funded" bind:checked={data.construction_funded}>
+    Is the construction fully funded?
+  </Checkbox>
+
+  <p>Funding sources</p>
+  <CheckboxGroup>
+    {#each fundingSources as source}
+      {#if source != "other"}
+        <Checkbox id={source} bind:checked={data.funding_sources[source]}>
+          {source.toUpperCase()}
+        </Checkbox>
+      {/if}
+    {/each}
+  </CheckboxGroup>
+  <TextInput
+    label="Other funding sources"
+    bind:value={data.funding_sources.other}
+  />
+</fieldset>
+
+<style>
+  fieldset {
+    /* TODO govuk doesn't style it, but this seems useful */
+    border: 2px solid black;
+    padding: 8px;
+  }
+</style>

--- a/src/lib/sidebar/pipeline/BudgetForm.svelte
+++ b/src/lib/sidebar/pipeline/BudgetForm.svelte
@@ -3,6 +3,14 @@
   import { Checkbox, CheckboxGroup, MoneyInput, TextInput } from "lib/govuk";
 
   export let data: PipelineBudget;
+  // Svelte reactivity for fields modified by this component are invisible to
+  // the caller, so use this callback to listen to changes.
+  export let onUpdate: () => void;
+
+  function update(_: PipelineBudget) {
+    onUpdate();
+  }
+  $: update(data);
 
   // TODO Note below we make sure "other" isn't in this list, just to make TS happy
   let fundingSources = [

--- a/src/lib/sidebar/pipeline/TimingForm.svelte
+++ b/src/lib/sidebar/pipeline/TimingForm.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { NumberInput, Radio } from "lib/govuk";
+  import type { PipelineTiming } from "types";
+
+  export let data: PipelineTiming;
+  // Are status and timescale required?
+  export let required: boolean;
+</script>
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend">Timing and status</legend>
+
+  <Radio
+    legend="Status"
+    id="scheme-status"
+    choices={[
+      ["aspiration", "Aspiration"],
+      ["planned", "Planned"],
+      ["in development", "In development"],
+      ["in construction", "In construction"],
+      ["completed", "Completed"],
+    ]}
+    inlineSmall
+    {required}
+    bind:value={data.status}
+  />
+
+  <Radio
+    legend="Timescale"
+    id="scheme-timescale"
+    choices={[
+      ["short", "Short (1-3 years)"],
+      ["medium", "Medium (3-6 years)"],
+      ["long", "Long (6-10 years)"],
+    ]}
+    inlineSmall
+    {required}
+    bind:value={data.timescale}
+  />
+  <NumberInput
+    label="Estimated completion year (if known)"
+    width={4}
+    min={2010}
+    max={2100}
+    bind:value={data.timescale_year}
+  />
+
+  <NumberInput
+    label="What year was this scheme most recently published?"
+    width={4}
+    min={2010}
+    max={2100}
+    bind:value={data.year_published}
+  />
+
+  <NumberInput
+    label="What year was this scheme most recently consulted on?"
+    width={4}
+    min={2010}
+    max={2100}
+    bind:value={data.year_consulted}
+  />
+</fieldset>
+
+<style>
+  fieldset {
+    /* TODO govuk doesn't style it, but this seems useful */
+    border: 2px solid black;
+    padding: 8px;
+  }
+</style>

--- a/src/lib/sidebar/pipeline/TimingForm.svelte
+++ b/src/lib/sidebar/pipeline/TimingForm.svelte
@@ -5,6 +5,14 @@
   export let data: PipelineTiming;
   // Are status and timescale required?
   export let required: boolean;
+  // Svelte reactivity for fields modified by this component are invisible to
+  // the caller, so use this callback to listen to changes.
+  export let onUpdate: () => void;
+
+  function update(_: PipelineTiming) {
+    onUpdate();
+  }
+  $: update(data);
 </script>
 
 <fieldset class="govuk-fieldset">

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -227,7 +227,20 @@ export function getUnexpectedProperties(props: { [name: string]: any }): {
   }
 
   if (schema == "pipeline" && copy.pipeline) {
-    for (let key of ["atf4_type", "accuracy", "is_alternative"]) {
+    for (let key of [
+      "atf4_type",
+      "accuracy",
+      "is_alternative",
+      "budget",
+      "development_funded",
+      "construction_funded",
+      "funding_sources",
+      "status",
+      "timescale",
+      "timescale_year",
+      "year_published",
+      "year_consulted",
+    ]) {
       delete copy.pipeline[key];
     }
     if (Object.entries(copy.pipeline).length == 0) {

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -83,6 +83,18 @@ export function backfill(json: any): SchemeCollection {
       delete scheme.pipeline.budget_unfunded;
       delete scheme.pipeline.funding_source;
       delete scheme.pipeline.funded;
+
+      // Backfill fields added 14 Feburary 2024
+      for (let f of json.features) {
+        if (f.properties.pipeline) {
+          f.properties.pipeline.development_funded ??= false;
+          f.properties.pipeline.construction_funded ??= false;
+          f.properties.pipeline.funding_sources ??= emptyFundingSources();
+
+          f.properties.pipeline.status ??= "";
+          f.properties.pipeline.timescale ??= "";
+        }
+      }
     }
   }
 
@@ -131,7 +143,7 @@ export function emptyPipelineScheme(): PipelineScheme {
   };
 }
 
-function emptyFundingSources(): FundingSources {
+export function emptyFundingSources(): FundingSources {
   return {
     atf2: false,
     atf3: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface SchemeData {
 // Every field is optional in this type, to match the reality of starting with
 // a blank form. Mandatory fields are marked in the form UI. Optional string
 // types are encoded as "".
-export interface PipelineScheme {
+export interface PipelineScheme extends PipelineBudget, PipelineTiming {
   // TODO "intersection" is unclear
   scheme_type:
     | "cycling route"
@@ -40,7 +40,17 @@ export interface PipelineScheme {
     | "";
   atf4_lead_type: PipelineType | "";
   scheme_description: string;
+}
 
+export interface PipelineBudget {
+  // GBP
+  budget?: number;
+  development_funded: boolean;
+  construction_funded: boolean;
+  funding_sources: FundingSources;
+}
+
+export interface PipelineTiming {
   // TODO Check with DB schema
   status:
     | "aspiration"
@@ -53,12 +63,6 @@ export interface PipelineScheme {
   timescale_year?: number;
   year_published?: number;
   year_consulted?: number;
-
-  // GBP
-  budget?: number;
-  development_funded: boolean;
-  construction_funded: boolean;
-  funding_sources: FundingSources;
 }
 
 export interface FundingSources {

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,7 +138,7 @@ export interface InterventionProps {
   hide_while_editing?: boolean;
 }
 
-export interface PipelineIntervention {
+export interface PipelineIntervention extends PipelineBudget, PipelineTiming {
   atf4_type: PipelineType | "";
   accuracy: "high" | "medium" | "low" | "";
   is_alternative: boolean;

--- a/tests/data/pipeline_before_feb_fields.geojson
+++ b/tests/data/pipeline_before_feb_fields.geojson
@@ -1,0 +1,50 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "scheme_reference": "bb649a68-5fc0-423a-b679-25dc43a8d020",
+        "intervention_type": "other",
+        "pipeline": {
+          "atf4_type": "",
+          "accuracy": "",
+          "is_alternative": false
+        },
+        "is_coverage_polygon": false,
+        "name": "POI"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-0.3140953, 50.8386259]
+      },
+      "id": 1
+    }
+  ],
+  "schemes": {
+    "bb649a68-5fc0-423a-b679-25dc43a8d020": {
+      "scheme_reference": "bb649a68-5fc0-423a-b679-25dc43a8d020",
+      "color": "#377eb8",
+      "pipeline": {
+        "scheme_type": "",
+        "atf4_lead_type": "",
+        "scheme_description": "",
+        "status": "",
+        "timescale": "",
+        "development_funded": false,
+        "construction_funded": false,
+        "funding_sources": {
+          "atf2": false,
+          "atf3": false,
+          "atf4": false,
+          "atf4e": false,
+          "crsts": false,
+          "luf": false,
+          "other": ""
+        }
+      }
+    }
+  },
+  "authority": "LAD_Adur",
+  "origin": "atip-v2"
+}

--- a/tests/shared.ts
+++ b/tests/shared.ts
@@ -23,7 +23,10 @@ export async function clearExistingInterventions(page: Page) {
   await page.keyboard.down("Escape");
   await page.keyboard.down("Escape");
 
-  await page.getByText("Manage files").click();
+  // A test may leave the "Manage files" panel open
+  if (!(await page.getByRole("button", { name: "Clear all" }).isVisible())) {
+    await page.getByText("Manage files").click();
+  }
   await page.getByRole("button", { name: "Clear all" }).click();
   await page.getByRole("button", { name: "Clear all work" }).click();
   // Close the panel


### PR DESCRIPTION
As requested by our user. I referred to #398 but didn't preserve the behavior of aggregating per-feature timing/budget to inform the scheme-wide variant. We could consider adding this back if it's requested, but I'm not sure if there are situations when the values are known both overall and individually.

I added some tests and checked old files, but please also do test things out carefully