### PR TITLE
Show LCWIP fields in browse popups

### DIFF
--- a/src/lib/browse/DescribePipelineBudget.svelte
+++ b/src/lib/browse/DescribePipelineBudget.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { FundingSources, PipelineBudget } from "types";
+
+  export let props: PipelineBudget;
+
+  function listFundingSources(props: PipelineBudget): string {
+    if (!props.funding_sources) {
+      return "";
+    }
+    let list = [];
+    for (let key of ["atf2", "atf3", "atf4", "atf4e", "crsts", "luf"]) {
+      if (props.funding_sources[key as keyof FundingSources]) {
+        list.push(key.toUpperCase());
+      }
+    }
+    if (props.funding_sources.other) {
+      list.push(props.funding_sources.other);
+    }
+    return list.join(", ");
+  }
+  $: funding = listFundingSources(props);
+</script>
+
+{#if props.budget}
+  <p>
+    Cost: <b>{props.budget.toLocaleString()}</b>
+    GBP
+  </p>
+{/if}
+
+{#if props.development_funded}
+  <p>Development is fully funded</p>
+{/if}
+
+{#if props.construction_funded}
+  <p>Construction is fully funded</p>
+{/if}
+
+{#if funding}
+  <p>
+    Funding sources: <b>{funding}</b>
+  </p>
+{/if}

--- a/src/lib/browse/DescribePipelineTiming.svelte
+++ b/src/lib/browse/DescribePipelineTiming.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { PipelineTiming } from "types";
+
+  export let props: PipelineTiming;
+</script>
+
+{#if props.status}
+  <p>
+    Status: <b>{props.status}</b>
+  </p>
+{/if}
+
+{#if props.timescale}
+  <p>
+    Timescale: <b>{props.timescale}</b>
+  </p>
+{/if}
+
+{#if props.timescale_year}
+  <p>
+    Estimated completion year: <b>{props.timescale_year}</b>
+  </p>
+{/if}
+
+{#if props.year_published}
+  <p>
+    Scheme most recently published: <b>{props.year_published}</b>
+  </p>
+{/if}
+
+{#if props.year_consulted}
+  <p>
+    Scheme most recently consulted on: <b>{props.year_consulted}</b>
+  </p>
+{/if}

--- a/src/lib/browse/InterventionPopup.svelte
+++ b/src/lib/browse/InterventionPopup.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { prettyPrintMeters } from "lib/maplibre";
   import { filterInterventionText, filterSchemeText, schemes } from "./stores";
+  import DescribePipelineTiming from "./DescribePipelineTiming.svelte";
+  import DescribePipelineBudget from "./DescribePipelineBudget.svelte";
 
   export let props: { [name: string]: any };
 
@@ -18,27 +20,79 @@
   }
 </script>
 
-<div style="max-width: 30vw;">
+<div style="max-width: 30vw; max-height: 60vh; overflow: auto;">
   <h2>
     {@html highlightFilter(props.name, $filterInterventionText)} ({props.intervention_type})
   </h2>
   {#if props.length_meters}
-    <p>Length: {prettyPrintMeters(props.length_meters)}</p>
+    <p>
+      Length: <b>{prettyPrintMeters(props.length_meters)}</b>
+    </p>
   {/if}
   {#if props.description}
     <p>{@html highlightFilter(props.description, $filterInterventionText)}</p>
   {/if}
+
+  {#if props.pipeline}
+    {@const p = props.pipeline}
+    {#if p.atf4_type}
+      <p>
+        ATF4 type: <b>{p.atf4_type}</b>
+      </p>
+    {/if}
+    {#if p.accuracy}
+      <p>
+        Accuracy: <b>{p.accuracy}</b>
+      </p>
+    {/if}
+    {#if p.is_alternative}
+      <p>Represents an alternative route</p>
+    {/if}
+    <DescribePipelineBudget props={p} />
+    <DescribePipelineTiming props={p} />
+  {/if}
+
   <hr />
+
   <p>
     Part of scheme: {@html highlightFilter(
       scheme.scheme_name ?? "",
       $filterSchemeText,
     )} ({@html highlightFilter(props.scheme_reference, $filterSchemeText)})
   </p>
-  <p>Authority or region: {scheme.browse?.authority_or_region}</p>
-  <p>Capital scheme ID: {scheme.browse?.capital_scheme_id}</p>
-  <p>Funding programme: {scheme.browse?.funding_programme}</p>
+  <p>
+    Authority or region: <b>{scheme.browse?.authority_or_region}</b>
+  </p>
+  {#if scheme.browse?.capital_scheme_id}
+    <p>
+      Capital scheme ID: <b>{scheme.browse?.capital_scheme_id}</b>
+    </p>
+  {/if}
+  <p>
+    Funding programme: <b>{scheme.browse?.funding_programme}</b>
+  </p>
   {#if scheme.browse?.current_milestone}
-    <p>Current milestone: {scheme.browse?.current_milestone}</p>
+    <p>
+      Current milestone: <b>{scheme.browse?.current_milestone}</b>
+    </p>
+  {/if}
+
+  {#if scheme.pipeline}
+    {@const p = scheme.pipeline}
+    {#if p.scheme_type}
+      <p>
+        Scheme type: <b>{p.scheme_type}</b>
+      </p>
+    {/if}
+    {#if p.atf4_lead_type}
+      <p>
+        ATF4 lead type: <b>{p.atf4_lead_type}</b>
+      </p>
+    {/if}
+    {#if p.scheme_description}
+      <p>Descripton: {p.scheme_description}</p>
+    {/if}
+    <DescribePipelineBudget props={p} />
+    <DescribePipelineTiming props={p} />
   {/if}
 </div>


### PR DESCRIPTION
A start towards #493. The extra LCWIP fields are invisible now; this at least starts showing them in per-feature popups. Also added bolding to values, to try and be consistent with the style for other browse popups.

I don't know if this way of presenting information is useful, but it seems better than not showing anything