### PR TITLE
Make some alternate ways to toggle snapping mode

### DIFF
--- a/src/lib/draw/route/RouteControls.svelte
+++ b/src/lib/draw/route/RouteControls.svelte
@@ -18,6 +18,10 @@
   function undo() {
     $routeTool!.undo();
   }
+
+  function toggleSnap() {
+    $routeTool!.toggleSnapMode();
+  }
 </script>
 
 <SecondaryButton disabled={$undoLength == 0} on:click={undo}>
@@ -31,13 +35,15 @@
 {#if $snapMode}
   <p style="background: red; color: white; padding: 8px;">
     Snapping to existing roads. Press <b>s</b>
-    to draw anywhere
+     or click below to draw anywhere
   </p>
+  <SecondaryButton on:click={toggleSnap}>Draw anywhere</SecondaryButton>
 {:else}
   <p style="background: blue; color: white; padding: 8px;">
     Drawing points anywhere. Press <b>s</b>
-    to snap to roads
+     or click below to snap to roads
   </p>
+  <SecondaryButton on:click={toggleSnap}>Snap to roads</SecondaryButton>
 {/if}
 
 <ul>

--- a/src/lib/draw/route/route_tool.ts
+++ b/src/lib/draw/route/route_tool.ts
@@ -129,7 +129,7 @@ export class RouteTool {
     if (e.key == "Enter") {
       e.stopPropagation();
       this.finish();
-    } else if (e.key == "s") {
+    } else if (e.key == "s" || e.key == "S") {
       e.stopPropagation();
       this.inner.toggleSnapMode();
       this.redraw();
@@ -289,6 +289,11 @@ export class RouteTool {
 
   undo() {
     this.inner.undo();
+    this.redraw();
+  }
+
+  toggleSnapMode() {
+    this.inner.toggleSnapMode();
     this.redraw();
   }
 


### PR DESCRIPTION
Some users are having trouble switching between freehand and snap mode. I can't reproduce the problem and don't really know what's going wrong on their end. So try to tackle it in two ways:

1) Allow lowercase or uppercase 's' to be the hotkey. Maybe people accidentally have caps lock on?
2) Add a button to the side to click and toggle. It's awkward to use, since it takes the cursor away from the map where drawing is happening, but is better than nothing