### PR TITLE
Start refactoring scheme sketcher code, before moving to a library

### DIFF
--- a/src/lib/draw/EditGeometryMode.svelte
+++ b/src/lib/draw/EditGeometryMode.svelte
@@ -10,7 +10,6 @@
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
   import { cfg } from "./config";
-  import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { FeatureUnion } from "types";
   import PointControls from "./point/PointControls.svelte";
@@ -129,17 +128,7 @@
     if (source.properties.waypoints) {
       destination.properties.waypoints = source.properties.waypoints;
     }
-    // Only copy route_name if the user hasn't set it. It's not simple to
-    // distinguish the user manually editing the name from it being auto-filled
-    // previously, so be safe and don't overwrite anything. The user can always
-    // use the auto-fill button explicitly.
-    if (
-      source.properties.route_name &&
-      !destination.properties.name &&
-      $schema != "pipeline"
-    ) {
-      destination.properties.name = source.properties.route_name;
-    }
+    cfg.updateFeature(destination, source);
   }
 
   function finish() {

--- a/src/lib/draw/EditGeometryMode.svelte
+++ b/src/lib/draw/EditGeometryMode.svelte
@@ -8,8 +8,8 @@
     routeTool,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/maplibre";
-  import { cfg } from "./config";
+  import type { FeatureWithProps } from "lib/draw/types";
+  import { cfg } from "lib/draw/config";
   import { onDestroy, onMount } from "svelte";
   import type { FeatureUnion } from "types";
   import PointControls from "./point/PointControls.svelte";

--- a/src/lib/draw/EditGeometryMode.svelte
+++ b/src/lib/draw/EditGeometryMode.svelte
@@ -9,7 +9,7 @@
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { interventionName } from "lib/sidebar/scheme_data";
+  import { cfg } from "./config";
   import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { FeatureUnion } from "types";
@@ -37,7 +37,7 @@
       return gj;
     });
     let feature = maybeFeature!;
