### PR TITLE
Capture browse layer state in the URL

### DIFF
--- a/src/lib/browse/layers/areas/CensusOutputAreas.svelte
+++ b/src/lib/browse/layers/areas/CensusOutputAreas.svelte
@@ -17,7 +17,7 @@
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
   import SequentialLegend from "../SequentialLegend.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   let name = "census_output_areas";
   let colorScale = colors.sequential_low_to_high;
@@ -33,13 +33,13 @@
   function stringify(x: State): string | null {
     return x.show ? x.kind : null;
   }
-  function parse(result: string): State {
+  function parse(x: string): State {
     return {
       show: true,
-      kind: result,
+      kind: x,
     };
   }
-  let state = customUrl(name, defaultState, stringify, parse);
+  let state = customUrlState(name, defaultState, stringify, parse);
 
   // Mutually exclusive, like a radio button. We need these for checkboxes to work
   let showHouseholdsWithCar = $state.kind == "percent_households_with_car";

--- a/src/lib/browse/layers/areas/CombinedAuthorities.svelte
+++ b/src/lib/browse/layers/areas/CombinedAuthorities.svelte
@@ -17,11 +17,12 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "combined_authorities";
   let color = colors.combined_authorities;
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
@@ -33,7 +34,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Combined authorities
   <span slot="right">
@@ -58,7 +59,7 @@
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -76,7 +77,7 @@
       "line-width": 2.5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </GeoJSON>

--- a/src/lib/browse/layers/areas/IMD.svelte
+++ b/src/lib/browse/layers/areas/IMD.svelte
@@ -16,6 +16,7 @@
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "imd";
 
@@ -23,10 +24,10 @@
   // The deciles are [1, 10]. The 5 colors cover two each.
   let limits = [0, 2, 4, 6, 8, 10];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Indices of Multiple Deprivation
   <span slot="right">
     <HelpButton>
@@ -46,7 +47,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} limits={["Least deprived", "Most deprived"]} />
 {/if}
 
@@ -66,7 +67,7 @@
       "fill-opacity": hoverStateFilter(0.5, 0.7),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -90,7 +91,7 @@
       "line-width": 0.5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </VectorTileSource>

--- a/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
+++ b/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
@@ -17,11 +17,12 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "local_authority_districts";
   let color = colors.local_authority_districts;
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
@@ -33,7 +34,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Local Authority Districts
   <span slot="right">
@@ -58,7 +59,7 @@
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -76,7 +77,7 @@
       "line-width": 2.5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </GeoJSON>

--- a/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
+++ b/src/lib/browse/layers/areas/LocalPlanningAuthorities.svelte
@@ -16,17 +16,18 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "local_planning_authorities";
   let color = colors.local_planning_authorities;
 
-  let show = false;
+  let show = showHideLayer(name);
 
   // TODO Note there are overlapping features, so the tooltip may be incomplete
   // -- but can't we fix that now?
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Local Planning Authorities
   <span slot="right">
@@ -79,7 +80,7 @@
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -96,7 +97,7 @@
       "line-width": 2.5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </VectorTileSource>

--- a/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
+++ b/src/lib/browse/layers/areas/ParliamentaryConstituencies.svelte
@@ -17,11 +17,12 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "parliamentary_constituencies";
   let color = colors.parliamentary_constituencies;
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     // There are common suffixes that don't work with the search
@@ -38,7 +39,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Parliamentary constituencies
   <span slot="right">
@@ -66,7 +67,7 @@
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -85,7 +86,7 @@
       "line-width": 5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </VectorTileSource>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -4,7 +4,7 @@
   import { layerId } from "lib/maplibre";
   import { RasterLayer, RasterTileSource } from "svelte-maplibre";
   import OsOglLicense from "../OsOglLicense.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   type State = {
     show: boolean;
@@ -19,15 +19,15 @@
   function stringify(x: State): string | null {
     return x.show ? `${x.pollutant}/${x.opacity}` : null;
   }
