### PR TITLE
Upgrade to maplibre 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "atip",
       "version": "0.0.0",
       "dependencies": {
-        "@maptiler/geocoding-control": "^1.2.1",
+        "@maptiler/geocoding-control": "^1.2.2",
         "@turf/area": "^6.5.0",
         "@turf/bbox": "^6.5.0",
         "@turf/boolean-contains": "^6.5.0",
@@ -24,11 +24,11 @@
         "govuk-svelte": "github:acteng/govuk-svelte",
         "humanize-string": "^3.0.0",
         "js-cookie": "^3.0.5",
-        "maplibre-gl": "^3.5.1",
+        "maplibre-gl": "^4.0.2",
         "read-excel-file": "^5.7.1",
         "route-snapper": "^0.3.0",
         "svelte": "^4.2.10",
-        "svelte-maplibre": "^0.7.7",
+        "svelte-maplibre": "^0.8.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -926,13 +926,13 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.1.1.tgz",
+      "integrity": "sha512-z85ARNPCBI2Cs5cPOS3DSbraTN+ue8zrcYVoSWBuNrD/mA+2SKAJ+hIzI22uN7gac6jBMnCdpPKRxS/V0KSZVQ==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "rw": "^1.3.3",
         "sort-object": "^3.0.3"
@@ -944,16 +944,16 @@
       }
     },
     "node_modules/@maptiler/geocoding-control": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@maptiler/geocoding-control/-/geocoding-control-1.2.1.tgz",
-      "integrity": "sha512-KJV/JLJbcKf5vAlP04IyyWxrQAObBjgDv4rFYjzLW1d1UqxmyFUynOuIZQALnOQehKJGhxBVZFQmV/x52KaNsw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@maptiler/geocoding-control/-/geocoding-control-1.2.2.tgz",
+      "integrity": "sha512-w0JH0MOWN/z4l5t89LPinn9P9CGUg+L9R0WslXSVFP8gX9SYUMaqmGB28txXlSJsckA5/oyYfOe5UOBgXK7sbw==",
       "dependencies": {
-        "geo-coordinates-parser": "^1.6.3"
+        "geo-coordinates-parser": "^1.6.4"
       },
       "peerDependencies": {
         "@maptiler/sdk": "^1",
         "leaflet": "^1.9 || ^1.8",
-        "maplibre-gl": "^2 || ^3.0.0-alpha || ^3",
+        "maplibre-gl": "^2 || ^3 || ^4",
         "ol": "^7.5.2",
         "react": "^17 || ^18",
         "svelte": "^4.2"
@@ -1372,21 +1372,37 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "dev": true
     },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.8.tgz",
+      "integrity": "sha512-EXdsL4EhoUtGm2GC2ZYtXn+Fzc6pluVgagvo2VC1RHWToLGlTRwVYoDpqS/7QXa01rmDyBjJk3Catpf60VMkwg==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.3.tgz",
-      "integrity": "sha512-2W46IOXlu7vC8m3+M5rDqSnuY22GFxxx3xhkoyqyPWrD+eP2iAwNst0A1+umLYjCTJMJTSpiofphn9h9k+Kw+w=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.3.tgz",
-      "integrity": "sha512-d263B3KCQtXKVZMHpMJrEW5EeLBsQ8jvAS9nhpUKC5hHIlQaACG9PWkW8qxEeNuceo9120AwPjeS91uNa4ltqA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -1403,9 +1419,9 @@
       }
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.4.tgz",
-      "integrity": "sha512-SOFlLGZkLbEXJRwcWCqeP/Koyaf/uAqLXHUsdo/nMfjLsNd8kqauwHe9GBOljSmpcHp/LC6kOjo3SidGjNirVA=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -1414,9 +1430,9 @@
       "dev": true
     },
     "node_modules/@types/supercluster": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.2.tgz",
-      "integrity": "sha512-qMhofL945Z4njQUuntadexAgPtpiBC014WvVqU70Prj42LC77Xgmz04us7hSMmwjs7KbgAwGBmje+FSOvDbP0Q==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -2036,9 +2052,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
-      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2435,9 +2451,9 @@
       }
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2537,9 +2553,9 @@
       "dev": true
     },
     "node_modules/maplibre-gl": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.5.1.tgz",