-    name = interventionName(feature);
+    name = cfg.interventionName(feature);
 
     if (feature.geometry.type == "LineString") {
       $routeTool?.editExistingRoute(

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -26,7 +26,8 @@
     Popup,
     type LayerClickInfo,
   } from "svelte-maplibre";
-  import type { FeatureUnion, SchemeCollection } from "types";
+  import type { SchemeCollection } from "types";
+  import type { FeatureWithAnyProps } from "lib/draw/types";
 
   $: gj = addLineStringEndpoints($gjSchemeCollection);
 
@@ -108,7 +109,7 @@
 
   function tooltip(features: Feature[] | null): string {
     if (features) {
-      let feature = features[0] as FeatureUnion;
+      let feature = features[0] as FeatureWithAnyProps;
       let name = cfg.interventionName(feature);
       let scheme =
         $gjSchemeCollection.schemes[feature.properties.scheme_reference]

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -12,7 +12,7 @@
     isPolygon,
     layerId,
   } from "lib/maplibre";
-  import { interventionName } from "lib/sidebar/scheme_data";
+  import { cfg } from "./config";
   import type {
     DataDrivenPropertyValueSpecification,
     ExpressionSpecification,
@@ -109,7 +109,7 @@
   function tooltip(features: Feature[] | null): string {
     if (features) {
       let feature = features[0] as FeatureUnion;
-      let name = interventionName(feature);
+      let name = cfg.interventionName(feature);
       let scheme =
         $gjSchemeCollection.schemes[feature.properties.scheme_reference]
           .scheme_name ?? "Untitled scheme";

--- a/src/lib/draw/InterventionLayer.svelte
+++ b/src/lib/draw/InterventionLayer.svelte
@@ -12,7 +12,7 @@
     isPolygon,
     layerId,
   } from "lib/maplibre";
-  import { cfg } from "./config";
+  import { cfg } from "lib/draw/config";
   import type {
     DataDrivenPropertyValueSpecification,
     ExpressionSpecification,

--- a/src/lib/draw/config.ts
+++ b/src/lib/draw/config.ts
@@ -1,0 +1,12 @@
+import type { FeatureUnion } from "types";
+import { interventionName } from "lib/sidebar/scheme_data";
+
+// The draw code should be agnostic to the feature properties that differ by
+// schema. Start centralizing the logic here, so it's easy for other users to
+// override.
+
+export let cfg = {
+  interventionName: (feature: FeatureUnion) => {
+    return interventionName(feature);
+  },
+};

--- a/src/lib/draw/config.ts
+++ b/src/lib/draw/config.ts
@@ -1,5 +1,5 @@
 import type { FeatureUnion } from "types";
-import type { FeatureWithProps } from "lib/maplibre";
+import type { FeatureWithProps } from "lib/draw/types";
 import type { LineString, Polygon, Point } from "geojson";
 import { interventionName } from "lib/sidebar/scheme_data";
 import { schema } from "stores";

--- a/src/lib/draw/config.ts
+++ b/src/lib/draw/config.ts
@@ -1,12 +1,52 @@
 import type { FeatureUnion } from "types";
+import type { FeatureWithProps } from "lib/maplibre";
+import type { LineString, Polygon, Point } from "geojson";
 import { interventionName } from "lib/sidebar/scheme_data";
+import { schema } from "stores";
+import { get } from "svelte/store";
 
 // The draw code should be agnostic to the feature properties that differ by
 // schema. Start centralizing the logic here, so it's easy for other users to
 // override.
 
 export let cfg = {
-  interventionName: (feature: FeatureUnion) => {
-    return interventionName(feature);
+  interventionName: (f: FeatureUnion) => {
+    return interventionName(f);
+  },
+
+  newPointFeature: (f: FeatureWithProps<Point>) => {
+    f.properties.intervention_type = "other";
+  },
+
+  newPolygonFeature: (f: FeatureWithProps<Polygon>) => {
+    f.properties.intervention_type = "area";
+    f.properties.is_coverage_polygon = false;
+  },
+
+  newLineStringFeature: (f: FeatureWithProps<LineString | Polygon>) => {
+    f.properties.intervention_type = "route";
+    if (f.properties.route_name) {
+      if (get(schema) != "pipeline") {
+        f.properties.name = f.properties.route_name;
+      }
+      delete f.properties.route_name;
+    }
+  },
+
+  updateFeature: (
+    destination: FeatureUnion,
+    source: FeatureWithProps<Point | LineString | Polygon>,
+  ) => {
+    // Only copy route_name if the user hasn't set it. It's not simple to
+    // distinguish the user manually editing the name from it being auto-filled
+    // previously, so be safe and don't overwrite anything. The user can always
+    // use the auto-fill button explicitly.
+    if (
+      source.properties.route_name &&
+      !destination.properties.name &&
+      get(schema) != "pipeline"
+    ) {
+      destination.properties.name = source.properties.route_name;
+    }
   },
 };

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -8,11 +8,11 @@
     getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/maplibre";
+  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PointControls from "./PointControls.svelte";
-  import { cfg } from "../config";
+  import { cfg } from "lib/draw/config";
 
   onMount(() => {
     $pointTool!.start();

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -12,6 +12,7 @@
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PointControls from "./PointControls.svelte";
+  import { cfg } from "../config";
 
   onMount(() => {
     $pointTool!.start();
@@ -27,7 +28,7 @@
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
       feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      feature.properties.intervention_type = "other";
+      cfg.newPointFeature(feature);
       gj.features.push(feature as Feature<Point>);
       return gj;
     });

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-  import type { Point } from "geojson";
-  import {
-    gjSchemeCollection,
-    mode,
-    newFeatureId,
-    pointTool,
-    getArbitrarySchemeRef,
-  } from "lib/draw/stores";
+  import type { Feature, Point } from "geojson";
+  import { mode, pointTool } from "lib/draw/stores";
   import { SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
-  import type { Feature } from "types";
   import PointControls from "./PointControls.svelte";
   import { cfg } from "lib/draw/config";
 
@@ -24,15 +16,8 @@
     $pointTool!.clearEventListeners();
   });
 
-  function onSuccess(feature: FeatureWithProps<Point>) {
-    gjSchemeCollection.update((gj) => {
-      feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      cfg.newPointFeature(feature);
-      gj.features.push(feature as Feature<Point>);
-      return gj;
-    });
-
+  function onSuccess(feature: Feature<Point>) {
+    cfg.newPointFeature(feature);
     mode.set({ mode: "edit-form", id: feature.id as number });
   }
 

--- a/src/lib/draw/point/PointMode.svelte
+++ b/src/lib/draw/point/PointMode.svelte
@@ -5,10 +5,10 @@
     mode,
     newFeatureId,
     pointTool,
+    getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PointControls from "./PointControls.svelte";
@@ -26,8 +26,7 @@
   function onSuccess(feature: FeatureWithProps<Point>) {
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference =
-        getArbitraryScheme(gj).scheme_reference;
+      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
       feature.properties.intervention_type = "other";
       gj.features.push(feature as Feature<Point>);
       return gj;

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -1,15 +1,13 @@
-import type { Point } from "geojson";
-import type { FeatureWithProps } from "lib/draw/types";
+import type { Feature, Point } from "geojson";
 import { setPrecision } from "lib/draw/stores";
 import type { Map, MapMouseEvent } from "maplibre-gl";
 
-// Note this uses the geojson FeatureWithProps, not our specialization in types.ts
 export class PointTool {
   map: Map;
   active: boolean;
-  eventListenersSuccess: ((f: FeatureWithProps<Point>) => void)[];
+  eventListenersSuccess: ((f: Feature<Point>) => void)[];
   eventListenersFailure: (() => void)[];
-  cursor: FeatureWithProps<Point> | null;
+  cursor: Feature<Point> | null;
 
   onMouseMove = (e: MapMouseEvent) => {
     if (this.active) {
@@ -70,7 +68,7 @@ export class PointTool {
     this.stop();
   }
 
-  addEventListenerSuccess(callback: (f: FeatureWithProps<Point>) => void) {
+  addEventListenerSuccess(callback: (f: Feature<Point>) => void) {
     this.eventListenersSuccess.push(callback);
   }
   addEventListenerFailure(callback: () => void) {

--- a/src/lib/draw/point/point_tool.ts
+++ b/src/lib/draw/point/point_tool.ts
@@ -1,5 +1,6 @@
 import type { Point } from "geojson";
-import { pointFeature, type FeatureWithProps } from "lib/maplibre";
+import type { FeatureWithProps } from "lib/draw/types";
+import { setPrecision } from "lib/draw/stores";
 import type { Map, MapMouseEvent } from "maplibre-gl";
 
 // Note this uses the geojson FeatureWithProps, not our specialization in types.ts
@@ -12,7 +13,14 @@ export class PointTool {
 
   onMouseMove = (e: MapMouseEvent) => {
     if (this.active) {
-      this.cursor = pointFeature(e.lngLat.toArray());
+      this.cursor = {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Point",
+          coordinates: setPrecision(e.lngLat.toArray()),
+        },
+      };
     }
   };
 

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-  import type { Polygon } from "geojson";
-  import {
-    gjSchemeCollection,
-    mode,
-    newFeatureId,
-    polygonTool,
-    getArbitrarySchemeRef,
-  } from "lib/draw/stores";
+  import type { Feature, Polygon } from "geojson";
+  import { mode, polygonTool } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
-  import type { Feature } from "types";
   import PolygonControls from "./PolygonControls.svelte";
   import { cfg } from "lib/draw/config";
 
@@ -24,15 +16,8 @@
     $polygonTool!.clearEventListeners();
   });
 
-  function onSuccess(feature: FeatureWithProps<Polygon>) {
-    gjSchemeCollection.update((gj) => {
-      feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      cfg.newPolygonFeature(feature);
-      gj.features.push(feature as Feature<Polygon>);
-      return gj;
-    });
-
+  function onSuccess(feature: Feature<Polygon>) {
+    cfg.newPolygonFeature(feature);
     mode.set({ mode: "edit-form", id: feature.id as number });
   }
 

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -12,6 +12,7 @@
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PolygonControls from "./PolygonControls.svelte";
+  import { cfg } from "../config";
 
   onMount(() => {
     $polygonTool!.startNew();
@@ -27,8 +28,7 @@
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
       feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      feature.properties.intervention_type = "area";
-      feature.properties.is_coverage_polygon = false;
+      cfg.newPolygonFeature(feature);
       gj.features.push(feature as Feature<Polygon>);
       return gj;
     });

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -8,11 +8,11 @@
     getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/maplibre";
+  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PolygonControls from "./PolygonControls.svelte";
-  import { cfg } from "../config";
+  import { cfg } from "lib/draw/config";
 
   onMount(() => {
     $polygonTool!.startNew();

--- a/src/lib/draw/polygon/PolygonMode.svelte
+++ b/src/lib/draw/polygon/PolygonMode.svelte
@@ -5,10 +5,10 @@
     mode,
     newFeatureId,
     polygonTool,
+    getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import PolygonControls from "./PolygonControls.svelte";
@@ -26,8 +26,7 @@
   function onSuccess(feature: FeatureWithProps<Polygon>) {
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference =
-        getArbitraryScheme(gj).scheme_reference;
+      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
       feature.properties.intervention_type = "area";
       feature.properties.is_coverage_polygon = false;
       gj.features.push(feature as Feature<Polygon>);

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -8,11 +8,11 @@
     getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/maplibre";
+  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import RouteControls from "./RouteControls.svelte";
-  import { cfg } from "../config";
+  import { cfg } from "lib/draw/config";
 
   onMount(() => {
     $routeTool!.startRoute();

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -9,10 +9,10 @@
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import RouteControls from "./RouteControls.svelte";
+  import { cfg } from "../config";
 
   onMount(() => {
     $routeTool!.startRoute();
@@ -28,13 +28,7 @@
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
       feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      feature.properties.intervention_type = "route";
-      if (feature.properties.route_name) {
-        if ($schema != "pipeline") {
-          feature.properties.name = feature.properties.route_name;
-        }
-        delete feature.properties.route_name;
-      }
+      cfg.newLineStringFeature(feature);
       gj.features.push(feature as Feature<LineString>);
       return gj;
     });

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -5,10 +5,10 @@
     mode,
     newFeatureId,
     routeTool,
+    getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { schema } from "stores";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
@@ -27,8 +27,7 @@
   function onSuccess(feature: FeatureWithProps<LineString | Polygon>) {
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference =
-        getArbitraryScheme(gj).scheme_reference;
+      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
       feature.properties.intervention_type = "route";
       if (feature.properties.route_name) {
         if ($schema != "pipeline") {

--- a/src/lib/draw/route/RouteMode.svelte
+++ b/src/lib/draw/route/RouteMode.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-  import type { LineString, Polygon } from "geojson";
-  import {
-    gjSchemeCollection,
-    mode,
-    newFeatureId,
-    routeTool,
-    getArbitrarySchemeRef,
-  } from "lib/draw/stores";
+  import type { Feature, LineString, Polygon } from "geojson";
+  import { mode, routeTool } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
-  import type { Feature } from "types";
   import RouteControls from "./RouteControls.svelte";
   import { cfg } from "lib/draw/config";
 
@@ -24,15 +16,9 @@
     $routeTool!.clearEventListeners();
   });
 
-  function onSuccess(feature: FeatureWithProps<LineString | Polygon>) {
-    gjSchemeCollection.update((gj) => {
-      feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      cfg.newLineStringFeature(feature);
-      gj.features.push(feature as Feature<LineString>);
-      return gj;
-    });
-
+  function onSuccess(feature: Feature<LineString | Polygon>) {
+    // We did startRoute, so we know it's a LineString
+    cfg.newLineStringFeature(feature as Feature<LineString>);
     mode.set({ mode: "edit-form", id: feature.id as number });
   }
 

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -7,8 +7,13 @@
   import nearestPointOnLine from "@turf/nearest-point-on-line";
   // Note we don't use our specialization of Feature here
   import type { Feature, LineString, Point, Position } from "geojson";
-  import { gjSchemeCollection, mode, newFeatureId } from "lib/draw/stores";
-  import { emptyGeojson, layerId, setPrecision } from "lib/maplibre";
+  import {
+    gjSchemeCollection,
+    mode,
+    newFeatureId,
+    setPrecision,
+  } from "lib/draw/stores";
+  import { emptyGeojson, layerId } from "lib/maplibre";
   import type { MapMouseEvent } from "maplibre-gl";
   import { map } from "stores";
   import { onDestroy, onMount } from "svelte";

--- a/src/lib/draw/route/SplitRouteMode.svelte
+++ b/src/lib/draw/route/SplitRouteMode.svelte
@@ -5,7 +5,6 @@
 
   import { splitRoute, type RouteProps } from "route-snapper-ts";
   import nearestPointOnLine from "@turf/nearest-point-on-line";
-  // Note we don't use our specialization of Feature here
   import type { Feature, LineString, Point, Position } from "geojson";
   import {
     gjSchemeCollection,
@@ -18,7 +17,6 @@
   import { map } from "stores";
   import { onDestroy, onMount } from "svelte";
   import { CircleLayer, GeoJSON, MapEvents } from "svelte-maplibre";
-  import type { Feature as OurFeature } from "types";
   import splitIcon from "../../../../assets/split_route.svg";
 
   const circleRadiusPixels = 10;
@@ -111,10 +109,9 @@
         gj.features.splice(
           snappedIndex!,
           1,
-          // TODO Maybe splitRoute's types can be more precise. Existing
-          // properties get copied, so this is valid.
-          piece1 as unknown as OurFeature<LineString>,
-          piece2 as unknown as OurFeature<LineString>,
+          // @ts-expect-error The more specific types are lost. Trust splitRoute.
+          piece1,
+          piece2,
         );
 
         return gj;

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -12,6 +12,7 @@
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";
+  import { cfg } from "../config";
 
   onMount(() => {
     $routeTool!.startArea();
@@ -27,8 +28,10 @@
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
       feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      feature.properties.intervention_type = "area";
-      gj.features.push(feature as Feature<Polygon>);
+      // We did startArea, so we know it's a Polygon
+      let polygonFeature = feature as Feature<Polygon>;
+      cfg.newPolygonFeature(polygonFeature);
+      gj.features.push(polygonFeature);
       return gj;
     });
 

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -5,10 +5,10 @@
     mode,
     newFeatureId,
     routeTool,
+    getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
   import type { FeatureWithProps } from "lib/maplibre";
-  import { getArbitraryScheme } from "lib/sidebar/scheme_data";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";
@@ -26,8 +26,7 @@
   function onSuccess(feature: FeatureWithProps<LineString | Polygon>) {
     gjSchemeCollection.update((gj) => {
       feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference =
-        getArbitraryScheme(gj).scheme_reference;
+      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
       feature.properties.intervention_type = "area";
       gj.features.push(feature as Feature<Polygon>);
       return gj;

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
-  import type { LineString, Polygon } from "geojson";
-  import {
-    gjSchemeCollection,
-    mode,
-    newFeatureId,
-    routeTool,
-    getArbitrarySchemeRef,
-  } from "lib/draw/stores";
+  import type { Feature, LineString, Polygon } from "geojson";
+  import { mode, routeTool } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
-  import type { Feature } from "types";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";
   import { cfg } from "lib/draw/config";
 
@@ -24,17 +16,9 @@
     $routeTool!.clearEventListeners();
   });
 
-  function onSuccess(feature: FeatureWithProps<LineString | Polygon>) {
-    gjSchemeCollection.update((gj) => {
-      feature.id = newFeatureId(gj);
-      feature.properties.scheme_reference = getArbitrarySchemeRef(gj);
-      // We did startArea, so we know it's a Polygon
-      let polygonFeature = feature as Feature<Polygon>;
-      cfg.newPolygonFeature(polygonFeature);
-      gj.features.push(polygonFeature);
-      return gj;
-    });
-
+  function onSuccess(feature: Feature<LineString | Polygon>) {
+    // We did startArea, so we know it's a Polygon
+    cfg.newPolygonFeature(feature as Feature<Polygon>);
     mode.set({ mode: "edit-form", id: feature.id as number });
   }
 

--- a/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
+++ b/src/lib/draw/snap_polygon/SnapPolygonMode.svelte
@@ -8,11 +8,11 @@
     getArbitrarySchemeRef,
   } from "lib/draw/stores";
   import { ButtonGroup, DefaultButton, SecondaryButton } from "govuk-svelte";
-  import type { FeatureWithProps } from "lib/maplibre";
+  import type { FeatureWithProps } from "lib/draw/types";
   import { onDestroy, onMount } from "svelte";
   import type { Feature } from "types";
   import SnapPolygonControls from "./SnapPolygonControls.svelte";
-  import { cfg } from "../config";
+  import { cfg } from "lib/draw/config";
 
   onMount(() => {
     $routeTool!.startArea();

--- a/src/lib/draw/stores.ts
+++ b/src/lib/draw/stores.ts
@@ -59,3 +59,11 @@ export function deleteIntervention(id: number) {
   sidebarHover.set(null);
   mode.set({ mode: "list" });
 }
+
+// When creating a new feature, arbitrarily assign it to the first scheme. The
+// user can change it later.
+export function getArbitrarySchemeRef(
+  schemeCollection: SchemeCollection,
+): string {
+  return Object.values(schemeCollection.schemes)[0].scheme_reference;
+}

--- a/src/lib/draw/stores.ts
+++ b/src/lib/draw/stores.ts
@@ -1,9 +1,11 @@
 import { emptyCollection } from "lib/sidebar/scheme_data";
 import { writable, type Writable } from "svelte/store";
-import type { Mode, SchemeCollection } from "types";
+import type { SchemeCollection } from "types";
+import type { Mode } from "./types";
 import { PointTool } from "./point/point_tool";
 import { PolygonTool } from "maplibre-draw-polygon";
 import { RouteTool } from "route-snapper-ts";
+import type { Position } from "geojson";
 
 // TODO Should we instead store a map from ID to feature?
 export const gjSchemeCollection: Writable<SchemeCollection> =
@@ -66,4 +68,10 @@ export function getArbitrarySchemeRef(
   schemeCollection: SchemeCollection,
 ): string {
   return Object.values(schemeCollection.schemes)[0].scheme_reference;
+}
+
+// Per https://datatracker.ietf.org/doc/html/rfc7946#section-11.2, 6 decimal
+// places (10cm) is plenty of precision
+export function setPrecision(pt: Position): Position {
+  return [Math.round(pt[0] * 10e6) / 10e6, Math.round(pt[1] * 10e6) / 10e6];
 }

--- a/src/lib/draw/types.ts
+++ b/src/lib/draw/types.ts
@@ -21,7 +21,6 @@ export type Mode =
   | { mode: "streetview" };
 
 // Properties are guaranteed to exist, but can be anything, so TS is mostly disabled
-// TODO Remove, probably
-export type FeatureWithProps<G extends Geometry> = Feature<G> & {
+export type FeatureWithAnyProps<G extends Geometry = Geometry> = Feature<G> & {
   properties: { [name: string]: any };
 };

--- a/src/lib/draw/types.ts
+++ b/src/lib/draw/types.ts
@@ -1,0 +1,27 @@
+import type { Feature, Geometry } from "geojson";
+
+export type Mode =
+  | {
+      mode: "list";
+    }
+  | {
+      mode: "edit-form";
+      id: number;
+    }
+  | {
+      mode: "edit-geometry";
+      id: number;
+    }
+  | { mode: "new-point" }
+  | { mode: "new-freehand-polygon" }
+  | { mode: "new-snapped-polygon" }
+  | { mode: "new-route" }
+  | { mode: "split-route" }
+  | { mode: "set-image" }
+  | { mode: "streetview" };
+
+// Properties are guaranteed to exist, but can be anything, so TS is mostly disabled
+// TODO Remove, probably
+export type FeatureWithProps<G extends Geometry> = Feature<G> & {
+  properties: { [name: string]: any };
+};

--- a/src/lib/maplibre/utils.ts
+++ b/src/lib/maplibre/utils.ts
@@ -1,13 +1,6 @@
 // Helpers for https://maplibre.org/maplibre-gl-js-docs/style-spec/
 import turfBbox from "@turf/bbox";
-import type {
-  Feature,
-  FeatureCollection,
-  GeoJSON,
-  Geometry,
-  Point,
-  Position,
-} from "geojson";
+import type { FeatureCollection, GeoJSON } from "geojson";
 import type {
   DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
@@ -44,23 +37,6 @@ export function emptyGeojson(): FeatureCollection {
     type: "FeatureCollection",
     features: [],
   };
-}
-
-export function pointFeature(pt: Position): FeatureWithProps<Point> {
-  return {
-    type: "Feature",
-    properties: {},
-    geometry: {
-      type: "Point",
-      coordinates: setPrecision(pt),
-    },
-  };
-}
-
-// Per https://datatracker.ietf.org/doc/html/rfc7946#section-11.2, 6 decimal
-// places (10cm) is plenty of precision
-export function setPrecision(pt: Position): Position {
-  return [Math.round(pt[0] * 10e6) / 10e6, Math.round(pt[1] * 10e6) / 10e6];
 }
 
 // Helper for https://maplibre.org/maplibre-style-spec/expressions/#match.
@@ -146,8 +122,3 @@ export function addLineStringEndpoints(
   }
   return output;
 }
-
-// Properties are guaranteed to exist
-export type FeatureWithProps<G extends Geometry> = Feature<G> & {
-  properties: { [name: string]: any };
-};

--- a/src/lib/sidebar/scheme_data.ts
+++ b/src/lib/sidebar/scheme_data.ts
@@ -262,11 +262,3 @@ export function getUnexpectedProperties(props: { [name: string]: any }): {
 
   return copy;
 }
-
-// TODO Remove when the UI can manage multiple schemes. This function only
-// makes sense when there's one scheme in the collection.
-export function getArbitraryScheme(
-  schemeCollection: SchemeCollection,
-): SchemeData {
-  return Object.values(schemeCollection.schemes)[0];
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,23 +166,3 @@ export interface UserSettings {
 export function isStreetViewImagery(x: string): x is "google" | "bing" {
   return x == "google" || x == "bing";
 }
-
-export type Mode =
-  | {
-      mode: "list";
-    }
-  | {
-      mode: "edit-form";
-      id: number;
-    }
-  | {
-      mode: "edit-geometry";
-      id: number;
-    }
-  | { mode: "new-point" }
-  | { mode: "new-freehand-polygon" }
-  | { mode: "new-snapped-polygon" }
-  | { mode: "new-route" }
-  | { mode: "split-route" }
-  | { mode: "set-image" }
-  | { mode: "streetview" };


### PR DESCRIPTION
I want to move the bulk of the scheme sketcher code into a new git repo, exposed as a Sveltekit library. The goal is to more easily use pieces of this from other projects, such as the inspectorate tools. It's not an easy refactor; the bulk of the core drawing logic is already in `maplibre-draw-polygon` and `route-snapper`, but the code here manages the toolbox, switches modes, manages the store with the GeoJSON features, etc.

Roughly the split of responsibility I picture is like this. The sketch library will handle `lib/draw/` and parts of `lib/sidebar` -- giving people the mode switching logic, multi layer (scheme) management, sidebar controls, etc. What will remain in this repo (and have a new, much simpler variation in inspectorate tools) is per-schema forms, backfilling logic, etc. So the library shouldn't really care about feature properties beyond a few of the truly common ones.

This PR is a first step that makes `lib/draw/` much more self-contained and starts teasing apart the types. I think even as a standalone refactor without doing the rest, it has some value. It's not complete -- the code still pulls in repo-wide `map` and `userSetings` stores, and I need to think through how to make the `SchemeCollection` type more generic. Assuming tests pass and there are no comments, I'll merge next time I work on this. A next step will probably be starting the new repo and discovering more tricky complications.