-  function parse(result: string): State {
-    let [pollutant, opacity] = result.split("/");
+  function parse(x: string): State {
+    let [pollutant, opacity] = x.split("/");
     return {
       show: true,
       pollutant,
       opacity: parseInt(opacity),
     };
   }
-  let state = customUrl("pollution", defaultState, stringify, parse);
+  let state = customUrlState("pollution", defaultState, stringify, parse);
 
   // URLs and layers found from https://uk-air.defra.gov.uk/data/wms-services
   // and QGIS

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -40,6 +40,10 @@
     PM10Roads_viridis: ["22", "Data for 2022"],
   }[$state.pollutant];
 
+  // Changes to opacity shouldn't re-render the tile URL. Use this indirection
+  // (thanks to https://thoughtspile.github.io/2023/04/22/svelte-state/)
+  $: url = tilesUrl($state.pollutant);
+
   function wmsUrl(): string {
     return `https://ukair.maps.rcdo.co.uk/ukairserver/services/aq_amb_2022/${$state.pollutant}/MapServer/WMSServer`;
   }
@@ -122,7 +126,7 @@
   />
 {/if}
 
-<RasterTileSource tiles={[tilesUrl($state.pollutant)]} tileSize={256}>
+<RasterTileSource tiles={[url]} tileSize={256}>
   <RasterLayer
     {...layerId("pollution")}
     paint={{

--- a/src/lib/browse/layers/areas/RoadNoise.svelte
+++ b/src/lib/browse/layers/areas/RoadNoise.svelte
@@ -15,6 +15,7 @@
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "road_noise";
 
@@ -35,10 +36,10 @@
     colors.sequential_low_to_high[4],
   ];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Road noise
   <span slot="right">
     <HelpButton>
@@ -58,7 +59,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} limits={["55", "65", "75", ">"]} />
 {/if}
 
@@ -83,7 +84,7 @@
       "fill-opacity": hoverStateFilter(0.5, 0.8),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost

--- a/src/lib/browse/layers/areas/Wards.svelte
+++ b/src/lib/browse/layers/areas/Wards.svelte
@@ -21,7 +21,17 @@
   let name = "wards";
   let color = colors.wards;
 
-  let show = false;
+  let show = new URLSearchParams(window.location.search).has(name);
+  function updateURL(show: boolean) {
+    let url = new URL(window.location.href);
+    if (show) {
+      url.searchParams.set(name, "1");
+    } else {
+      url.searchParams.delete(name);
+    }
+    window.history.replaceState(null, "", url.toString());
+  }
+  $: updateURL(show);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     let name = encodeURIComponent(e.detail.features[0].properties!.name);

--- a/src/lib/browse/layers/areas/Wards.svelte
+++ b/src/lib/browse/layers/areas/Wards.svelte
@@ -17,21 +17,12 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "wards";
   let color = colors.wards;
 
-  let show = new URLSearchParams(window.location.search).has(name);
-  function updateURL(show: boolean) {
-    let url = new URL(window.location.href);
-    if (show) {
-      url.searchParams.set(name, "1");
-    } else {
-      url.searchParams.delete(name);
-    }
-    window.history.replaceState(null, "", url.toString());
-  }
-  $: updateURL(show);
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     let name = encodeURIComponent(e.detail.features[0].properties!.name);
@@ -40,7 +31,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Wards
   <span slot="right">
@@ -68,7 +59,7 @@
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost
@@ -87,7 +78,7 @@
       "line-width": 2.5,
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </VectorTileSource>

--- a/src/lib/browse/layers/lines/BusRoutes.svelte
+++ b/src/lib/browse/layers/lines/BusRoutes.svelte
@@ -15,13 +15,14 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "bus_routes";
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend color={colors.bus_route_with_lane} />
   Bus routes
   <span slot="right">
@@ -60,7 +61,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost

--- a/src/lib/browse/layers/lines/CyclePaths.svelte
+++ b/src/lib/browse/layers/lines/CyclePaths.svelte
@@ -16,12 +16,12 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import OsmLicense from "../OsmLicense.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   let name = "cycle_paths";
 
   type State = {
-    group: boolean;
+    show: boolean;
     track: boolean;
     lane: boolean;
     shared_use_segregated: boolean;
@@ -34,29 +34,26 @@
     "shared_use_unsegregated",
   ] as const;
   let defaultState = {
-    group: false,
+    show: false,
     track: true,
     lane: true,
     shared_use_segregated: true,
     shared_use_unsegregated: true,
   };
   function stringify(x: State): string | null {
-    if (!x.group) {
-      return null;
-    }
-    return keys.filter((c) => x[c]).join(",");
+    return x.show ? keys.filter((c) => x[c]).join(",") : null;
   }
