### PR TITLE
Use UUIDs for (almost) all form elements

### DIFF
--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -196,21 +196,18 @@
   <SecondaryButton on:click={resetFilters}>Reset all filters</SecondaryButton>
   <Select
     label="Authority or region"
-    id="filterAuthority"
     choices={authorities}
     emptyOption
     bind:value={filterAuthority}
   />
   <Select
     label="Funding programme"
-    id="filterFundingProgramme"
     choices={fundingProgrammes}
     emptyOption
     bind:value={filterFundingProgramme}
   />
   <Select
     label="Current milestone"
-    id="filterCurrentMilestone"
     choices={currentMilestones}
     emptyOption
     bind:value={filterCurrentMilestone}

--- a/src/lib/browse/Filters.svelte
+++ b/src/lib/browse/Filters.svelte
@@ -244,7 +244,7 @@
 </CollapsibleCard>
 
 <CheckboxGroup small>
-  <Checkbox id="show-schemes" bind:checked={show}>
+  <Checkbox bind:checked={show}>
     Showing {schemesToBeShown.size.toLocaleString()} schemes ({counts.route.toLocaleString()}
     routes, {counts.area.toLocaleString()} areas,
     {counts.crossing.toLocaleString()} crossings, {counts.other.toLocaleString()}

--- a/src/lib/browse/InterventionColorSelector.svelte
+++ b/src/lib/browse/InterventionColorSelector.svelte
@@ -32,7 +32,6 @@
 
 <Select
   label="Color interventions"
-  id="colorInterventions"
   choices={[
     ["fundingProgramme", "By funding programme"],
     ["interventionType", "By intervention type"],

--- a/src/lib/browse/layers/areas/CensusOutputAreas.svelte
+++ b/src/lib/browse/layers/areas/CensusOutputAreas.svelte
@@ -72,7 +72,6 @@
 </script>
 
 <Checkbox
-  id="percent_households_with_car"
   bind:checked={showHouseholdsWithCar}
   on:change={() => {
     showAverageCars = false;
@@ -109,7 +108,6 @@
 {/if}
 
 <Checkbox
-  id="average_cars_per_household"
   bind:checked={showAverageCars}
   on:change={() => {
     showHouseholdsWithCar = false;
@@ -150,7 +148,6 @@
 {/if}
 
 <Checkbox
-  id="population_density"
   bind:checked={showPopulationDensity}
   on:change={() => {
     showHouseholdsWithCar = false;

--- a/src/lib/browse/layers/areas/CombinedAuthorities.svelte
+++ b/src/lib/browse/layers/areas/CombinedAuthorities.svelte
@@ -33,7 +33,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Combined authorities
   <span slot="right">

--- a/src/lib/browse/layers/areas/IMD.svelte
+++ b/src/lib/browse/layers/areas/IMD.svelte
@@ -26,7 +26,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Indices of Multiple Deprivation
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
+++ b/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
@@ -33,7 +33,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Local Authority Districts
   <span slot="right">

--- a/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
+++ b/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
@@ -26,7 +26,7 @@
   // -- but can't we fix that now?
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Local Planning Authorities
   <span slot="right">

--- a/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
+++ b/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Parliamentary constituencies
   <span slot="right">

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -65,7 +65,7 @@
   }
 </script>
 
-<Checkbox id="pollution" bind:checked={show}>
+<Checkbox bind:checked={show}>
   Pollution
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -98,7 +98,6 @@
 {#if show}
   <Select
     label="Pollutant"
-    id="pollutant"
     choices={[
       ["PM25_viridis", "Background PM2.5"],
       ["PM10_viridis", "Background PM10"],

--- a/src/lib/browse/layers/areas/Wards.svelte
+++ b/src/lib/browse/layers/areas/Wards.svelte
@@ -30,7 +30,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Wards
   <span slot="right">

--- a/src/lib/browse/layers/lines/BusRoutes.svelte
+++ b/src/lib/browse/layers/lines/BusRoutes.svelte
@@ -21,7 +21,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend color={colors.bus_route_with_lane} />
   Bus routes
   <span slot="right">

--- a/src/lib/browse/layers/lines/CyclePaths.svelte
+++ b/src/lib/browse/layers/lines/CyclePaths.svelte
@@ -75,7 +75,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={showGroup}>
+<Checkbox bind:checked={showGroup}>
   Cycle paths
   <span slot="right">
     <HelpButton>
@@ -117,7 +117,7 @@
   <div style="border: 1px solid black; padding: 8px;">
     <CheckboxGroup>
       {#each legend as [kind, label, color]}
-        <Checkbox id={kind} bind:checked={showLayer[kind]}>
+        <Checkbox bind:checked={showLayer[kind]}>
           <ColorLegend {color} />
           {label}
         </Checkbox>

--- a/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
+++ b/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
@@ -22,7 +22,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Major Road Network
   <span slot="right">

--- a/src/lib/browse/layers/lines/NationalCycleNetwork.svelte
+++ b/src/lib/browse/layers/lines/NationalCycleNetwork.svelte
@@ -22,7 +22,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   National Cycle Network
   <span slot="right">

--- a/src/lib/browse/layers/lines/PCT.svelte
+++ b/src/lib/browse/layers/lines/PCT.svelte
@@ -79,7 +79,6 @@
   <SequentialLegend {colorScale} {limits} />
   <Radio
     legend="Trip purpose"
-    id="tripPurpose"
     choices={[
       ["pct_commute", "Commuting"],
       ["pct_school", "School"],
@@ -89,7 +88,6 @@
   />
   <Select
     label="Scenario"
-    id="scenario"
     choices={[
       ["baseline", "Baseline (2011)"],
       ["gov_target", "Government target (2025)"],

--- a/src/lib/browse/layers/lines/PCT.svelte
+++ b/src/lib/browse/layers/lines/PCT.svelte
@@ -49,7 +49,7 @@
   }
 </script>
 
-<Checkbox id={nameCommute} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Propensity to Cycle Tool
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/lines/PavementWidths.svelte
+++ b/src/lib/browse/layers/lines/PavementWidths.svelte
@@ -22,7 +22,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   OS Pavement widths
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/lines/RoadSpeeds.svelte
+++ b/src/lib/browse/layers/lines/RoadSpeeds.svelte
@@ -41,7 +41,7 @@
   };
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   OS Speeds
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/lines/RoadSpeeds.svelte
+++ b/src/lib/browse/layers/lines/RoadSpeeds.svelte
@@ -70,7 +70,6 @@
   <SequentialLegend {colorScale} {limits} />
   <Radio
     legend="Show speed types"
-    id="showSpeed"
     choices={[
       ["indicative_mph", "Posted speed limit"],
       ["highest_mph", "Highest measured average speed"],

--- a/src/lib/browse/layers/lines/RoadWidths.svelte
+++ b/src/lib/browse/layers/lines/RoadWidths.svelte
@@ -22,7 +22,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   OS Road widths
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/lines/Trams.svelte
+++ b/src/lib/browse/layers/lines/Trams.svelte
@@ -23,7 +23,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend color={colors.trams} />
   Trams
   <span slot="right">

--- a/src/lib/browse/layers/points/BusStops.svelte
+++ b/src/lib/browse/layers/points/BusStops.svelte
@@ -20,7 +20,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Bus stops
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/points/CriticalIssues.svelte
+++ b/src/lib/browse/layers/points/CriticalIssues.svelte
@@ -67,7 +67,7 @@
   <ErrorMessage {errorMessage} />
   {#if numberIssues > 0}
     <CheckboxGroup small>
-      <Checkbox id="show-criticals" bind:checked={show}>
+      <Checkbox bind:checked={show}>
         <ColorLegend {color} />
         Show {numberIssues.toLocaleString()} issues
       </Checkbox>

--- a/src/lib/browse/layers/points/Crossings.svelte
+++ b/src/lib/browse/layers/points/Crossings.svelte
@@ -53,7 +53,7 @@
   ];
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Crossings
   <span slot="right">
     <HelpButton>

--- a/src/lib/browse/layers/points/CycleParking.svelte
+++ b/src/lib/browse/layers/points/CycleParking.svelte
@@ -18,7 +18,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Cycle parking
   <span slot="right">

--- a/src/lib/browse/layers/points/Education.svelte
+++ b/src/lib/browse/layers/points/Education.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<Checkbox id={"education"} bind:checked={showGroup}>
+<Checkbox bind:checked={showGroup}>
   Education
   <span slot="right">
     <HelpButton>
@@ -47,15 +47,15 @@
 {#if showGroup}
   <div style="border: 1px solid black; padding: 8px;">
     <CheckboxGroup>
-      <Checkbox id={"school"} bind:checked={showLayer.school}>
+      <Checkbox bind:checked={showLayer.school}>
         <ColorLegend color={colors.education.schools} />
         Schools
       </Checkbox>
-      <Checkbox id={"college"} bind:checked={showLayer.college}>
+      <Checkbox bind:checked={showLayer.college}>
         <ColorLegend color={colors.education.colleges} />
         Colleges
       </Checkbox>
-      <Checkbox id={"university"} bind:checked={showLayer.university}>
+      <Checkbox bind:checked={showLayer.university}>
         <ColorLegend color={colors.education.universities} />
         Universities
       </Checkbox>

--- a/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
@@ -33,7 +33,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   {pluralNoun}
   <span slot="right">

--- a/src/lib/browse/layers/points/RailwayStations.svelte
+++ b/src/lib/browse/layers/points/RailwayStations.svelte
@@ -19,7 +19,7 @@
   let show = false;
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   <ColorLegend {color} />
   Railway Stations
   <span slot="right">

--- a/src/lib/browse/layers/points/Stats19.svelte
+++ b/src/lib/browse/layers/points/Stats19.svelte
@@ -133,7 +133,7 @@
   ];
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Stats19
   <span slot="right">
     <HelpButton>
@@ -176,16 +176,10 @@
 {#if show}
   <div style="border: 1px solid black; padding: 8px;">
     <CheckboxGroup small>
-      <Checkbox id="stats19-pedestrians" bind:checked={filterPedestrians}>
-        Pedestrians
-      </Checkbox>
-      <Checkbox id="stats19-cyclists" bind:checked={filterCyclists}>
-        Cyclists
-      </Checkbox>
-      <Checkbox id="stats19-horse-riders" bind:checked={filterHorseRiders}>
-        Horse riders
-      </Checkbox>
-      <Checkbox id="stats19-other" bind:checked={filterOther}>Other</Checkbox>
+      <Checkbox bind:checked={filterPedestrians}>Pedestrians</Checkbox>
+      <Checkbox bind:checked={filterCyclists}>Cyclists</Checkbox>
+      <Checkbox bind:checked={filterHorseRiders}>Horse riders</Checkbox>
+      <Checkbox bind:checked={filterOther}>Other</Checkbox>
     </CheckboxGroup>
     <div>
       Filter years:

--- a/src/lib/browse/layers/points/VehicleCounts.svelte
+++ b/src/lib/browse/layers/points/VehicleCounts.svelte
@@ -36,7 +36,7 @@
   }
 </script>
 
-<Checkbox id={name} bind:checked={show}>
+<Checkbox bind:checked={show}>
   Vehicle counts
   <span slot="right">
     <HelpButton>

--- a/src/lib/common/BaselayerSwitcher.svelte
+++ b/src/lib/common/BaselayerSwitcher.svelte
@@ -8,7 +8,6 @@
 
 <Select
   label="Basemap"
-  id="basemap"
   choices={getStyleChoices()}
   bind:value={$mapStyle}
   {disabled}

--- a/src/lib/common/FileInput.svelte
+++ b/src/lib/common/FileInput.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { FormElement } from "lib/govuk";
 
   export let label: string;
-  // This must be unique in the page
-  export let id: string;
   // Called with the file contents as text
   export let loadFile: (text: string) => void;
 
@@ -19,6 +18,8 @@
     let files = fileInput.files!;
     reader.readAsText(files[0]);
   }
+
+  let id = uuidv4();
 </script>
 
 <FormElement {label} {id}>

--- a/src/lib/common/StreetViewTool.svelte
+++ b/src/lib/common/StreetViewTool.svelte
@@ -79,7 +79,6 @@
 
     <Radio
       legend="Source"
-      id="streetViewImagery"
       choices={[
         ["google", "Google Street View"],
         ["bing", "Bing Streetside"],

--- a/src/lib/critical_entry/Form.svelte
+++ b/src/lib/critical_entry/Form.svelte
@@ -163,7 +163,6 @@
 
 <Select
   label="Current design stage"
-  id="currentDesignStage"
   choices={designStages}
   emptyOption
   bind:value={currentDesignStage}
@@ -174,7 +173,6 @@
 
 <Select
   label="Critical issue type"
-  id="criticalIssueType"
   choices={criticalIssueTypes}
   emptyOption
   bind:value={criticalIssueType}

--- a/src/lib/critical_entry/LocationDescription.svelte
+++ b/src/lib/critical_entry/LocationDescription.svelte
@@ -46,7 +46,7 @@
   />
 </FormElement>
 <CheckboxGroup small>
-  <Checkbox id="lookupLocation" bind:checked={lookupLocation}>
+  <Checkbox bind:checked={lookupLocation}>
     Lookup location description automatically
   </Checkbox>
 </CheckboxGroup>

--- a/src/lib/draw/StreetViewMode.svelte
+++ b/src/lib/draw/StreetViewMode.svelte
@@ -16,7 +16,6 @@
 
 <Radio
   legend="Source"
-  id="streetViewImagery"
   choices={[
     ["google", "Google Street View"],
     ["bing", "Bing Streetside"],

--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -75,14 +75,12 @@
 
 <CheckboxGroup small>
   <Checkbox
-    id="extendRoute"
     bind:checked={extendRoute}
     hint="Keep clicking to add more points to the end of the route"
   >
     Add points to end
   </Checkbox>
   <Checkbox
-    id="avoidDoublingBack"
     bind:checked={$userSettings.avoidDoublingBack}
     hint="Try to make the route avoid using the same streets with multiple waypoints"
   >

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { gjSchemeCollection, routeTool } from "lib/draw/stores";
   import {
     FormElement,
@@ -10,7 +11,6 @@
   import { prettyPrintMeters } from "lib/maplibre";
   import type { InterventionProps } from "types";
 
-  export let id: number;
   export let props: InterventionProps;
 
   // Sets the intervention name to "From {road1 and road2} to {road3 and
@@ -22,10 +22,12 @@
       window.alert(`Couldn't auto-name route: ${e}`);
     }
   }
+
+  let nameId = uuidv4();
 </script>
 
-<FormElement label="Name" id={"name-" + id}>
-  <input type="text" class="govuk-input" bind:value={props.name} />
+<FormElement label="Name" id={nameId}>
+  <input type="text" class="govuk-input" id={nameId} bind:value={props.name} />
   <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
   {#if props.length_meters}
     <SecondaryButton on:click={() => autoFillName()} disabled={!$routeTool}>

--- a/src/lib/forms/FormV1.svelte
+++ b/src/lib/forms/FormV1.svelte
@@ -36,7 +36,6 @@
 
 <Select
   label="Scheme"
-  id={"scheme-" + id}
   choices={Object.values($gjSchemeCollection.schemes).map((scheme) => [
     scheme.scheme_reference,
     scheme.scheme_name ?? "Untitled scheme",
@@ -46,7 +45,6 @@
 
 <Radio
   legend="Type"
-  id={"type-" + id}
   choices={[
     ["area", "Area"],
     ["route", "Route"],

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -99,17 +99,11 @@
     bind:value={props.pipeline.accuracy}
   />
 
-  <Checkbox
-    id={"alternative-" + id}
-    bind:checked={props.pipeline.is_alternative}
-  >
+  <Checkbox bind:checked={props.pipeline.is_alternative}>
     Is this an alternative route and not the default option?
   </Checkbox>
   {#if shouldDisplayCoveragePolygonQuestion && props.is_coverage_polygon !== undefined}
-    <Checkbox
-      id={"coverage-polygon-" + id}
-      bind:checked={props.is_coverage_polygon}
-    >
+    <Checkbox bind:checked={props.is_coverage_polygon}>
       Does this polygon show the coverage of the scheme? (All area considered
       while making the scheme)
     </Checkbox>

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -65,7 +65,6 @@
 
 <Select
   label="Scheme"
-  id={"scheme-" + id}
   choices={Object.values($gjSchemeCollection.schemes).map((scheme) => [
     scheme.scheme_reference,
     scheme.scheme_name ?? "Untitled scheme",
@@ -82,13 +81,11 @@
 {#if props.pipeline}
   <PipelineType
     label="Type"
-    id={"pipeline-type-" + id}
     bind:value={props.pipeline.atf4_type}
   />
 
   <Radio
     legend="Accuracy of mapped data"
-    id={"accuracy-" + id}
     choices={[
       ["high", "High"],
       ["medium", "Medium"],

--- a/src/lib/forms/PipelineForm.svelte
+++ b/src/lib/forms/PipelineForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { emptyFundingSources } from "lib/sidebar/scheme_data";
   import { gjSchemeCollection, routeTool } from "lib/draw/stores";
   import {
@@ -15,7 +16,6 @@
   import TimingForm from "lib/sidebar/pipeline/TimingForm.svelte";
   import BudgetForm from "lib/sidebar/pipeline/BudgetForm.svelte";
 
-  export let id: number;
   export let props: InterventionProps;
 
   // Lazily fill for each feature (whether newly created or loaded from an older-format file)
@@ -50,11 +50,13 @@
       window.alert(`Couldn't auto-name route: ${e}`);
     }
   }
+
+  let nameId = uuidv4();
 </script>
 
-<FormElement label="Name" id={"name-" + id}>
+<FormElement label="Name" id={nameId}>
   <div class="govuk-hint">Use the name from the LCWIP if possible</div>
-  <input type="text" class="govuk-input" bind:value={props.name} />
+  <input type="text" class="govuk-input" id={nameId} bind:value={props.name} />
   <!-- Only LineStrings can be auto-named, and length_meters being set is the simplest proxy for that -->
   {#if props.length_meters}
     <SecondaryButton on:click={() => autoFillName()} disabled={!$routeTool}>
@@ -79,10 +81,7 @@
 {/if}
 
 {#if props.pipeline}
-  <PipelineType
-    label="Type"
-    bind:value={props.pipeline.atf4_type}
-  />
+  <PipelineType label="Type" bind:value={props.pipeline.atf4_type} />
 
   <Radio
     legend="Accuracy of mapped data"

--- a/src/lib/forms/PipelineType.svelte
+++ b/src/lib/forms/PipelineType.svelte
@@ -3,7 +3,6 @@
   import type { PipelineType } from "types";
 
   export let label: string;
-  export let id: string;
   export let value: PipelineType | "";
 
   // Keep in sync with intervention_type_short in scheme_data
@@ -16,7 +15,6 @@
 
 <Select
   {label}
-  {id}
   choices={[
     repeat("New segregated cycling facility"),
     repeat("New junction treatment"),

--- a/src/lib/govuk/Checkbox.svelte
+++ b/src/lib/govuk/Checkbox.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
+
   // This component must be placed inside a CheckboxGroup. The default slot is
   // required, and is the label for the checkbox. There's an optional "right"
   // slot placed to the right of the checkbox on the same row, but clicking it
   // doesn't activate the checkbox.
 
-  // A unique ID
-  export let id: string;
   export let checked: boolean;
   // TODO Using class="govuk-hint govuk-checkboxes__hint" takes too much space
   // in the use cases so far, so use a tooltip instead.
@@ -15,6 +15,8 @@
   // label, we have to disable this in the govuk style.
   let haveRightSlot = $$slots.right !== undefined;
   let style = haveRightSlot ? "float: none" : "";
+
+  let id = uuidv4();
 </script>
 
 <div class="govuk-checkboxes__item" {style}>

--- a/src/lib/govuk/FormElement.svelte
+++ b/src/lib/govuk/FormElement.svelte
@@ -2,7 +2,7 @@
   // The label to show
   export let label: string;
   // A unique (per page) ID of the form element being labelled. Something in
-  // this component's slot must have this ID.
+  // this component's slot must have this ID. Generate using UUID to be safe.
   export let id: string;
 </script>
 

--- a/src/lib/govuk/MoneyInput.svelte
+++ b/src/lib/govuk/MoneyInput.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { ErrorMessage, FormElement, SecondaryButton } from "./";
 
   export let label: string;
   export let value: number | undefined;
+
+  let id = uuidv4();
 
   let stringValue: string = value == undefined ? "" : prettyprint(value);
   function update(x: string) {
@@ -42,7 +45,7 @@
   // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
 </script>
 
-<FormElement {label} id={label}>
+<FormElement {label} {id}>
   <ErrorMessage errorMessage={validate(stringValue)} />
   {#if value != undefined}
     <div class="govuk-hint">&#163;{prettyprint(value)}</div>
@@ -51,7 +54,7 @@
     type="text"
     inputmode="numeric"
     class={`govuk-input govuk-input--width-10`}
-    id={label}
+    {id}
     bind:value={stringValue}
   />
   <SecondaryButton

--- a/src/lib/govuk/NumberInput.svelte
+++ b/src/lib/govuk/NumberInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
+
   // For integer inputs only
   import ErrorMessage from "./ErrorMessage.svelte";
   import FormElement from "./FormElement.svelte";
@@ -12,11 +14,11 @@
 
   let stringValue: string | undefined = value?.toString();
 
+  let id = uuidv4();
+
   function parse() {
     value = stringValue == undefined ? undefined : parseInt(stringValue, 10);
   }
-
-  // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
 
   function validate(stringValue: string | undefined): string {
     if (stringValue == "" || stringValue == undefined) {
@@ -40,13 +42,13 @@
   }
 </script>
 
-<FormElement {label} id={label}>
+<FormElement {label} {id}>
   <ErrorMessage errorMessage={validate(stringValue)} />
   <input
     type="text"
     inputmode="numeric"
     class={`govuk-input govuk-input--width-${width}`}
-    id={label}
+    {id}
     bind:value={stringValue}
     on:change={parse}
   />

--- a/src/lib/govuk/Radio.svelte
+++ b/src/lib/govuk/Radio.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import ErrorMessage from "./ErrorMessage.svelte";
 
   // A label for the entire group of radio buttons
   export let legend: string;
-  // A unique (per page) ID of the radio group
-  export let id: string;
   // A list of [value, label] representing the choices
   export let choices: [string, string][];
   // Lay out radio buttons horizontally and decrease font size
@@ -16,6 +15,8 @@
   export let value: string;
 
   $: errorMessage = required && value == "" ? "Required" : "";
+
+  let id = uuidv4();
 </script>
 
 <div class="govuk-form-group">

--- a/src/lib/govuk/Select.svelte
+++ b/src/lib/govuk/Select.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { ErrorMessage, FormElement } from "lib/govuk";
 
   export let label: string;
-  // A unique (per page) ID
-  export let id: string;
   // A list of [value, label] representing the choices
   export let choices: [string, string][];
   // Make the first option the empty string
@@ -13,6 +12,8 @@
 
   // The current value
   export let value: string;
+
+  let id = uuidv4();
 </script>
 
 <FormElement {label} {id}>

--- a/src/lib/govuk/TextArea.svelte
+++ b/src/lib/govuk/TextArea.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import { ErrorMessage, FormElement } from "./";
 
   export let label: string;
@@ -6,10 +7,10 @@
   export let rows: number = 5;
   export let errorMessage = "";
 
-  // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
+  let id = uuidv4();
 </script>
 
-<FormElement {label} id={label}>
+<FormElement {label} {id}>
   <ErrorMessage {errorMessage} />
-  <textarea class="govuk-textarea" id={label} {rows} bind:value />
+  <textarea class="govuk-textarea" {id} {rows} bind:value />
 </FormElement>

--- a/src/lib/govuk/TextInput.svelte
+++ b/src/lib/govuk/TextInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { v4 as uuidv4 } from "uuid";
   import ErrorMessage from "./ErrorMessage.svelte";
   import FormElement from "./FormElement.svelte";
 
@@ -7,13 +8,13 @@
   // Show an error if input is empty
   export let required = false;
 
-  // TODO Using the label as a unique ID, so users don't have to invent an arbitrary string
+  let id = uuidv4();
 
   $: errorMessage =
     required && (value == undefined || value == "") ? "Required" : "";
 </script>
 
-<FormElement {label} id={label}>
+<FormElement {label} {id}>
   <ErrorMessage {errorMessage} />
-  <input type="text" class="govuk-input" id={label} bind:value />
+  <input type="text" class="govuk-input" {id} bind:value />
 </FormElement>

--- a/src/lib/sidebar/EditForm.svelte
+++ b/src/lib/sidebar/EditForm.svelte
@@ -102,8 +102,8 @@
 <ErrorMessage errorMessage={warning} />
 {#if $schema == "v1"}
   <UnexpectedProperties id={feature.id} props={feature.properties} />
-  <FormV1 id={feature.id} bind:props={feature.properties} />
+  <FormV1 bind:props={feature.properties} />
 {:else if $schema == "pipeline"}
   <UnexpectedProperties id={feature.id} props={feature.properties} />
-  <PipelineForm id={feature.id} bind:props={feature.properties} />
+  <PipelineForm bind:props={feature.properties} />
 {/if}

--- a/src/lib/sidebar/FileManagement.svelte
+++ b/src/lib/sidebar/FileManagement.svelte
@@ -125,7 +125,7 @@
 
 {#if $mode.mode == "list"}
   <CollapsibleCard label="Manage files">
-    <FileInput label="Load GeoJSON file" id="load-geojson" {loadFile} />
+    <FileInput label="Load GeoJSON file" {loadFile} />
 
     <ButtonGroup>
       <SecondaryButton on:click={exportToGeojson}>

--- a/src/lib/sidebar/ListMode.svelte
+++ b/src/lib/sidebar/ListMode.svelte
@@ -92,11 +92,7 @@
 <SecondaryButton on:click={newBlankScheme}>
   Add new blank scheme
 </SecondaryButton>
-<FileInput
-  label="Add scheme from file"
-  id="merge-file"
-  loadFile={mergeSchemesFromFile}
-/>
+<FileInput label="Add scheme from file" loadFile={mergeSchemesFromFile} />
 <ErrorMessage errorMessage={errorFromFile} />
 
 <hr />

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -143,13 +143,7 @@
     Delete
   </WarningButton>
 </h3>
-<Checkbox
-  id={"show-scheme-" + scheme_reference}
-  bind:checked={showScheme}
-  on:change={showOrHide}
->
-  Show
-</Checkbox>
+<Checkbox bind:checked={showScheme} on:change={showOrHide}>Show</Checkbox>
 <slot />
 {#if $schema == "pipeline"}
   <PipelineSchemeForm {scheme_reference} />

--- a/src/lib/sidebar/PerSchemeControls.svelte
+++ b/src/lib/sidebar/PerSchemeControls.svelte
@@ -194,7 +194,6 @@
     </p>
     <Select
       label="Move interventions to another scheme"
-      id="move-interventions"
       choices={moveSchemeChoices()}
       bind:value={moveToScheme}
       on:change={moveFeatures}

--- a/src/lib/sidebar/PipelineSchemeForm.svelte
+++ b/src/lib/sidebar/PipelineSchemeForm.svelte
@@ -70,7 +70,6 @@
 
     <Radio
       legend="Scheme type"
-      id="scheme-type"
       choices={[
         ["cycling route", "Cycling route"],
         ["walking route", "Walking route"],
@@ -89,7 +88,6 @@
 
     <PipelineType
       label="Type of the main intervention"
-      id="lead-pipeline-type"
       bind:value={pipeline.atf4_lead_type}
     />
 

--- a/src/lib/sidebar/pipeline/BudgetForm.svelte
+++ b/src/lib/sidebar/pipeline/BudgetForm.svelte
@@ -28,10 +28,10 @@
 
   <MoneyInput label="Cost (GBP)" bind:value={data.budget} />
 
-  <Checkbox id="development_funded" bind:checked={data.development_funded}>
+  <Checkbox bind:checked={data.development_funded}>
     Is the development fully funded?
   </Checkbox>
-  <Checkbox id="construction_funded" bind:checked={data.construction_funded}>
+  <Checkbox bind:checked={data.construction_funded}>
     Is the construction fully funded?
   </Checkbox>
 
@@ -39,7 +39,7 @@
   <CheckboxGroup>
     {#each fundingSources as source}
       {#if source != "other"}
-        <Checkbox id={source} bind:checked={data.funding_sources[source]}>
+        <Checkbox bind:checked={data.funding_sources[source]}>
           {source.toUpperCase()}
         </Checkbox>
       {/if}

--- a/src/lib/sidebar/pipeline/TimingForm.svelte
+++ b/src/lib/sidebar/pipeline/TimingForm.svelte
@@ -20,7 +20,6 @@
 
   <Radio
     legend="Status"
-    id="scheme-status"
     choices={[
       ["aspiration", "Aspiration"],
       ["planned", "Planned"],
@@ -35,7 +34,6 @@
 
   <Radio
     legend="Timescale"
-    id="scheme-timescale"
     choices={[
       ["short", "Short (1-3 years)"],
       ["medium", "Medium (3-6 years)"],

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -73,7 +73,7 @@
         </div>
       </Modal>
     {/if}
-    <FileInput label="Load schemes from GeoJSON" id="load-geojson" {loadFile} />
+    <FileInput label="Load schemes from GeoJSON" {loadFile} />
     <ErrorMessage {errorMessage} />
 
     {#if $schemes.size > 0}

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -146,7 +146,6 @@
 
     <Radio
       legend="Or pick from the map"
-      id="showBoundaries"
       choices={[
         ["TA", "Transport Authorities"],
         ["LAD", "Local Authority Districts"],

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -157,11 +157,7 @@
     <hr />
 
     <ErrorMessage errorMessage={uploadErrorMessage} />
-    <FileInput
-      label="Or upload an ATIP GeoJSON file"
-      {loadFile}
-      id="load-geojson"
-    />
+    <FileInput label="Or upload an ATIP GeoJSON file" {loadFile} />
   </div>
   <div class="govuk-grid-column-one-half">
     <div id="map">


### PR DESCRIPTION
The budget and timing forms hardcoded IDs for most form elements, so when we repeated these forms in different places, we started violating the unique ID requirement. There were other possible pre-existing problems with this before that change.

This may help with the radio/checkbox bugs reported. I still can't reproduce those on my end, so writing a test to check for it is tough. Maybe this fix helps, but it certainly doesn't hurt.

The fix is just to use UUID everywhere. It simplifies the use of these components anyway.

There are a few remaining manual uses of IDs in things like the critical page. I'll follow up with a separate PR to clean up some uses of `FormElement`.