-      "integrity": "sha512-XFpqAKjpm7Y6cV3B1MDZ3FGUCXyrfeM2QkXloKc4x2QK9/e6/BEHdVebtxXcTrwdzpQexKrMqzdYCbaobJRNrw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.0.2.tgz",
+      "integrity": "sha512-1HlJJyfPIbAwK1OlNzKDyuNf1NKlEwsjZZhPYpazX4yoP6ud1aC7DNct62fMSkn+hd6mRekIqzYEzIfOCC31QQ==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -2548,12 +2564,13 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
-        "@types/geojson": "^7946.0.11",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.1",
-        "@types/pbf": "^3.0.3",
-        "@types/supercluster": "^7.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^20.1.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
@@ -2799,10 +2816,11 @@
       }
     },
     "node_modules/pmtiles": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.10.0.tgz",
-      "integrity": "sha512-X+s6JyperpcAkKwv55MKx72ckOUB0ZjcfK4929iM0SS0MkLydEi2FSW1E8YTE1E2XaZ2TVk/MIUrbsZuXV7K2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.0.4.tgz",
+      "integrity": "sha512-dqxfYM/b0Y59JEk55piird5gqcRwq9o3yLBV2/l7ecfMPbCt+ccVxtPf5Ox8h/amCyRov+WgnbLLFGp8D5E8Gw==",
       "dependencies": {
+        "@types/leaflet": "^1.9.8",
         "fflate": "^0.8.0"
       }
     },
@@ -3334,15 +3352,15 @@
       }
     },
     "node_modules/svelte-maplibre": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/svelte-maplibre/-/svelte-maplibre-0.7.7.tgz",
-      "integrity": "sha512-fnv8L3tA4EMePp9BGKAc8AvXCsg34z56NBMGjYkz6qkl90qSTY4vUhIu1KXbwjGfQmHBmPkIl9VSdnnHCMnaRA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/svelte-maplibre/-/svelte-maplibre-0.8.1.tgz",
+      "integrity": "sha512-CTm/s0+mJzBHSoO5zPKBo3ORmUyiWS3Ex4xvVdNgVg+sDesHasEAJ0N1/NUrd56S33zgRdFZGzRnRguCnKFAzw==",
       "dependencies": {
         "d3-geo": "^3.1.0",
         "just-compare": "^2.3.0",
         "just-flush": "^2.3.0",
-        "maplibre-gl": "^3.5.0",
-        "pmtiles": "^2.10.0"
+        "maplibre-gl": "^4.0.0",
+        "pmtiles": "^3.0.3"
       },
       "peerDependencies": {
         "@deck.gl/core": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
-    "@maptiler/geocoding-control": "^1.2.1",
+    "@maptiler/geocoding-control": "^1.2.2",
     "@turf/area": "^6.5.0",
     "@turf/bbox": "^6.5.0",
     "@turf/boolean-contains": "^6.5.0",
@@ -50,11 +50,11 @@
     "govuk-svelte": "github:acteng/govuk-svelte",
     "humanize-string": "^3.0.0",
     "js-cookie": "^3.0.5",
-    "maplibre-gl": "^3.5.1",
+    "maplibre-gl": "^4.0.2",
     "read-excel-file": "^5.7.1",
     "route-snapper": "^0.3.0",
     "svelte": "^4.2.10",
-    "svelte-maplibre": "^0.7.7",
+    "svelte-maplibre": "^0.8.1",
     "uuid": "^9.0.1"
   }
 }

--- a/src/lib/browse/layers/points/CriticalIssues.svelte
+++ b/src/lib/browse/layers/points/CriticalIssues.svelte
@@ -39,19 +39,15 @@
     }
   }
 
-  function clickCluster(e: CustomEvent<LayerClickInfo>) {
-    ($map.getSource(source) as GeoJSONSource).getClusterExpansionZoom(
-      e.detail.features[0].properties!.cluster_id,
-      (err, zoom) => {
-        if (!err) {
-          $map.easeTo({
-            // @ts-ignore We know this is a point
-            center: e.detail.features[0].geometry.coordinates,
-            zoom: zoom as number,
-          });
-        }
-      },
-    );
+  async function clickCluster(e: CustomEvent<LayerClickInfo>) {
+    let zoom = await (
+      $map.getSource(source) as GeoJSONSource
+    ).getClusterExpansionZoom(e.detail.features[0].properties!.cluster_id);
+    $map.easeTo({
+      // @ts-ignore We know this is a point
+      center: e.detail.features[0].geometry.coordinates,
+      zoom,
+    });
   }
 </script>
 


### PR DESCRIPTION
Was waiting on a geocoder dependency to get support, but now we can do this. https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md lots of changes, most invisibly handled in svelte-maplibre already