-  function parse(result: string): State {
+  function parse(x: string): State {
     return {
-      group: true,
-      track: result.includes("track"),
-      lane: result.includes("lane"),
-      shared_use_segregated: result.includes("shared_use_segregated"),
-      shared_use_unsegregated: result.includes("shared_use_unsegregated"),
+      show: true,
+      track: x.includes("track"),
+      lane: x.includes("lane"),
+      shared_use_segregated: x.includes("shared_use_segregated"),
+      shared_use_unsegregated: x.includes("shared_use_unsegregated"),
     };
   }
 
-  let state = customUrl(name, defaultState, stringify, parse);
+  let state = customUrlState(name, defaultState, stringify, parse);
 
   let legend = [
     ["track", "Separated tracks", colors.cycle_paths.track],
@@ -104,7 +101,7 @@
   }
 </script>
 
-<Checkbox bind:checked={$state.group}>
+<Checkbox bind:checked={$state.show}>
   Cycle paths
   <span slot="right">
     <HelpButton>
@@ -142,7 +139,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if $state.group}
+{#if $state.show}
   <div style="border: 1px solid black; padding: 8px;">
     <CheckboxGroup>
       {#each legend as [kind, label, color]}
@@ -176,7 +173,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: $state.group ? "visible" : "none",
+      visibility: $state.show ? "visible" : "none",
     }}
     filter={makeFilter($state)}
     manageHoverState

--- a/src/lib/browse/layers/lines/CyclePaths.svelte
+++ b/src/lib/browse/layers/lines/CyclePaths.svelte
@@ -97,7 +97,7 @@
 
   function makeFilter(state: State): ExpressionSpecification {
     let include = keys.filter((l) => state[l]);
-    return ["in", ["get", "type"], ["literal", include]];
+    return ["in", ["get", "kind"], ["literal", include]];
   }
 </script>
 

--- a/src/lib/browse/layers/lines/Gradients.svelte
+++ b/src/lib/browse/layers/lines/Gradients.svelte
@@ -17,15 +17,16 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "gradient";
   let colorScale = colors.gradient_flat_to_steep;
   let limits = [0, 3, 5, 8, 10, 20, 100];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Gradients
   <span slot="right">
     <HelpButton>
@@ -50,7 +51,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} {limits} />
 {/if}
 
@@ -72,7 +73,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>
@@ -95,7 +96,7 @@
       "symbol-spacing": 50,
       "icon-allow-overlap": true,
       "icon-rotate": ["case", ["<", ["get", "gradient"], 0], 180, 0],
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   />
 </VectorTileSource>

--- a/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
+++ b/src/lib/browse/layers/lines/MajorRoadNetwork.svelte
@@ -15,14 +15,15 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "mrn";
   let color = colors.mrn;
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Major Road Network
   <span slot="right">
@@ -53,7 +54,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/lines/NationalCycleNetwork.svelte
+++ b/src/lib/browse/layers/lines/NationalCycleNetwork.svelte
@@ -15,14 +15,15 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "national_cycle_network";
   let color = colors.national_cycle_network;
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   National Cycle Network
   <span slot="right">
@@ -53,7 +54,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/lines/PCT.svelte
+++ b/src/lib/browse/layers/lines/PCT.svelte
@@ -14,7 +14,7 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   // TODO It'd be much simpler to have one source with both attributes
   let nameCommute = "pct_commute";
@@ -33,20 +33,17 @@
     scenario: "baseline",
   };
   function stringify(x: State): string | null {
-    if (!x.show) {
-      return null;
-    }
-    return `${x.tripPurpose}/${x.scenario}`;
+    return x.show ? `${x.tripPurpose}/${x.scenario}` : null;
   }
