### PR TITLE
Disable the pollution layer. #490

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -13,7 +13,6 @@
   import LocalAuthorityDistrictsLayerControl from "./layers/areas/LocalAuthorityDistricts.svelte";
   import LocalPlanningAuthoritiesLayerControl from "./layers/areas/LocalPlanningAuthorities.svelte";
   import ParliamentaryConstituenciesLayerControl from "./layers/areas/ParliamentaryConstituencies.svelte";
-  import PollutionLayerControl from "./layers/areas/Pollution.svelte";
   import RoadNoiseLayerControl from "./layers/areas/RoadNoise.svelte";
   import RuralUrbanLayerControl from "./layers/areas/RuralUrban.svelte";
   import WardsLayerControl from "./layers/areas/Wards.svelte";
@@ -136,7 +135,6 @@
         <RoadSpeedsLayerControl />
         <ProblemsLayerControl />
       {/if}
-      <PollutionLayerControl />
       <RoadNoiseLayerControl />
       <UserDataLayerControl />
     </CheckboxGroup>

--- a/src/lib/browse/layers/areas/Pollution.svelte
+++ b/src/lib/browse/layers/areas/Pollution.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // TODO Disabled due to CORS
   import { Select } from "govuk-svelte";
   import { ExternalLink } from "lib/common";
   import { layerId } from "lib/maplibre";


### PR DESCRIPTION
Broke everywhere due to DEFRA starting to enforce CORS. This layer has always had problems, #490, so our resolution should really be to track down the raw data, so we can process + host + display ourselves, like we do for road noise.