### PR TITLE
Update LADs and CAs. #526

### DIFF
--- a/src/lib/browse/layers/areas/CombinedAuthorities.svelte
+++ b/src/lib/browse/layers/areas/CombinedAuthorities.svelte
@@ -27,7 +27,7 @@
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
       `https://www.ons.gov.uk/visualisations/areas/${
-        e.detail.features[0].properties!.CAUTH22CD
+        e.detail.features[0].properties!.CAUTH24CD
       }`,
       "_blank",
     );
@@ -39,10 +39,10 @@
   <span slot="help">
     <p>
       Data from <ExternalLink
-        href="https://geoportal.statistics.gov.uk/datasets/ons::combined-authorities-december-2022-boundaries-en-buc/explore"
+        href="https://geoportal.statistics.gov.uk/datasets/8369f71423ba474ebdbac60a539b53c8_0/explore"
       >
         ONS Geography
-      </ExternalLink>, as of December 2022.
+      </ExternalLink>, as of May 2024.
     </p>
     <OsOglLicense />
   </span>

--- a/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
+++ b/src/lib/browse/layers/areas/LocalAuthorityDistricts.svelte
@@ -27,7 +27,7 @@
   function onClick(e: CustomEvent<LayerClickInfo>) {
     window.open(
       `https://www.ons.gov.uk/visualisations/areas/${
-        e.detail.features[0].properties!.LAD23CD
+        e.detail.features[0].properties!.LAD24CD
       }`,
       "_blank",
     );
@@ -39,10 +39,10 @@
   <span slot="help">
     <p>
       Data from <ExternalLink
-        href="https://geoportal.statistics.gov.uk/maps/79a4e87783be4b6bbb96ddad6dda52a3"
+        href="https://geoportal.statistics.gov.uk/datasets/fb6ab0ce776243339e45e33444f431c8_0/explore"
       >
         ONS Geography
-      </ExternalLink>, as of January 2024.
+      </ExternalLink>, as of May 2024.
     </p>
     <OsOglLicense />
   </span>


### PR DESCRIPTION
Compare https://acteng.github.io/atip/ladsladslads_andcas/browse.html with the internal page. New CAs are clearly visible. I'm actually still hunting around to find the changes between January and May 2024 for LADs; Cumbria was already split by January.

Pete, you'll need to copy two new files to the GCS bucket: http://atip.uk/layers/v1/local_authority_districts.geojson and http://atip.uk/layers/v1/combined_authorities.geojson, and update manifest