-  function parse(result: string): State {
-    let [tripPurpose, scenario] = result.split("/");
+  function parse(x: string): State {
+    let [tripPurpose, scenario] = x.split("/");
     return {
       show: true,
       tripPurpose,
       scenario,
     };
   }
-  let state = customUrl("pct", defaultState, stringify, parse);
+  let state = customUrlState("pct", defaultState, stringify, parse);
 
   // TODO Don't use a function and @html; do everything in Svelte?
   function tooltip(props: { [name: string]: any }): string {

--- a/src/lib/browse/layers/lines/PavementWidths.svelte
+++ b/src/lib/browse/layers/lines/PavementWidths.svelte
@@ -14,12 +14,13 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "pavement_widths";
   let colorScale = colors.sequential_low_to_high;
   let limits = [0, 2, 4, 6, 8, 13];
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function direction(angle: number): string {
     // 0 degrees is directly north. Split 360 into 8 pieces: 45 degrees. Shift
@@ -35,7 +36,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   OS Pavement widths
   <span slot="right">
     <HelpButton>
@@ -65,7 +66,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} {limits} />
 {/if}
 
@@ -92,7 +93,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props openOn="hover">

--- a/src/lib/browse/layers/lines/RoadSpeeds.svelte
+++ b/src/lib/browse/layers/lines/RoadSpeeds.svelte
@@ -14,14 +14,33 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { customUrl } from "../url";
 
   let name = "road_speeds";
   let colorScale = colors.sequential_low_to_high;
   let limits = [0, 20, 30, 40, 50, 90];
 
-  let showSpeed = "indicative_mph";
-
-  let show = false;
+  type State = {
+    show: boolean;
+    kind: string;
+  };
+  let defaultState = {
+    show: false,
+    kind: "indicative_mph",
+  };
+  function stringify(x: State): string | null {
+    if (!x.show) {
+      return null;
+    }
+    return x.kind;
+  }
+  function parse(result: string): State {
+    return {
+      show: true,
+      kind: result,
+    };
+  }
+  let state = customUrl(name, defaultState, stringify, parse);
 
   let times: Record<string, string> = {
     mf4to7: "Monday-Friday 4-7am",
@@ -41,7 +60,7 @@
   };
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$state.show}>
   OS Speeds
   <span slot="right">
     <HelpButton>
@@ -66,7 +85,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $state.show}
   <SequentialLegend {colorScale} {limits} />
   <Radio
     legend="Show speed types"
@@ -74,7 +93,7 @@
       ["indicative_mph", "Posted speed limit"],
       ["highest_mph", "Highest measured average speed"],
     ]}
-    bind:value={showSpeed}
+    bind:value={$state.kind}
     inlineSmall
   />
 {/if}
@@ -88,12 +107,12 @@
     manageHoverState
     eventsIfTopMost
     paint={{
-      "line-color": makeColorRamp(["get", showSpeed], limits, colorScale),
+      "line-color": makeColorRamp(["get", $state.kind], limits, colorScale),
       "line-width": denseLineWidth,
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $state.show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/lines/RoadSpeeds.svelte
+++ b/src/lib/browse/layers/lines/RoadSpeeds.svelte
@@ -14,7 +14,7 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   let name = "road_speeds";
   let colorScale = colors.sequential_low_to_high;
@@ -29,18 +29,15 @@
     kind: "indicative_mph",
   };
   function stringify(x: State): string | null {
-    if (!x.show) {
-      return null;
-    }
-    return x.kind;
+    return x.show ? x.kind : null;
   }
-  function parse(result: string): State {
+  function parse(x: string): State {
     return {
       show: true,
-      kind: result,
+      kind: x,
     };
   }
-  let state = customUrl(name, defaultState, stringify, parse);
+  let state = customUrlState(name, defaultState, stringify, parse);
 
   let times: Record<string, string> = {
     mf4to7: "Monday-Friday 4-7am",

--- a/src/lib/browse/layers/lines/RoadWidths.svelte
+++ b/src/lib/browse/layers/lines/RoadWidths.svelte
@@ -14,15 +14,16 @@
   } from "svelte-maplibre";
   import { colors, denseLineWidth } from "../../colors";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "road_widths";
   let colorScale = colors.sequential_low_to_high;
   let limits = [0, 5, 10, 15, 20, 100];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   OS Road widths
   <span slot="right">
     <HelpButton>
@@ -44,7 +45,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} {limits} />
 {/if}
 
@@ -63,7 +64,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/lines/StrategicRoadNetwork.svelte
+++ b/src/lib/browse/layers/lines/StrategicRoadNetwork.svelte
@@ -15,14 +15,15 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "srn";
   let color = colors.srn;
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   Strategic Road Network
   <span slot="right">
@@ -54,7 +55,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/lines/Trams.svelte
+++ b/src/lib/browse/layers/lines/Trams.svelte
@@ -10,10 +10,11 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "trams";
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
@@ -23,7 +24,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend color={colors.trams} />
   Trams
   <span slot="right">
@@ -50,7 +51,7 @@
       "line-opacity": hoverStateFilter(1.0, 0.5),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost

--- a/src/lib/browse/layers/points/BusStops.svelte
+++ b/src/lib/browse/layers/points/BusStops.svelte
@@ -11,16 +11,17 @@
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "bus_stops";
 
   let colorScale = colors.sequential_low_to_high;
   let limits = [0, 3, 10, 20, 30, 100];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Bus stops
   <span slot="right">
     <HelpButton>
@@ -44,7 +45,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <p>Peak hourly frequency:</p>
   <SequentialLegend {colorScale} {limits} />
 {/if}
@@ -70,7 +71,7 @@
       ],
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost

