### PR TITLE
Fluidly link sketch and browse pages

### DIFF
--- a/src/lib/browse/schemes/Filters.svelte
+++ b/src/lib/browse/schemes/Filters.svelte
@@ -86,6 +86,7 @@
       }
       if (
         source == "ATF" &&
+        scheme.browse!.funding_programme &&
         !filterFundingProgrammes[scheme.browse!.funding_programme]
       ) {
         return false;

--- a/src/lib/browse/schemes/Filters.svelte
+++ b/src/lib/browse/schemes/Filters.svelte
@@ -9,14 +9,13 @@
     AutocompleteTextInput,
   } from "govuk-svelte";
   import { Modal } from "lib/common";
-  import type { Feature, Schemes, SchemeData } from "types";
+  import type { Feature, Schemes } from "types";
   import {
     atfFundingProgrammes,
     currentMilestones as currentMilestoneColors,
   } from "./colors";
 
   export let source: string;
-  export let schemes: Map<string, SchemeData>;
   export let schemesGj: Schemes;
   export let filterSchemeText: string;
   export let filterInterventionText: string;
@@ -32,18 +31,16 @@
     currentMilestoneColors,
   ).map((x) => [x, x]);
 
-  $: authorities = getAuthorities(schemes);
+  $: authorities = getAuthorities(schemesGj);
   let filterAuthority = "";
   let filterFundingProgrammes = Object.fromEntries(
     Object.keys(atfFundingProgrammes).map((x) => [x, true]),
   );
   let filterCurrentMilestone = "";
 
