### PR TITLE
Adjust crossings layer, adding unknown signalised category. #480

### DIFF
--- a/src/lib/browse/layers/points/Crossings.svelte
+++ b/src/lib/browse/layers/points/Crossings.svelte
@@ -41,6 +41,7 @@
     ["Toucan", "#87C55F"],
     ["Pegasus", "#9EB9F3"],
     ["Uncontrolled", "#FE88B1"],
+    ["Signalised", "#C9DB74"],
     ["Unknown", "red"],
   ];
 </script>


### PR DESCRIPTION
Two fixes, both thanks to @rskedgell:

- Detect more parallel crossings (example by `#19.63/51.541493/-0.0113397`)
- Add an unknown signalised category (example by `#18.8/51.5464977/-0.0011429`)

Pete, please update using http://atip.uk/layers/v1/crossings.pmtiles, new md5sum is 281cfa9eeafd445d4de523d73b12575b