--- a/src/lib/browse/layers/points/Crossings.svelte
+++ b/src/lib/browse/layers/points/Crossings.svelte
@@ -15,10 +15,11 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "crossings";
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function tooltip(props: { [name: string]: any }): string {
     let descriptions: Record<string, string> = {
@@ -53,7 +54,7 @@
   ];
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Crossings
   <span slot="right">
     <HelpButton>
@@ -68,7 +69,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <Legend rows={legend} />
 {/if}
 
@@ -99,7 +100,7 @@
       ],
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     hoverCursor="pointer"
     eventsIfTopMost

--- a/src/lib/browse/layers/points/CycleParking.svelte
+++ b/src/lib/browse/layers/points/CycleParking.svelte
@@ -10,13 +10,14 @@
   import { SymbolLayer, VectorTileSource } from "svelte-maplibre";
   import cycleParking from "../../../../../assets/bicycle_parking.png?url";
   import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "cycle_parking";
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <img src={cycleParking} alt="a logo representing cycle parking" />
   Cycle parking
   <span slot="right">
@@ -51,7 +52,7 @@
       "icon-image": "cycle_parking",
       "icon-size": 1.0,
       "icon-allow-overlap": true,
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/points/Education.svelte
+++ b/src/lib/browse/layers/points/Education.svelte
@@ -15,39 +15,36 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsmLicense from "../OsmLicense.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   let name = "education";
 
   type State = {
-    group: boolean;
+    show: boolean;
     school: boolean;
     college: boolean;
     university: boolean;
   };
   let keys = ["school", "college", "university"] as const;
   let defaultState = {
-    group: false,
+    show: false,
     school: true,
     college: true,
     university: true,
   };
   function stringify(x: State): string | null {
-    if (!x.group) {
-      return null;
-    }
-    return keys.filter((c) => x[c]).join(",");
+    return x.show ? keys.filter((c) => x[c]).join(",") : null;
   }
-  function parse(result: string): State {
+  function parse(x: string): State {
     return {
-      group: true,
-      school: result.includes("school"),
-      college: result.includes("college"),
-      university: result.includes("university"),
+      show: true,
+      school: x.includes("school"),
+      college: x.includes("college"),
+      university: x.includes("university"),
     };
   }
 
-  let state = customUrl(name, defaultState, stringify, parse);
+  let state = customUrlState(name, defaultState, stringify, parse);
 
   function makeFilter(state: State): ExpressionSpecification {
     let include = keys.filter((l) => state[l]);
@@ -55,7 +52,7 @@
   }
 </script>
 
-<Checkbox bind:checked={$state.group}>
+<Checkbox bind:checked={$state.show}>
   Education
   <span slot="right">
     <HelpButton>
@@ -67,7 +64,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if $state.group}
+{#if $state.show}
   <div style="border: 1px solid black; padding: 8px;">
     <CheckboxGroup>
       <Checkbox bind:checked={$state.school}>
@@ -105,7 +102,7 @@
       "fill-opacity": hoverStateFilter(0.7, 1.0),
     }}
     layout={{
-      visibility: $state.group ? "visible" : "none",
+      visibility: $state.show ? "visible" : "none",
     }}
     filter={makeFilter($state)}
     manageHoverState

