### PR TITLE
Adding querystring to local storage on browse page to store "layer session" 

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -74,6 +74,7 @@
     },
   };
 
+  // Before any individual layers check the URL state for their initial setup, restore the query parameters to whatever was saved last time. If there are already query parameters besides the basemap style, then keep them.
   const initialQueryParams = new URLSearchParams(window.location.search);
 
   if (
@@ -85,14 +86,15 @@
     const previousSessionQueryString =
       window.localStorage.getItem(localStorageQuerystringKey) || "";
     const newQueryParams = new URLSearchParams(previousSessionQueryString);
-    // @ts-ignore typescript is convinced foreach doesn't exist but it's working?
-    newQueryParams.entries().forEach(([key, value]) => {
+    for (const entry in newQueryParams.entries) {
+      const key = entry[0];
+      const value = entry[1];
       if (value == null) {
         url.searchParams.delete(key);
       } else {
         url.searchParams.set(key, value);
       }
-    });
+    }
     window.history.replaceState(null, "", url.toString());
   }
 </script>

--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -86,9 +86,7 @@
     const previousSessionQueryString =
       window.localStorage.getItem(localStorageQuerystringKey) || "";
     const newQueryParams = new URLSearchParams(previousSessionQueryString);
-    for (const entry in newQueryParams.entries) {
-      const key = entry[0];
-      const value = entry[1];
+    for (const [key, value] of newQueryParams) {
       if (value == null) {
         url.searchParams.delete(key);
       } else {

--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -46,6 +46,7 @@
   // Workaround for https://github.com/sveltejs/svelte/issues/7630
   $: streetviewEnabled = !$interactiveMapLayersEnabled;
   $: interactiveMapLayersEnabled.set(!streetviewEnabled);
+  const localStorageQuerystringKey = "browsepage-querystring";
 
   // When StreetView is on, disable interactive layers -- no hovering or
   // clicking behavior. Achieve this by enabling an invisible layer on top of
@@ -72,6 +73,28 @@
       return getRoadLayerNames(map, get(mapStyle));
     },
   };
+
+  const initialQueryParams = new URLSearchParams(window.location.search);
+
+  if (
+    !initialQueryParams ||
+    (initialQueryParams.size === 1 &&
+      initialQueryParams.keys().next().value == "style")
+  ) {
+    let url = new URL(window.location.href);
+    const previousSessionQueryString =
+      window.localStorage.getItem(localStorageQuerystringKey) || "";
+    const newQueryParams = new URLSearchParams(previousSessionQueryString);
+    // @ts-ignore typescript is convinced foreach doesn't exist but it's working?
+    newQueryParams.entries().forEach(([key, value]) => {
+      if (value == null) {
+        url.searchParams.delete(key);
+      } else {
+        url.searchParams.set(key, value);
+      }
+    });
+    window.history.replaceState(null, "", url.toString());
+  }
 </script>
 
 <div bind:this={$controls}>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -53,16 +53,10 @@
   }
 
   function label(pollutant: string): string {
-    if (info === undefined) {
-      return "";
-    }
     return info![1];
   }
 
   function tilesUrl(pollutant: string): string {
-    if (info === undefined) {
-      return "";
-    }
     let params = new URLSearchParams({
       request: "GetMap",
       version: "1.3.0",
@@ -78,9 +72,6 @@
   }
 
   function legendUrl(pollutant: string): string {
-    if (info === undefined) {
-      return "";
-    }
     let params = new URLSearchParams({
       request: "GetLegendGraphic",
       version: "1.3.0",

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -53,10 +53,16 @@
   }
 
   function label(pollutant: string): string {
+    if (info === undefined) {
+      return "";
+    }
     return info![1];
   }
 
   function tilesUrl(pollutant: string): string {
+    if (info === undefined) {
+      return "";
+    }
     let params = new URLSearchParams({
       request: "GetMap",
       version: "1.3.0",
@@ -72,6 +78,9 @@
   }
 
   function legendUrl(pollutant: string): string {
+    if (info === undefined) {
+      return "";
+    }
     let params = new URLSearchParams({
       request: "GetLegendGraphic",
       version: "1.3.0",

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -1,5 +1,7 @@
 import { writable, type Writable } from "svelte/store";
 
+const localStorageKey = "browsepage-querystring";
+
 // Create a store to represent whether a layer should be shown or hidden. The
 // state is synced as a URL query parameter.
 export function showHideLayer(name: string): Writable<boolean> {
@@ -50,6 +52,7 @@ export function customUrlState<T>(
       url.searchParams.set(name, value);
     }
     window.history.replaceState(null, "", url.toString());
+    window.localStorage.setItem(localStorageKey, url.searchParams.toString());
   });
   return store;
 }

--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -16,6 +16,7 @@ export function showHideLayer(name: string): Writable<boolean> {
       url.searchParams.delete(name);
     }
     window.history.replaceState(null, "", url.toString());
+    window.localStorage.setItem(localStorageKey, url.searchParams.toString());
   });
   return store;
 }


### PR DESCRIPTION
…session can be resumed by default

Seems to  be working mostly okay except public transport layers don't work. will investigate but putting it up so you can see my approach and test it out