### PR TITLE
Use gzipped scheme data

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -44,6 +44,9 @@ app.get("/data/*", async (req, resp) => {
       resp.type("application/geo+json");
     } else if (path.endsWith(".pmtiles")) {
       resp.type("binary/octet-stream");
+    } else if (path.endsWith(".geojson.gz")) {
+      resp.type("application/geo+json");
+      resp.append("Content-Encoding", "gzip");
     }
 
     // Return the whole file?

--- a/src/lib/browse/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/LoadRemoteSchemeData.svelte
@@ -8,7 +8,7 @@
 
   onMount(async () => {
     let resp = await fetch(
-      `${privateResourceBaseUrl()}/v1/random_schemes.geojson`,
+      `${privateResourceBaseUrl()}/v1/all_schemes_output.geojson.gz`,
     );
     let text = await resp.text();
     loadFile(text);


### PR DESCRIPTION
As fate would have it, we're forced to look at #493 immediately, because we're now over the 32MB app engine response limit. If we gzip that file, it's down to about 7MB and loads much faster on slow connections anyway!

Do `gzip --keep all_schemes_output.geojson` after running the combine script, and upload that to the same `private_layers/v1/` folder. Please test in the dev environment first, deploy this PR manually (backend/README has instructions), make sure everthing works end-to-end, then push to test env