### PR TITLE
Add buttons to switch to browser from sketcher

### DIFF
--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -16,6 +16,7 @@ export { default as Popup } from "./Popup.svelte";
 export { default as MapLibreMap } from "./MapLibreMap.svelte";
 export { default as ZoomOutMap } from "./ZoomOutMap.svelte";
 export * from "./storage";
+export * from "./navigation";
 export { Modal, WarningIcon } from "scheme-sketcher-lib/common";
 
 export async function getAuthoritiesGeoJson(): Promise<AuthorityBoundaries> {

--- a/src/lib/common/navigation.ts
+++ b/src/lib/common/navigation.ts
@@ -1,10 +1,10 @@
 import { schema as schemaStore } from "../../stores";
-import { get } from "svelte/store"
+import { get } from "svelte/store";
 
 export function openBrowsePage() {
-    window.location.href = "browse.html";
+  window.location.href = "browse.html";
 }
 
 export function startSketching(authorityName: string) {
-    window.location.href = `scheme.html?authority=${authorityName}&schema=${get(schemaStore)}`;
+  window.location.href = `scheme.html?authority=${authorityName}&schema=${get(schemaStore)}`;
 }

--- a/src/lib/common/navigation.ts
+++ b/src/lib/common/navigation.ts
@@ -8,3 +8,7 @@ export function openBrowsePage() {
 export function startSketching(authorityName: string) {
   window.location.href = `scheme.html?authority=${authorityName}&schema=${get(schemaStore)}`;
 }
+
+export function openChooseSketchArea() {
+  window.location.href = "/";
+}

--- a/src/lib/common/navigation.ts
+++ b/src/lib/common/navigation.ts
@@ -1,0 +1,10 @@
+import { schema as schemaStore } from "../../stores";
+import { get } from "svelte/store"
+
+export function openBrowsePage() {
+    window.location.href = "browse.html";
+}
+
+export function startSketching(authorityName: string) {
+    window.location.href = `scheme.html?authority=${authorityName}&schema=${get(schemaStore)}`;
+}

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -15,10 +15,12 @@
     MapLibreMap,
     ZoomOutMap,
     Header,
+    openChooseSketchArea,
   } from "lib/common";
   import { map, mapStyle } from "stores";
   import { onMount } from "svelte";
   import { map as sketchMapStore } from "scheme-sketcher-lib/config";
+  import { SecondaryButton } from "govuk-svelte";
 
   onMount(() => {
     // For govuk components. Must happen here.
@@ -54,6 +56,9 @@
       <h1>Scheme Browser</h1>
       <ZoomOutMap boundaryGeojson={$atfSchemesGj} />
     </div>
+    <SecondaryButton on:click={openChooseSketchArea}>
+      Open Scheme Sketcher
+    </SecondaryButton>
 
     <div bind:this={sidebarDiv} />
   </div>

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -144,7 +144,10 @@
         />
       {/if}
 
-      <DefaultButton on:click={() => startSketching(inputValue)} disabled={!validEntry}>
+      <DefaultButton
+        on:click={() => startSketching(inputValue)}
+        disabled={!validEntry}
+      >
         Start
       </DefaultButton>
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -34,6 +34,7 @@
     type LayerClickInfo,
   } from "svelte-maplibre";
   import Header from "./ChooseAreaHeader.svelte";
+  import { startSketching, openBrowsePage } from "../lib/common/navigation";
 
   let authoritiesGj: AuthorityBoundaries = {
     type: "FeatureCollection",
@@ -105,13 +106,7 @@
   }
 
   function onClick(e: CustomEvent<LayerClickInfo>) {
-    window.location.href = `scheme.html?authority=${
-      e.detail.features[0].properties!.full_name
-    }&schema=${$schemaStore}`;
-  }
-
-  function start() {
-    window.location.href = `scheme.html?authority=${inputValue}&schema=${$schemaStore}`;
+    startSketching(e.detail.features[0].properties!.full_name);
   }
 </script>
 
@@ -128,9 +123,14 @@
 
       <h1>Scheme Sketcher</h1>
 
-      <SecondaryButton on:click={() => (showAbout = !showAbout)}>
-        About
-      </SecondaryButton>
+      <div class="govuk-button-group">
+        <SecondaryButton on:click={() => (showAbout = !showAbout)}>
+          About
+        </SecondaryButton>
+        <SecondaryButton on:click={openBrowsePage}>
+          Open Scheme Browser
+        </SecondaryButton>
+      </div>
       <ErrorMessage errorMessage={pageErrorMessage} />
 
       {#if authoritiesGj.features.length > 0}
@@ -144,7 +144,7 @@
         />
       {/if}
 
-      <DefaultButton on:click={start} disabled={!validEntry}>
+      <DefaultButton on:click={() => startSketching(inputValue)} disabled={!validEntry}>
         Start
       </DefaultButton>
 

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -5,6 +5,7 @@
   // @ts-expect-error no declarations
   import { initAll } from "govuk-frontend";
   import {
+    ButtonGroup,
     DefaultButton,
     ErrorMessage,
     FileInput,
@@ -124,14 +125,14 @@
 
       <h1>Scheme Sketcher</h1>
 
-      <div class="govuk-button-group">
+      <ButtonGroup>
         <SecondaryButton on:click={() => (showAbout = !showAbout)}>
           About
         </SecondaryButton>
         <SecondaryButton on:click={openBrowsePage}>
           Open Scheme Browser
         </SecondaryButton>
-      </div>
+      </ButtonGroup>
       <ErrorMessage errorMessage={pageErrorMessage} />
 
       {#if authoritiesGj.features.length > 0}

--- a/src/pages/ChooseArea.svelte
+++ b/src/pages/ChooseArea.svelte
@@ -23,6 +23,8 @@
     MapLibreMap,
     Popup,
     setLocalStorageItem,
+    startSketching,
+    openBrowsePage,
   } from "lib/common";
   import About from "lib/sketch/About.svelte";
   import { schema as schemaStore } from "stores";
@@ -34,7 +36,6 @@
     type LayerClickInfo,
   } from "svelte-maplibre";
   import Header from "./ChooseAreaHeader.svelte";
-  import { startSketching, openBrowsePage } from "../lib/common/navigation";
 
   let authoritiesGj: AuthorityBoundaries = {
     type: "FeatureCollection",

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -26,6 +26,7 @@
   import { mode } from "scheme-sketcher-lib/draw/stores";
   import { ButtonGroup, SecondaryButton } from "govuk-svelte";
   import About from "lib/sketch/About.svelte";
+  import { openBrowsePage } from "lib/common/navigation";
   import FileManagement from "lib/sketch/FileManagement.svelte";
   import Instructions from "lib/sketch/Instructions.svelte";
   import { PerModeControls } from "scheme-sketcher-lib/sidebar";
@@ -124,6 +125,9 @@
         <SecondaryButton on:click={toggleAbout}>About</SecondaryButton>
         <SecondaryButton on:click={toggleInstructions}>
           Instructions
+        </SecondaryButton>
+        <SecondaryButton on:click={openBrowsePage}>
+          Open Browse Page
         </SecondaryButton>
       </ButtonGroup>
     {/if}

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -127,7 +127,7 @@
           Instructions
         </SecondaryButton>
         <SecondaryButton on:click={openBrowsePage}>
-          Open Browse Page
+          Open Scheme Browser
         </SecondaryButton>
       </ButtonGroup>
     {/if}

--- a/src/pages/SketchSchemes.svelte
+++ b/src/pages/SketchSchemes.svelte
@@ -22,11 +22,11 @@
     MapLibreMap,
     ZoomOutMap,
     Header,
+    openBrowsePage,
   } from "lib/common";
   import { mode } from "scheme-sketcher-lib/draw/stores";
   import { ButtonGroup, SecondaryButton } from "govuk-svelte";
   import About from "lib/sketch/About.svelte";
-  import { openBrowsePage } from "lib/common/navigation";
   import FileManagement from "lib/sketch/FileManagement.svelte";
   import Instructions from "lib/sketch/Instructions.svelte";
   import { PerModeControls } from "scheme-sketcher-lib/sidebar";


### PR DESCRIPTION
Moving the navigation logic outside of the components so that they can be reused. Seems overkill right now maybe but I think we might want a more complex version of open browse page at which point it being in its own file makes a bit more sense. Will have to have a bit of a general cleanup to move all nav stuff to this file