-  function getAuthorities(
-    schemes: Map<string, SchemeData>,
-  ): [string, string][] {
+  function getAuthorities(schemesGj: Schemes): [string, string][] {
     let names: Set<string> = new Set();
-    for (let x of schemes.values()) {
+    for (let x of Object.values(schemesGj.schemes)) {
       if (x.browse?.authority_or_region) {
         names.add(x.browse.authority_or_region);
       }
@@ -77,7 +74,7 @@
         return false;
       }
 
-      let scheme = schemes.get(feature.properties.scheme_reference!)!;
+      let scheme = schemesGj.schemes[feature.properties.scheme_reference!];
       if (
         filterAuthority &&
         scheme.browse?.authority_or_region != filterAuthority
@@ -176,11 +173,9 @@
     filterSchemeText = "";
   }
 
-  function schemeAutocompleteOptions(
-    schemes: Map<string, SchemeData>,
-  ): [string, string][] {
+  function schemeAutocompleteOptions(schemesGj: Schemes): [string, string][] {
     let result = [] as [string, string][];
-    for (let scheme of schemes.values()) {
+    for (let scheme of Object.values(schemesGj.schemes)) {
       // TODO Consider not doing this for LCWIPs
       result.push([scheme.scheme_reference, scheme.scheme_reference]);
       if (scheme.scheme_name) {
@@ -228,7 +223,7 @@
         <AutocompleteTextInput
           label="Scheme name or reference"
           bind:value={filterSchemeText}
-          options={schemeAutocompleteOptions(schemes)}
+          options={schemeAutocompleteOptions(schemesGj)}
         />
 
         <Select
@@ -277,7 +272,7 @@
     <AutocompleteTextInput
       label="Scheme name or reference"
       bind:value={filterSchemeText}
-      options={schemeAutocompleteOptions(schemes)}
+      options={schemeAutocompleteOptions(schemesGj)}
     />
 
     <Select

--- a/src/lib/browse/schemes/InterventionLayer.svelte
+++ b/src/lib/browse/schemes/InterventionLayer.svelte
@@ -22,7 +22,8 @@
   import InterventionPopup from "./InterventionPopup.svelte";
   import type { Schemes } from "types";
 
-  export let source: string;
+  export let name: string;
+  export let description: string;
   export let show: boolean;
 
   export let schemesGj: Schemes;
@@ -47,7 +48,7 @@
 
 <GeoJSON data={gj}>
   <CircleLayer
-    {...layerId(`${source}-interventions-points`)}
+    {...layerId(`${name}-interventions-points`)}
     filter={["all", isPoint, hideWhileEditing, notEndpoint]}
     manageHoverState
     eventsIfTopMost
@@ -64,7 +65,7 @@
     <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
     <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup
-        {source}
+        {description}
         {props}
         {schemesGj}
         {filterSchemeText}
@@ -74,7 +75,7 @@
   </CircleLayer>
 
   <LineLayer
-    {...layerId(`${source}-interventions-lines`)}
+    {...layerId(`${name}-interventions-lines`)}
     filter={["all", isLine, hideWhileEditing]}
     manageHoverState
     eventsIfTopMost
@@ -91,7 +92,7 @@
     <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
     <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup
-        {source}
+        {description}
         {props}
         {schemesGj}
         {filterSchemeText}
@@ -100,7 +101,7 @@
     </Popup>
   </LineLayer>
   <CircleLayer
-    {...layerId(`${source}-interventions-lines-endpoints`)}
+    {...layerId(`${name}-interventions-lines-endpoints`)}
     filter={["==", "endpoint", true]}
     paint={{
       "circle-radius": 0.5 * lineWidth,
@@ -114,7 +115,7 @@
   />
 
   <FillLayer
-    {...layerId(`${source}-interventions-polygons`)}
+    {...layerId(`${name}-interventions-polygons`)}
     filter={["all", isPolygon, hideWhileEditing]}
     manageHoverState
     eventsIfTopMost
@@ -130,7 +131,7 @@
     <Popup let:props popupClass="border-popup"><p>{props.name}</p></Popup>
     <Popup let:props openOn="click" popupClass="border-popup">
       <InterventionPopup
-        {source}
+        {description}
         {props}
         {schemesGj}
         {filterSchemeText}
@@ -139,7 +140,7 @@
     </Popup>
   </FillLayer>
   <LineLayer
-    {...layerId(`${source}-interventions-polygons-outlines`)}
+    {...layerId(`${name}-interventions-polygons-outlines`)}
     filter={["all", isPolygon, hideWhileEditing]}
     paint={{
       "line-color": color,

--- a/src/lib/browse/schemes/InterventionLayer.svelte
+++ b/src/lib/browse/schemes/InterventionLayer.svelte
@@ -20,12 +20,11 @@
     LineLayer,
   } from "svelte-maplibre";
   import InterventionPopup from "./InterventionPopup.svelte";
-  import type { Schemes, SchemeData } from "types";
+  import type { Schemes } from "types";
 
   export let source: string;
   export let show: boolean;
 
-  export let schemes: Map<string, SchemeData>;
   export let schemesGj: Schemes;
   export let filterSchemeText: string;
   export let filterInterventionText: string;
@@ -68,7 +67,6 @@
         {source}
         {props}
         {schemesGj}
-        {schemes}
         {filterSchemeText}
         {filterInterventionText}
       />
@@ -96,7 +94,6 @@
         {source}
         {props}
         {schemesGj}
-        {schemes}
         {filterSchemeText}
         {filterInterventionText}
       />
@@ -136,7 +133,6 @@
         {source}
         {props}
         {schemesGj}
-        {schemes}
         {filterSchemeText}
         {filterInterventionText}
       />

--- a/src/lib/browse/schemes/InterventionPopup.svelte
+++ b/src/lib/browse/schemes/InterventionPopup.svelte
@@ -83,10 +83,14 @@
       // TODO Handle duplicate filenames
       let filename = `browse_copy_${scheme.scheme_reference}`;
 
-      setLocalStorage(
-        getKey(authority, filename),
-        JSON.stringify(serializeSchemes(authority, gj)),
-      );
+      let copy = serializeSchemes(authority, gj);
+      // Clean up the per-feature properties used for display
+      for (let f of copy.features) {
+        delete f.properties.funding_programme;
+        delete f.properties.current_milestone;
+      }
+
+      setLocalStorage(getKey(authority, filename), JSON.stringify(copy));
 
       window.open(getEditUrl(authority, filename, schema), "_blank");
     }

--- a/src/lib/browse/schemes/InterventionPopup.svelte
+++ b/src/lib/browse/schemes/InterventionPopup.svelte
@@ -12,17 +12,16 @@
   } from "lib/common/files";
   import DescribePipelineTiming from "./DescribePipelineTiming.svelte";
   import DescribePipelineBudget from "./DescribePipelineBudget.svelte";
-  import type { Schema, Schemes, SchemeData } from "types";
+  import type { Schema, Schemes } from "types";
   import { afterUpdate } from "svelte";
 
   export let source: string;
   export let props: { [name: string]: any };
-  export let schemes: Map<string, SchemeData>;
   export let schemesGj: Schemes;
   export let filterSchemeText: string;
   export let filterInterventionText: string;
 
-  $: scheme = schemes.get(props.scheme_reference)!;
+  $: scheme = schemesGj.schemes[props.scheme_reference];
 
   let div: HTMLDivElement | undefined;
   afterUpdate(() => {

--- a/src/lib/browse/schemes/InterventionPopup.svelte
+++ b/src/lib/browse/schemes/InterventionPopup.svelte
@@ -15,7 +15,7 @@
   import type { Schema, Schemes } from "types";
   import { afterUpdate } from "svelte";
 
-  export let source: string;
+  export let description: string;
   export let props: { [name: string]: any };
   export let schemesGj: Schemes;
   export let filterSchemeText: string;
@@ -131,7 +131,7 @@
 
     <hr />
 
-    <h2>{source.toUpperCase()} Scheme</h2>
+    <h2>{description}</h2>
 
     <p>
       <b>Scheme name</b>

--- a/src/lib/browse/schemes/InterventionPopup.svelte
+++ b/src/lib/browse/schemes/InterventionPopup.svelte
@@ -152,10 +152,12 @@
         : {scheme.browse?.capital_scheme_id}
       </p>
     {/if}
-    <p>
-      <b>Funding programme</b>
-      : {scheme.browse?.funding_programme}
-    </p>
+    {#if scheme.browse?.funding_programme}
+      <p>
+        <b>Funding programme</b>
+        : {scheme.browse?.funding_programme}
+      </p>
+    {/if}
     {#if scheme.browse?.current_milestone}
       <p>
         <b>Current milestone</b>

--- a/src/lib/browse/schemes/InterventionPopup.svelte
+++ b/src/lib/browse/schemes/InterventionPopup.svelte
@@ -73,15 +73,23 @@
 
     let schema: Schema = scheme.pipeline ? "pipeline" : "v1";
 
-    // TODO Handle duplicate filenames
-    let filename = `browse_copy_${scheme.scheme_reference}`;
+    if (scheme.browse?.local_filename) {
+      // Edit the existing file where this scheme came from. There might be other schemes in the same file.
+      window.open(
+        getEditUrl(authority, scheme.browse?.local_filename, schema),
+        "_blank",
+      );
+    } else {
+      // TODO Handle duplicate filenames
+      let filename = `browse_copy_${scheme.scheme_reference}`;
 
-    setLocalStorage(
-      getKey(authority, filename),
-      JSON.stringify(serializeSchemes(authority, gj)),
-    );
+      setLocalStorage(
+        getKey(authority, filename),
+        JSON.stringify(serializeSchemes(authority, gj)),
+      );
 
-    window.open(getEditUrl(authority, filename, schema), "_blank");
+      window.open(getEditUrl(authority, filename, schema), "_blank");
+    }
   }
 </script>
 
@@ -192,7 +200,11 @@
       Zoom to show entire scheme
     </SecondaryButton>
     <SecondaryButton on:click={editScheme}>
-      Edit a copy of this scheme
+      {#if scheme.browse?.local_filename}
+        Edit your existing version of this scheme
+      {:else}
+        Edit a copy of this scheme
+      {/if}
     </SecondaryButton>
   </div>
 {/key}

--- a/src/lib/browse/schemes/SchemesLayer.svelte
+++ b/src/lib/browse/schemes/SchemesLayer.svelte
@@ -5,10 +5,11 @@
     FileInput,
     Select,
     CheckboxGroup,
+    SecondaryButton,
   } from "govuk-svelte";
   import { appVersion, Legend, WarningIcon } from "lib/common";
   import LoadRemoteSchemeData from "./LoadRemoteSchemeData.svelte";
-  import { setupSchemes } from "./data";
+  import { importAllLocalSketches, setupSchemes } from "./data";
   import Filters from "./Filters.svelte";
   import {
     atfSchemesGj,
@@ -80,6 +81,13 @@
       // Should be impossible
       return ["red", []];
     }
+  }
+
+  function importFromSketch() {
+    setupSchemes(importAllLocalSketches());
+    $atfShow = true;
+    $lcwipShow = true;
+    errorMessage = "";
   }
 </script>
 
@@ -162,6 +170,10 @@
 
   <FileInput label="Load schemes from GeoJSON" onLoad={loadFile} />
   <ErrorMessage {errorMessage} />
+
+  <SecondaryButton on:click={importFromSketch}>
+    Show your sketches
+  </SecondaryButton>
 </CollapsibleCard>
 
 <InterventionLayer

--- a/src/lib/browse/schemes/SchemesLayer.svelte
+++ b/src/lib/browse/schemes/SchemesLayer.svelte
@@ -12,12 +12,18 @@
   import { importAllLocalSketches, setupSchemes } from "./data";
   import Filters from "./Filters.svelte";
   import {
-    atfSchemesGj,
-    lcwipSchemesGj,
-    filterAtfSchemeText,
-    filterAtfInterventionText,
-    filterLcwipSchemeText,
-    filterLcwipInterventionText,
+    mainAtfSchemes,
+    mainLcwipSchemes,
+    filterMainAtfSchemeText,
+    filterMainAtfInterventionText,
+    filterMainLcwipSchemeText,
+    filterMainLcwipInterventionText,
+    localAtfSchemes,
+    localLcwipSchemes,
+    filterLocalAtfSchemeText,
+    filterLocalAtfInterventionText,
+    filterLocalLcwipSchemeText,
+    filterLocalLcwipInterventionText,
   } from "./stores";
   import InterventionLayer from "./InterventionLayer.svelte";
   import { colorInterventionsBySchema, schemaLegend } from "schemas";
@@ -29,27 +35,45 @@
 
   let errorMessage = "";
 
-  let atfName = "atf_schemes";
-  let atfTitle = "ATF schemes";
-  let atfShow = showHideLayer(atfName);
-  let atfStyle = "fundingProgramme";
-  $: [atfColor, atfLegend] = pickStyle(atfStyle);
+  let mainAtfName = "main_atf_schemes";
+  let mainAtfTitle = "ATF schemes";
+  let mainAtfShow = showHideLayer(mainAtfName);
+  let mainAtfStyle = "fundingProgramme";
+  $: [mainAtfColor, mainAtfLegend] = pickStyle(mainAtfStyle);
 
-  let lcwipName = "lcwip_schemes";
-  let lcwipTitle = "LCWIP schemes";
-  let lcwipShow = showHideLayer(lcwipName);
-  let lcwipStyle = "interventionType";
-  $: [lcwipColor, lcwipLegend] = pickStyle(lcwipStyle);
+  let mainLcwipName = "main_lcwip_schemes";
+  let mainLcwipTitle = "LCWIP schemes";
+  let mainLcwipShow = showHideLayer(mainLcwipName);
+  let mainLcwipStyle = "interventionType";
+  $: [mainLcwipColor, mainLcwipLegend] = pickStyle(mainLcwipStyle);
 
-  function loadFile(filename: string, text: string) {
+  let localAtfName = "local_atf_schemes";
+  let localAtfTitle = "Your ATF schemes";
+  let localAtfShow = showHideLayer(localAtfName);
+  let localAtfStyle = "fundingProgramme";
+  $: [localAtfColor, localAtfLegend] = pickStyle(localAtfStyle);
+
+  let localLcwipName = "local_lcwip_schemes";
+  let localLcwipTitle = "Your LCWIP schemes";
+  let localLcwipShow = showHideLayer(localLcwipName);
+  let localLcwipStyle = "interventionType";
+  $: [localLcwipColor, localLcwipLegend] = pickStyle(localLcwipStyle);
+
+  function loadMainFile(filename: string, text: string) {
     try {
-      setupSchemes(JSON.parse(text));
-      $atfShow = true;
-      $lcwipShow = true;
+      setupSchemes(JSON.parse(text), mainAtfSchemes, mainLcwipSchemes);
+      $mainAtfShow = true;
+      $mainLcwipShow = true;
       errorMessage = "";
     } catch (err) {
       errorMessage = `The file you loaded is broken: ${err}`;
     }
+  }
+
+  function importLocalSketches() {
+    setupSchemes(importAllLocalSketches(), localAtfSchemes, localLcwipSchemes);
+    $localAtfShow = true;
+    $localLcwipShow = true;
   }
 
   function pickStyle(
@@ -80,30 +104,27 @@
       return ["red", []];
     }
   }
-
-  function importFromSketch() {
-    setupSchemes(importAllLocalSketches());
-    $atfShow = true;
-    $lcwipShow = true;
-    errorMessage = "";
-  }
 </script>
 
 <CollapsibleCard label="Schemes" open>
   {#if appVersion() == "Private (development)"}
-    <LoadRemoteSchemeData {loadFile} />
+    <LoadRemoteSchemeData loadFile={loadMainFile} />
   {/if}
 
   <CheckboxGroup small>
-    {#if Object.entries($atfSchemesGj.schemes).length > 0}
-      <LayerControl name={atfName} title={atfTitle} bind:show={$atfShow}>
+    {#if Object.entries($mainAtfSchemes.schemes).length > 0}
+      <LayerControl
+        name={mainAtfName}
+        title={mainAtfTitle}
+        bind:show={$mainAtfShow}
+      >
         <span slot="help">
           <p>
             <WarningIcon text="Scheme data caveats" />Please note there are data
             quality caveats for all scheme data:
           </p>
           <ul>
-            {#each $atfSchemesGj.notes ?? [] as note}
+            {#each $mainAtfSchemes.notes ?? [] as note}
               <li><p>{note}</p></li>
             {/each}
           </ul>
@@ -112,9 +133,9 @@
         <div slot="controls" style="border: 1px solid black; padding: 8px;">
           <Filters
             source="ATF"
-            bind:schemesGj={$atfSchemesGj}
-            bind:filterSchemeText={$filterAtfSchemeText}
-            bind:filterInterventionText={$filterAtfInterventionText}
+            bind:schemesGj={$mainAtfSchemes}
+            bind:filterSchemeText={$filterMainAtfSchemeText}
+            bind:filterInterventionText={$filterMainAtfInterventionText}
           />
 
           <Select
@@ -124,22 +145,26 @@
               ["interventionType", "By intervention type"],
               ["currentMilestone", "By current milestone"],
             ]}
-            bind:value={atfStyle}
+            bind:value={mainAtfStyle}
           />
-          <Legend rows={atfLegend} />
+          <Legend rows={mainAtfLegend} />
         </div>
       </LayerControl>
     {/if}
 
-    {#if Object.entries($lcwipSchemesGj.schemes).length > 0}
-      <LayerControl name={lcwipName} title={lcwipTitle} bind:show={$lcwipShow}>
+    {#if Object.entries($mainLcwipSchemes.schemes).length > 0}
+      <LayerControl
+        name={mainLcwipName}
+        title={mainLcwipTitle}
+        bind:show={$mainLcwipShow}
+      >
         <span slot="help">
           <p>
             <WarningIcon text="Scheme data caveats" />Please note there are data
             quality caveats for all scheme data:
           </p>
           <ul>
-            {#each $lcwipSchemesGj.notes ?? [] as note}
+            {#each $mainLcwipSchemes.notes ?? [] as note}
               <li><p>{note}</p></li>
             {/each}
           </ul>
@@ -148,43 +173,144 @@
         <div slot="controls" style="border: 1px solid black; padding: 8px;">
           <Filters
             source="LCWIP"
-            bind:schemesGj={$lcwipSchemesGj}
-            bind:filterSchemeText={$filterLcwipSchemeText}
-            bind:filterInterventionText={$filterLcwipInterventionText}
+            bind:schemesGj={$mainLcwipSchemes}
+            bind:filterSchemeText={$filterMainLcwipSchemeText}
+            bind:filterInterventionText={$filterMainLcwipInterventionText}
           />
 
           <Select
             label="Colour interventions"
             choices={[["interventionType", "By intervention type"]]}
-            bind:value={lcwipStyle}
+            bind:value={mainLcwipStyle}
           />
-          <Legend rows={lcwipLegend} />
+          <Legend rows={mainLcwipLegend} />
         </div>
       </LayerControl>
     {/if}
   </CheckboxGroup>
 
-  <FileInput label="Load schemes from GeoJSON" onLoad={loadFile} />
+  <FileInput label="Load schemes from GeoJSON" onLoad={loadMainFile} />
   <ErrorMessage {errorMessage} />
 
-  <SecondaryButton on:click={importFromSketch}>
+  <hr />
+
+  <SecondaryButton on:click={importLocalSketches}>
     Show your sketches
   </SecondaryButton>
+
+  <CheckboxGroup small>
+    {#if Object.entries($localAtfSchemes.schemes).length > 0}
+      <LayerControl
+        name={localAtfName}
+        title={localAtfTitle}
+        bind:show={$localAtfShow}
+      >
+        <span slot="help">
+          <p>
+            <WarningIcon text="Scheme data caveats" />Please note there are data
+            quality caveats for all scheme data:
+          </p>
+          <ul>
+            {#each $localAtfSchemes.notes ?? [] as note}
+              <li><p>{note}</p></li>
+            {/each}
+          </ul>
+        </span>
+
+        <div slot="controls" style="border: 1px solid black; padding: 8px;">
+          <Filters
+            source="ATF"
+            bind:schemesGj={$localAtfSchemes}
+            bind:filterSchemeText={$filterLocalAtfSchemeText}
+            bind:filterInterventionText={$filterLocalAtfInterventionText}
+          />
+
+          <Select
+            label="Colour interventions"
+            choices={[
+              ["fundingProgramme", "By funding programme"],
+              ["interventionType", "By intervention type"],
+              ["currentMilestone", "By current milestone"],
+            ]}
+            bind:value={localAtfStyle}
+          />
+          <Legend rows={localAtfLegend} />
+        </div>
+      </LayerControl>
+    {/if}
+
+    {#if Object.entries($localLcwipSchemes.schemes).length > 0}
+      <LayerControl
+        name={localLcwipName}
+        title={localLcwipTitle}
+        bind:show={$localLcwipShow}
+      >
+        <span slot="help">
+          <p>
+            <WarningIcon text="Scheme data caveats" />Please note there are data
+            quality caveats for all scheme data:
+          </p>
+          <ul>
+            {#each $localLcwipSchemes.notes ?? [] as note}
+              <li><p>{note}</p></li>
+            {/each}
+          </ul>
+        </span>
+
+        <div slot="controls" style="border: 1px solid black; padding: 8px;">
+          <Filters
+            source="LCWIP"
+            bind:schemesGj={$localLcwipSchemes}
+            bind:filterSchemeText={$filterLocalLcwipSchemeText}
+            bind:filterInterventionText={$filterLocalLcwipInterventionText}
+          />
+
+          <Select
+            label="Colour interventions"
+            choices={[["interventionType", "By intervention type"]]}
+            bind:value={localLcwipStyle}
+          />
+          <Legend rows={localLcwipLegend} />
+        </div>
+      </LayerControl>
+    {/if}
+  </CheckboxGroup>
 </CollapsibleCard>
 
 <InterventionLayer
-  source="atf"
-  show={$atfShow}
-  schemesGj={$atfSchemesGj}
-  filterSchemeText={$filterAtfSchemeText}
-  filterInterventionText={$filterAtfInterventionText}
-  color={atfColor}
+  name="main_atf"
+  description={mainAtfTitle}
+  show={$mainAtfShow}
+  schemesGj={$mainAtfSchemes}
+  filterSchemeText={$filterMainAtfSchemeText}
+  filterInterventionText={$filterMainAtfInterventionText}
+  color={mainAtfColor}
 />
 <InterventionLayer
-  source="lcwip"
-  show={$lcwipShow}
-  schemesGj={$lcwipSchemesGj}
-  filterSchemeText={$filterLcwipSchemeText}
-  filterInterventionText={$filterLcwipInterventionText}
-  color={lcwipColor}
+  name="main_lcwip"
+  description={mainLcwipTitle}
+  show={$mainLcwipShow}
+  schemesGj={$mainLcwipSchemes}
+  filterSchemeText={$filterMainLcwipSchemeText}
+  filterInterventionText={$filterMainLcwipInterventionText}
+  color={mainLcwipColor}
+/>
+
+<InterventionLayer
+  name="local_atf"
+  description={localAtfTitle}
+  show={$localAtfShow}
+  schemesGj={$localAtfSchemes}
+  filterSchemeText={$filterLocalAtfSchemeText}
+  filterInterventionText={$filterLocalAtfInterventionText}
+  color={localAtfColor}
+/>
+<InterventionLayer
+  name="local_lcwip"
+  description={localLcwipTitle}
+  show={$localLcwipShow}
+  schemesGj={$localLcwipSchemes}
+  filterSchemeText={$filterLocalLcwipSchemeText}
+  filterInterventionText={$filterLocalLcwipInterventionText}
+  color={localLcwipColor}
 />

--- a/src/lib/browse/schemes/SchemesLayer.svelte
+++ b/src/lib/browse/schemes/SchemesLayer.svelte
@@ -13,9 +13,7 @@
   import Filters from "./Filters.svelte";
   import {
     atfSchemesGj,
-    atfSchemes,
     lcwipSchemesGj,
-    lcwipSchemes,
     filterAtfSchemeText,
     filterAtfInterventionText,
     filterLcwipSchemeText,
@@ -97,7 +95,7 @@
   {/if}
 
   <CheckboxGroup small>
-    {#if $atfSchemes.size > 0}
+    {#if Object.entries($atfSchemesGj.schemes).length > 0}
       <LayerControl name={atfName} title={atfTitle} bind:show={$atfShow}>
         <span slot="help">
           <p>
@@ -115,7 +113,6 @@
           <Filters
             source="ATF"
             bind:schemesGj={$atfSchemesGj}
-            bind:schemes={$atfSchemes}
             bind:filterSchemeText={$filterAtfSchemeText}
             bind:filterInterventionText={$filterAtfInterventionText}
           />
@@ -134,7 +131,7 @@
       </LayerControl>
     {/if}
 
-    {#if $lcwipSchemes.size > 0}
+    {#if Object.entries($lcwipSchemesGj.schemes).length > 0}
       <LayerControl name={lcwipName} title={lcwipTitle} bind:show={$lcwipShow}>
         <span slot="help">
           <p>
@@ -152,7 +149,6 @@
           <Filters
             source="LCWIP"
             bind:schemesGj={$lcwipSchemesGj}
-            bind:schemes={$lcwipSchemes}
             bind:filterSchemeText={$filterLcwipSchemeText}
             bind:filterInterventionText={$filterLcwipInterventionText}
           />
@@ -180,7 +176,6 @@
   source="atf"
   show={$atfShow}
   schemesGj={$atfSchemesGj}
-  schemes={$atfSchemes}
   filterSchemeText={$filterAtfSchemeText}
   filterInterventionText={$filterAtfInterventionText}
   color={atfColor}
@@ -189,7 +184,6 @@
   source="lcwip"
   show={$lcwipShow}
   schemesGj={$lcwipSchemesGj}
-  schemes={$lcwipSchemes}
   filterSchemeText={$filterLcwipSchemeText}
   filterInterventionText={$filterLcwipInterventionText}
   color={lcwipColor}

--- a/src/lib/browse/schemes/data.ts
+++ b/src/lib/browse/schemes/data.ts
@@ -1,9 +1,13 @@
 import type { Feature, Schemes } from "types";
-import { atfSchemesGj, lcwipSchemesGj } from "./stores";
+import type { Writable } from "svelte/store";
 
 // Takes a GeoJSON file representing a bunch of scheme files combined into one.
 // Populates the two stores for each of ATF and LCWIP schemes.
-export function setupSchemes(gj: Schemes) {
+export function setupSchemes(
+  gj: Schemes,
+  atfStore: Writable<Schemes>,
+  lcwipStore: Writable<Schemes>,
+) {
   let atfGj: Schemes = {
     type: "FeatureCollection",
     features: [],
@@ -52,8 +56,8 @@ export function setupSchemes(gj: Schemes) {
     gj.features.push(feature);
   }
 
-  atfSchemesGj.set(atfGj);
-  lcwipSchemesGj.set(lcwipGj);
+  atfStore.set(atfGj);
+  lcwipStore.set(lcwipGj);
 }
 
 // These should ideally be fixed during upstream data validation processes.

--- a/src/lib/browse/schemes/data.ts
+++ b/src/lib/browse/schemes/data.ts
@@ -110,6 +110,7 @@ export function importAllLocalSketches(): Schemes {
       for (let scheme of Object.values(gj.schemes)) {
         scheme.browse = {
           authority_or_region: parts[1],
+          local_filename: parts[2],
         };
       }
 

--- a/src/lib/browse/schemes/stores.ts
+++ b/src/lib/browse/schemes/stores.ts
@@ -1,5 +1,5 @@
 import { writable, type Writable } from "svelte/store";
-import type { Schemes, SchemeData } from "types";
+import type { Schemes } from "types";
 
 // TODO Bundle this into one type, so it's easier to plumb around
 export const atfSchemesGj: Writable<Schemes> = writable({
@@ -7,9 +7,6 @@ export const atfSchemesGj: Writable<Schemes> = writable({
   features: [],
   schemes: {},
 });
-export const atfSchemes: Writable<Map<string, SchemeData>> = writable(
-  new Map(),
-);
 export const filterAtfInterventionText: Writable<string> = writable("");
 export const filterAtfSchemeText: Writable<string> = writable("");
 
@@ -18,8 +15,5 @@ export const lcwipSchemesGj: Writable<Schemes> = writable({
   features: [],
   schemes: {},
 });
-export const lcwipSchemes: Writable<Map<string, SchemeData>> = writable(
-  new Map(),
-);
 export const filterLcwipInterventionText: Writable<string> = writable("");
 export const filterLcwipSchemeText: Writable<string> = writable("");

--- a/src/lib/browse/schemes/stores.ts
+++ b/src/lib/browse/schemes/stores.ts
@@ -1,19 +1,37 @@
 import { writable, type Writable } from "svelte/store";
 import type { Schemes } from "types";
 
-// TODO Bundle this into one type, so it's easier to plumb around
-export const atfSchemesGj: Writable<Schemes> = writable({
-  type: "FeatureCollection",
-  features: [],
-  schemes: {},
-});
-export const filterAtfInterventionText: Writable<string> = writable("");
-export const filterAtfSchemeText: Writable<string> = writable("");
+// There are four variations -- main and local ATF and LCWIP schemes
 
-export const lcwipSchemesGj: Writable<Schemes> = writable({
+// TODO Bundle this into one type, so it's easier to plumb around
+export const mainAtfSchemes: Writable<Schemes> = writable({
   type: "FeatureCollection",
   features: [],
   schemes: {},
 });
-export const filterLcwipInterventionText: Writable<string> = writable("");
-export const filterLcwipSchemeText: Writable<string> = writable("");
+export const filterMainAtfInterventionText: Writable<string> = writable("");
+export const filterMainAtfSchemeText: Writable<string> = writable("");
+
+export const mainLcwipSchemes: Writable<Schemes> = writable({
+  type: "FeatureCollection",
+  features: [],
+  schemes: {},
+});
+export const filterMainLcwipInterventionText: Writable<string> = writable("");
+export const filterMainLcwipSchemeText: Writable<string> = writable("");
+
+export const localAtfSchemes: Writable<Schemes> = writable({
+  type: "FeatureCollection",
+  features: [],
+  schemes: {},
+});
+export const filterLocalAtfInterventionText: Writable<string> = writable("");
+export const filterLocalAtfSchemeText: Writable<string> = writable("");
+
+export const localLcwipSchemes: Writable<Schemes> = writable({
+  type: "FeatureCollection",
+  features: [],
+  schemes: {},
+});
+export const filterLocalLcwipInterventionText: Writable<string> = writable("");
+export const filterLocalLcwipSchemeText: Writable<string> = writable("");

--- a/src/lib/maplibre/zorder.ts
+++ b/src/lib/maplibre/zorder.ts
@@ -68,26 +68,39 @@ export let layerZorder = [
   // This is an outline, so draw on top
   sketch("hover-polygons"),
 
-  browse("atf-interventions-polygons"),
-  browse("lcwip-interventions-polygons"),
-  browse("atf-interventions-polygons-outlines"),
-  browse("lcwip-interventions-polygons-outlines"),
+  browse("main_atf-interventions-polygons"),
+  browse("main_lcwip-interventions-polygons"),
+  browse("main_atf-interventions-polygons-outlines"),
+  browse("main_lcwip-interventions-polygons-outlines"),
+
+  browse("local_atf-interventions-polygons"),
+  browse("local_lcwip-interventions-polygons"),
+  browse("local_atf-interventions-polygons-outlines"),
+  browse("local_lcwip-interventions-polygons-outlines"),
 
   // The hover effect thickens, so draw beneath
   sketch("hover-lines"),
   sketch("interventions-lines"),
   sketch("interventions-lines-endpoints"),
 
-  browse("atf-interventions-lines"),
-  browse("lcwip-interventions-lines"),
-  browse("atf-interventions-lines-endpoints"),
-  browse("lcwip-interventions-lines-endpoints"),
+  browse("main_atf-interventions-lines"),
+  browse("main_lcwip-interventions-lines"),
+  browse("main_atf-interventions-lines-endpoints"),
+  browse("main_lcwip-interventions-lines-endpoints"),
+
+  browse("local_atf-interventions-lines"),
+  browse("local_lcwip-interventions-lines"),
+  browse("local_atf-interventions-lines-endpoints"),
+  browse("local_lcwip-interventions-lines-endpoints"),
 
   sketch("hover-points"),
   sketch("interventions-points"),
 
-  browse("atf-interventions-points"),
-  browse("lcwip-interventions-points"),
+  browse("main_atf-interventions-points"),
+  browse("main_lcwip-interventions-points"),
+
+  browse("local_atf-interventions-points"),
+  browse("local_lcwip-interventions-points"),
 
   // Problem points are one layer that should display on top of scheme data
   browse("problems"),

--- a/src/pages/BrowseSchemes.svelte
+++ b/src/pages/BrowseSchemes.svelte
@@ -5,7 +5,7 @@
   import ActiveLayersLegend from "lib/browse/layers/ActiveLayersLegend.svelte";
   import "../style/main.css";
   import { controls } from "lib/browse/stores";
-  import { atfSchemesGj } from "lib/browse/schemes/stores";
+  import { mainAtfSchemes } from "lib/browse/schemes/stores";
   import {
     Geocoder,
     Layout,
@@ -50,7 +50,7 @@
 
     <div style="display: flex; justify-content: space-between">
       <h1>Scheme Browser</h1>
-      <ZoomOutMap boundaryGeojson={$atfSchemesGj} />
+      <ZoomOutMap boundaryGeojson={$mainAtfSchemes} />
     </div>
 
     <div bind:this={sidebarDiv} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,8 @@ export interface BrowseSchemeData {
   capital_scheme_id?: string;
   funding_programme?: string;
   current_milestone?: string;
+  // If this scheme was imported from local storage, track the original filename
+  local_filename?: string;
 }
 
 export type PipelineType =

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,10 +79,9 @@ export interface FundingSources {
 
 export interface BrowseSchemeData {
   authority_or_region: string;
-  capital_scheme_id: string;
-  funding_programme: string;
+  capital_scheme_id?: string;
+  funding_programme?: string;
   current_milestone?: string;
-  sketch_source: "ATF assessment" | "LCWIP mapping";
 }
 
 export type PipelineType =


### PR DESCRIPTION
This PR adapts the ideas in https://github.com/acteng/atip/tree/show-local-sketches-browse-page. The browse page has new controls to import all local sketches as new layers. The user can then jump to the sketch tool and edit one of those sketches.

Demo: https://acteng.github.io/atip/ss_sb_integration

Design decisions I'm not entirely sure about:
- The phrasing generally. "Your ATF/LCWIP schemes"? I started to use "local", but that word is very overloaded.
- Should we have layers for both "your ATF" and "your LCWIP", or just one "your sketches" layer? The reasons for splitting them for the main data may not make as much sense for the (presumably small) amount of local sketches.
- Can the filters be cleaned up for local ATF data? We won't ever have funding programme or milestone info, because there's no join with external data for local sketches.
- When editing a file from browse, if it comes from the main data, you edit a _copy_. If it comes from locally, you edit the local file. That local file might have multiple schemes, even though you only selected one from browse.