### PR TITLE
Update OSM-based layers. #526

### DIFF
--- a/src/lib/browse/layers/lines/BusRoutes.svelte
+++ b/src/lib/browse/layers/lines/BusRoutes.svelte
@@ -30,7 +30,7 @@
       shows whether the road has a bus lane or not.
     </p>
     <p>
-      Note this data is from OpenStreetMap (as of 9 August 2023), not <ExternalLink
+      Note this data is from OpenStreetMap (as of 20 October 2024), not <ExternalLink
         href="https://gtfs.org"
       >
         GTFS

--- a/src/lib/browse/layers/lines/CyclePaths.svelte
+++ b/src/lib/browse/layers/lines/CyclePaths.svelte
@@ -102,7 +102,7 @@
   <span slot="help">
     <p>
       This shows different types of cycle path, according to OpenStreetMap (as
-      of 15 August 2023).
+      of 20 October 2024).
     </p>
     <ul>
       <li>

--- a/src/lib/browse/layers/lines/Gradients.svelte
+++ b/src/lib/browse/layers/lines/Gradients.svelte
@@ -46,7 +46,10 @@
   </span>
   <span slot="controls">
     <SequentialLegend {colorScale} {limits} />
-    <p><img src={chevron} alt="arrow">Arrows point uphill</p>
+    <p>
+      <img src={chevron} alt="arrow" />
+      Arrows point uphill
+    </p>
   </span>
 </LayerControl>
 

--- a/src/lib/browse/layers/lines/Trams.svelte
+++ b/src/lib/browse/layers/lines/Trams.svelte
@@ -30,7 +30,7 @@
   <span slot="help">
     <p>
       This shows all trams and light rail lines, according to OpenStreetMap (as
-      of 7 February 2024). When these are close to a scheme, interactions
+      of 20 October 2024). When these are close to a scheme, interactions
       between the modes must be designed carefully.
     </p>
     <OsmLicense />

--- a/src/lib/browse/layers/points/Crossings.svelte
+++ b/src/lib/browse/layers/points/Crossings.svelte
@@ -61,7 +61,7 @@
         href="https://wiki.openstreetmap.org/wiki/Key:crossing"
       >
         crossing
-      </ExternalLink> data from OpenStreetMap (as of 9 August 2023).
+      </ExternalLink> data from OpenStreetMap (as of 20 October 2024).
     </p>
     <OsmLicense />
   </span>

--- a/src/lib/browse/layers/points/CycleParking.svelte
+++ b/src/lib/browse/layers/points/CycleParking.svelte
@@ -21,7 +21,7 @@
         href="https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbicycle_parking"
       >
         OpenStreetMap
-      </ExternalLink> (as of 9 August 2023). The type of parking, public/private
+      </ExternalLink> (as of 20 October 2024). The type of parking, public/private
       access, and whether it's covered are not shown.
     </p>
     <p>

--- a/src/lib/browse/layers/points/Education.svelte
+++ b/src/lib/browse/layers/points/Education.svelte
@@ -53,7 +53,7 @@
   <span slot="help">
     <p>
       This shows different places of education according to OpenStreetMap (as of
-      07 February 2024).
+      20 October 2024).
     </p>
     <OsmLicense />
   </span>

--- a/src/lib/browse/layers/points/Hospitals.svelte
+++ b/src/lib/browse/layers/points/Hospitals.svelte
@@ -26,8 +26,8 @@
         href="https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dhospital"
       >
         hospital
-      </ExternalLink> data from OpenStreetMap (as of 9 August 2023). It doesn't include
-      outpatient clinics or individual doctor's offices.
+      </ExternalLink> data from OpenStreetMap (as of 20 October 2024). It doesn't
+      include outpatient clinics or individual doctor's offices.
     </p>
     <OsmLicense />
   </span>

--- a/src/lib/browse/layers/points/RailwayStations.svelte
+++ b/src/lib/browse/layers/points/RailwayStations.svelte
@@ -21,7 +21,7 @@
         href="https://wiki.openstreetmap.org/wiki/Tag:railway%3Dstation"
       >
         railway station
-      </ExternalLink> data from OpenStreetMap (as of 9 August 2023).
+      </ExternalLink> data from OpenStreetMap (as of 20 October 2024).
     </p>
     <p>
       Icon from <ExternalLink href="https://www.nationalrail.co.uk/">

--- a/src/lib/browse/layers/points/SportsSpaces.svelte
+++ b/src/lib/browse/layers/points/SportsSpaces.svelte
@@ -30,7 +30,7 @@
         href="https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dsports_centre"
       >
         sports centres
-      </ExternalLink> data from OpenStreetMap (as of 9 August 2023).
+      </ExternalLink> data from OpenStreetMap (as of 20 October 2024).
     </p>
     <OsmLicense />
   </span>


### PR DESCRIPTION
9 easy layers regenerated, with no code changes in atip-data-prep. I've already updated the files on atip.uk, so the GH deployment will show new data. I compared all layers, no unexpected things missing, and I confirmed new known bus routes and cycle paths appear in Wirral and Bermondsey respectively. I didn't notice anything new in other layers, but I didn't really know where to look (and don't yet have a good geo-diffing workflow in place).

Pete, if these changes look good, please
1) Copy the 9 files to the GCS buckets. You can download the 9 files from http://atip.uk/layers/v1/cycle_paths.pmtiles and so on; let me know if I should just give you the 9 URLs
2) Update the manifests