--- a/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
+++ b/src/lib/browse/layers/points/PolygonAmenityLayerControl.svelte
@@ -13,6 +13,7 @@
     VectorTileSource,
   } from "svelte-maplibre";
   import { colors } from "../../colors";
+  import { showHideLayer } from "../url";
 
   // This name is used for multiple things:
   // - The name of a .pmtiles file
@@ -30,10 +31,10 @@
   // @ts-ignore TODO Also constrain name to exist in the colors type
   let color = colors[name];
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <ColorLegend {color} />
   {pluralNoun}
   <span slot="right">
@@ -52,7 +53,7 @@
       "fill-opacity": hoverStateFilter(0.7, 1.0),
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     manageHoverState
     eventsIfTopMost

--- a/src/lib/browse/layers/points/RailwayStations.svelte
+++ b/src/lib/browse/layers/points/RailwayStations.svelte
@@ -10,13 +10,14 @@
   import { GeoJSON, SymbolLayer } from "svelte-maplibre";
   import railwayStation from "../../../../../assets/railway_station.png?url";
   import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "railway_stations";
 
-  let show = false;
+  let show = showHideLayer(name);
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   <img src={railwayStation} alt="A logo representing a train" />
   Railway Stations
   <span slot="right">
@@ -45,7 +46,7 @@
       "icon-image": "railway_station",
       "icon-size": 1,
       "icon-allow-overlap": true,
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
   >
     <Popup let:props>

--- a/src/lib/browse/layers/points/Stats19.svelte
+++ b/src/lib/browse/layers/points/Stats19.svelte
@@ -16,7 +16,7 @@
   } from "svelte-maplibre";
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
-  import { customUrl } from "../url";
+  import { customUrlState } from "../url";
 
   let name = "stats19";
 
@@ -46,8 +46,8 @@
     let bools = keys.filter((c) => x[c]).join(",");
     return `${bools}/${x.minYear}/${x.maxYear}`;
   }
-  function parse(result: string): State {
-    let [bools, minYear, maxYear] = result.split("/");
+  function parse(x: string): State {
+    let [bools, minYear, maxYear] = x.split("/");
     return {
       show: true,
       pedestrians: bools.includes("pedestrians"),
@@ -59,7 +59,7 @@
     };
   }
 
-  let state = customUrl(name, defaultState, stringify, parse);
+  let state = customUrlState(name, defaultState, stringify, parse);
 
   $: filter = makeFilter(
     $state.minYear,

--- a/src/lib/browse/layers/points/VehicleCounts.svelte
+++ b/src/lib/browse/layers/points/VehicleCounts.svelte
@@ -15,6 +15,7 @@
   import { colors } from "../../colors";
   import OsOglLicense from "../OsOglLicense.svelte";
   import SequentialLegend from "../SequentialLegend.svelte";
+  import { showHideLayer } from "../url";
 
   let name = "vehicle_counts";
 
@@ -24,7 +25,7 @@
   // Remove some because there's not much width
   let describeLimits = ["", "40k", "80k", "120k", "160k", ""];
 
-  let show = false;
+  let show = showHideLayer(name);
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
@@ -36,7 +37,7 @@
   }
 </script>
 
-<Checkbox bind:checked={show}>
+<Checkbox bind:checked={$show}>
   Vehicle counts
   <span slot="right">
     <HelpButton>
@@ -63,7 +64,7 @@
     </HelpButton>
   </span>
 </Checkbox>
-{#if show}
+{#if $show}
   <SequentialLegend {colorScale} limits={describeLimits} />
 {/if}
 
@@ -104,7 +105,7 @@
       ],
     }}
     layout={{
-      visibility: show ? "visible" : "none",
+      visibility: $show ? "visible" : "none",
     }}
     hoverCursor="pointer"
     eventsIfTopMost

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -15,3 +15,26 @@ export function showHideLayer(name: string): Writable<boolean> {
   });
   return store;
 }
