### PR TITLE
Add OSM basemap style

### DIFF
--- a/src/lib/maplibre/highlight_roads.ts
+++ b/src/lib/maplibre/highlight_roads.ts
@@ -51,6 +51,18 @@ export function getRoadLayerNames(map: Map, mapStyle: string): string[] {
       )
       .map((layer) => layer.id);
   }
+  if (mapStyle == "openstreetmap") {
+    return map
+      .getStyle()
+      .layers.filter(
+        (layer) =>
+          // @ts-expect-error source-layer is present
+          layer["source-layer"] == "transportation" &&
+          layer.type == "line" &&
+          !layer.id.endsWith(" outline"),
+      )
+      .map((layer) => layer.id);
+  }
 
   // OS and Bluesky raster layers don't have anything we can use
   return [];

--- a/src/lib/maplibre/styles.ts
+++ b/src/lib/maplibre/styles.ts
@@ -19,6 +19,7 @@ export function getStyleChoices(): [string, string][] {
     ["hybrid", "MapTiler Satellite"],
     ["dataviz", "MapTiler Dataviz"],
     ["uk-openzoomstack-light", "OS Open Zoomstack"],
+    ["openstreetmap", "OpenStreetMap"],
   ]);
 }
 
@@ -32,7 +33,8 @@ export async function getStyleSpecification(
     style == "streets" ||
     style == "hybrid" ||
     style == "dataviz" ||
-    style == "uk-openzoomstack-light"
+    style == "uk-openzoomstack-light" ||
+    style == "openstreetmap"
   ) {
     attributionStore.set("&copy; MapTiler &copy; OpenStreetMap contributors");
     return `https://api.maptiler.com/maps/${style}/style.json?key=${


### PR DESCRIPTION
I somehow missed that MapTiler has managed to adapt the super-detailed OSM "carto" style from the main page into vector tiles. I think it's a very useful basemap for some use cases on the browse page, so make it an option.

Demo https://acteng.github.io/atip/carto_basemap/browse.html?style=openstreetmap