### PR TITLE
Improve browse page loading experience

### DIFF
--- a/src/lib/browse/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/LoadRemoteSchemeData.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+  import { SecondaryButton } from "govuk-svelte";
   import { fetchWithProgress, privateResourceBaseUrl } from "lib/common";
   // means setProgress may get percentages over 100.
   import { onMount } from "svelte";
 
   export let loadFile: (text: string) => void;
 
+  let shouldLoad = !new URLSearchParams(window.location.search).has(
+    "disable_schemes",
+  );
   let loading = true;
   let progress = 0;
 
-  onMount(async () => {
+  async function loadData() {
     let bytes = await fetchWithProgress(
       `${privateResourceBaseUrl()}/v1/all_schemes_output.geojson.gz`,
       (p) => {
@@ -19,10 +23,25 @@
     let text = new TextDecoder().decode(bytes);
     loadFile(text);
     loading = false;
+  }
+
+  onMount(async () => {
+    if (shouldLoad) {
+      await loadData();
+    }
   });
+
+  async function loadDataManually() {
+    shouldLoad = true;
+    await loadData();
+  }
 </script>
 
-{#if loading}
+{#if !shouldLoad}
+  <SecondaryButton on:click={loadDataManually}>
+    Load latest scheme data
+  </SecondaryButton>
+{:else if loading}
   {#if progress <= 100}
     <label>
       Downloading scheme data

--- a/src/lib/browse/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/LoadRemoteSchemeData.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { SecondaryButton } from "govuk-svelte";
   import { fetchWithProgress, privateResourceBaseUrl } from "lib/common";
-  // means setProgress may get percentages over 100.
   import { onMount } from "svelte";
 
   export let loadFile: (text: string) => void;

--- a/src/lib/browse/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/LoadRemoteSchemeData.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { privateResourceBaseUrl } from "lib/common";
+  import { fetchWithProgress, privateResourceBaseUrl } from "lib/common";
+  // means setProgress may get percentages over 100.
   import { onMount } from "svelte";
 
   export let loadFile: (text: string) => void;
@@ -10,50 +11,15 @@
   onMount(async () => {
     let bytes = await fetchWithProgress(
       `${privateResourceBaseUrl()}/v1/all_schemes_output.geojson.gz`,
+      (p) => {
+        progress = p;
+      },
     );
     progress = 100;
     let text = new TextDecoder().decode(bytes);
     loadFile(text);
     loading = false;
   });
-
-  // This requires the server to send back a Content-Length header. The actual
-  // bytes received may exceed this length (when the file is compressed), which
-  // means setProgress may get percentages over 100.
-  async function fetchWithProgress(url: string): Promise<Uint8Array> {
-    const response = await fetch(url);
-    // TODO Handle error cases better
-    const reader = response.body!.getReader();
-
-    let lengthHeader = response.headers.get("Content-Length");
-    if (!lengthHeader) {
-      throw new Error(`No Content-Length header from ${url}`);
-    }
-    const contentLength = parseInt(lengthHeader);
-
-    let receivedLength = 0;
-    let chunks = [];
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-
-      chunks.push(value);
-      receivedLength += value.length;
-
-      progress = (100.0 * receivedLength) / contentLength;
-    }
-
-    let allChunks = new Uint8Array(receivedLength);
-    let position = 0;
-    for (let chunk of chunks) {
-      allChunks.set(chunk, position);
-      position += chunk.length;
-    }
-
-    return allChunks;
-  }
 </script>
 
 {#if loading}

--- a/src/lib/browse/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/LoadRemoteSchemeData.svelte
@@ -5,17 +5,73 @@
   export let loadFile: (text: string) => void;
 
   let loading = true;
+  let progress = 0;
 
   onMount(async () => {
-    let resp = await fetch(
+    let bytes = await fetchWithProgress(
       `${privateResourceBaseUrl()}/v1/all_schemes_output.geojson.gz`,
     );
-    let text = await resp.text();
+    progress = 100;
+    let text = new TextDecoder().decode(bytes);
     loadFile(text);
     loading = false;
   });
+
+  // This requires the server to send back a Content-Length header. The actual
+  // bytes received may exceed this length (when the file is compressed), which
+  // means setProgress may get percentages over 100.
+  async function fetchWithProgress(url: string): Promise<Uint8Array> {
+    const response = await fetch(url);
+    // TODO Handle error cases better
+    const reader = response.body!.getReader();
+
+    let lengthHeader = response.headers.get("Content-Length");
+    if (!lengthHeader) {
+      throw new Error(`No Content-Length header from ${url}`);
+    }
+    const contentLength = parseInt(lengthHeader);
+
+    let receivedLength = 0;
+    let chunks = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      chunks.push(value);
+      receivedLength += value.length;
+
+      progress = (100.0 * receivedLength) / contentLength;
+    }
+
+    let allChunks = new Uint8Array(receivedLength);
+    let position = 0;
+    for (let chunk of chunks) {
+      allChunks.set(chunk, position);
+      position += chunk.length;
+    }
+
+    return allChunks;
+  }
 </script>
 
 {#if loading}
-  <p>Loading scheme data...</p>
+  {#if progress <= 100}
+    <label>
+      Downloading scheme data
+      <progress value={progress} />
+    </label>
+  {:else}
+    <label>
+      Processing scheme data
+      <progress />
+    </label>
+  {/if}
 {/if}
+
+<style>
+  progress {
+    width: 100%;
+  }
+</style>

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -50,6 +50,47 @@ export function appVersion(): string {
   return "Unknown";
 }
 
+// Fetch a URL and return bytes. Along the way, calls setProgress with a number [0, 100] -- but sometimes over 100 when the file is compressed. This function will throw if the server doesn't send back a Content-Length header.
+export async function fetchWithProgress(
+  url: string,
+  setProgress: (progress: number) => void,
+): Promise<Uint8Array> {
+  let response = await fetch(url);
+  // TODO Handle error cases better
+  let reader = response.body!.getReader();
+
+  let lengthHeader = response.headers.get("Content-Length");
+  if (!lengthHeader) {
+    throw new Error(`No Content-Length header from ${url}`);
+  }
+  let contentLength = parseInt(lengthHeader);
+
+  let receivedLength = 0;
+  let chunks = [];
+  while (true) {
+    let { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    if (value) {
+      chunks.push(value);
+      receivedLength += value.length;
+
+      setProgress((100.0 * receivedLength) / contentLength);
+    }
+  }
+
+  let allChunks = new Uint8Array(receivedLength);
+  let position = 0;
+  for (let chunk of chunks) {
+    allChunks.set(chunk, position);
+    position += chunk.length;
+  }
+
+  return allChunks;
+}
+
 // See .env
 export function publicResourceBaseUrl(): string {
   if (import.meta.env.VITE_RESOURCE_BASE) {

--- a/src/lib/draw/route/RouteSnapperLoader.svelte
+++ b/src/lib/draw/route/RouteSnapperLoader.svelte
@@ -33,7 +33,7 @@
   // This requires the server to send back a Content-Length header. The actual
   // bytes received may exceed this length (when the file is compressed), which
   // means setProgress may get percentages over 100.
-  async function fetchWithProgress(url: string) {
+  async function fetchWithProgress(url: string): Promise<Uint8Array> {
     const response = await fetch(url);
     // TODO Handle error cases better
     const reader = response.body!.getReader();


### PR DESCRIPTION
1) Add a progress bar to the browse page
2) Add a URL parameter `disable_schemes=1` to not do this automatically, for later use in inspectorate tools

I had to use https://www.danvega.dev/blog/network-throttling#chrome-devtools to test the progress bars, but if you have access to naturally slow internet, even easier ;)

Demo of second feature: https://acteng.github.io/atip/pipeline/browse.html?disable_schemes=1