+
+export function customUrl<T>(
+  name: string,
+  defaultValue: T,
+  stringify: (x: T) => string | null,
+  parse: (x: string) => T,
+): Writable<T> {
+  let param = new URLSearchParams(window.location.search).get(name);
+  let initialValue = param == null ? defaultValue : parse(param);
+  let store = writable(initialValue);
+  // TODO How do we avoid leaking this?
+  store.subscribe((state) => {
+    let url = new URL(window.location.href);
+    let value = stringify(state);
+    if (value == null) {
+      url.searchParams.delete(name);
+    } else {
+      url.searchParams.set(name, value);
+    }
+    window.history.replaceState(null, "", url.toString());
+  });
+  return store;
+}

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -27,8 +27,18 @@ export function customUrlState<T>(
   stringify: (state: T) => string | null,
   parse: (param: string) => T,
 ): Writable<T> {
+  let initialValue = defaultValue;
   let param = new URLSearchParams(window.location.search).get(name);
-  let initialValue = param == null ? defaultValue : parse(param);
+  if (param != null) {
+    try {
+      initialValue = parse(param);
+    } catch (err) {
+      console.warn(
+        `Parsing URL parameter ${name}=${param} failed, using default value: ${err}`,
+      );
+    }
+  }
+
   let store = writable(initialValue);
   // TODO How do we avoid leaking this?
   store.subscribe((state) => {

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -1,5 +1,7 @@
 import { writable, type Writable } from "svelte/store";
 
+// Create a store to represent whether a layer should be shown or hidden. The
+// state is synced as a URL query parameter.
 export function showHideLayer(name: string): Writable<boolean> {
   let initialValue = new URLSearchParams(window.location.search).has(name);
   let store = writable(initialValue);
@@ -16,11 +18,14 @@ export function showHideLayer(name: string): Writable<boolean> {
   return store;
 }
 
-export function customUrl<T>(
+// Create a store to represent some state about a layer, syncing it to a URL
+// query parameter. The parameter missing is equivalent to stringify returning
+// null.
+export function customUrlState<T>(
   name: string,
   defaultValue: T,
-  stringify: (x: T) => string | null,
-  parse: (x: string) => T,
+  stringify: (state: T) => string | null,
+  parse: (param: string) => T,
 ): Writable<T> {
   let param = new URLSearchParams(window.location.search).get(name);
   let initialValue = param == null ? defaultValue : parse(param);

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -1,0 +1,17 @@
+import { writable, type Writable } from "svelte/store";
+
+export function showHideLayer(name: string): Writable<boolean> {
+  let initialValue = new URLSearchParams(window.location.search).has(name);
+  let store = writable(initialValue);
+  // TODO How do we avoid leaking this?
+  store.subscribe((show) => {
+    let url = new URL(window.location.href);
+    if (show) {
+      url.searchParams.set(name, "1");
+    } else {
+      url.searchParams.delete(name);
+    }
+    window.history.replaceState(null, "", url.toString());
+  });
+  return store;
+}


### PR DESCRIPTION
Demo: https://acteng.github.io/atip/browse_layer_urls/browse.html?style=dataviz&crossings=1&stats19=other%2F2019%2F2022&road_noise=1#5.69/53.021/-1.825

This syncs up the state of browse layers with URL query parameters. This makes URLs much more reproducible/shareable, and is a step towards linking directly to the browse page (or embedding in an iframe?) from route check.

Note:
- If someone changes the URL, there's a full page refresh. We could squeeze everything into the URL fragment if we wanted to change this, but I don't think there's a use case for it
- No change for the critical issues layer, because that requires a custom file input
- We can't use a single query param (like `layers=x,y,z`) because some layers have more details
- The URL as it is now isn't quite reproducible, because the camera viewport gets ignored. That was a choice made because of a bug in svelte-maplibre that's now fixed, so I'll followup separately and fix on all pages