### PR TITLE
Allow some currently unexpected values

### DIFF
--- a/src/lib/sketch/config.ts
+++ b/src/lib/sketch/config.ts
@@ -288,6 +288,8 @@ export function getUnexpectedProperties(props: { [name: string]: any }): {
     "hide_while_editing",
     "is_coverage_polygon",
     "scheme_reference",
+    "full_path",
+    "route_name",
   ]) {
     delete copy[key];
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/42a15b4f-6f63-46d0-973d-a6f281f379d0)
So currently if you make an area using scheme sketcher lib, it ends up with a bunch of disallowed values, as a stop gap, especially for the tutorial, I suggest we just allow them, and figure this out upstream later