### PR TITLE
When the user initially uses ?disable_remote_schemes and then later loads the schemes, fix up the URL

### DIFF
--- a/src/lib/browse/layers/url.ts
+++ b/src/lib/browse/layers/url.ts
@@ -1,6 +1,5 @@
 import { writable, type Writable } from "svelte/store";
-
-const localStorageKey = "browsepage-querystring";
+import { changeUrlQueryParams } from "../stores";
 
 // Create a store to represent whether a layer should be shown or hidden. The
 // state is synced as a URL query parameter.
@@ -15,8 +14,7 @@ export function showHideLayer(name: string): Writable<boolean> {
     } else {
       url.searchParams.delete(name);
     }
-    window.history.replaceState(null, "", url.toString());
-    window.localStorage.setItem(localStorageKey, url.searchParams.toString());
+    changeUrlQueryParams(url);
   });
   return store;
 }
@@ -52,8 +50,7 @@ export function customUrlState<T>(
     } else {
       url.searchParams.set(name, value);
     }
-    window.history.replaceState(null, "", url.toString());
-    window.localStorage.setItem(localStorageKey, url.searchParams.toString());
+    changeUrlQueryParams(url);
   });
   return store;
 }

--- a/src/lib/browse/schemes/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/schemes/LoadRemoteSchemeData.svelte
@@ -2,6 +2,7 @@
   import { SecondaryButton } from "govuk-svelte";
   import { fetchWithProgress, privateResourceBaseUrl } from "lib/common";
   import { onMount } from "svelte";
+  import { changeUrlQueryParams } from "../stores";
 
   export let loadFile: (filename: string, text: string) => void;
 
@@ -37,11 +38,7 @@
     // Remove the URL parameter that originally disabled this
     let url = new URL(window.location.href);
     url.searchParams.delete("disable_schemes");
-    window.history.replaceState(null, "", url.toString());
-    window.localStorage.setItem(
-      "browsepage-querystring",
-      url.searchParams.toString(),
-    );
+    changeUrlQueryParams(url);
   }
 </script>
 

--- a/src/lib/browse/schemes/LoadRemoteSchemeData.svelte
+++ b/src/lib/browse/schemes/LoadRemoteSchemeData.svelte
@@ -33,6 +33,15 @@
   async function loadDataManually() {
     shouldLoad = true;
     await loadData();
+
+    // Remove the URL parameter that originally disabled this
+    let url = new URL(window.location.href);
+    url.searchParams.delete("disable_schemes");
+    window.history.replaceState(null, "", url.toString());
+    window.localStorage.setItem(
+      "browsepage-querystring",
+      url.searchParams.toString(),
+    );
   }
 </script>
 

--- a/src/lib/browse/stores.ts
+++ b/src/lib/browse/stores.ts
@@ -2,3 +2,14 @@ import { writable, type Writable } from "svelte/store";
 
 export const interactiveMapLayersEnabled: Writable<boolean> = writable(true);
 export let controls: Writable<HTMLDivElement | null> = writable(null);
+
+// After modifying URL query parameters, this will both change the URL in
+// browser history and remember it as the last browse page setting.
+export function changeUrlQueryParams(url: URL) {
+  window.history.replaceState(null, "", url.toString());
+
+  window.localStorage.setItem(
+    "browsepage-querystring",
+    url.searchParams.toString(),
+  );
+}

--- a/src/lib/common/MapLibreMap.svelte
+++ b/src/lib/common/MapLibreMap.svelte
@@ -52,6 +52,7 @@
     let url = new URL(window.location.href);
     url.searchParams.set("style", newStyle);
     window.history.replaceState(null, "", url.toString());
+    // Note this isn't stored in cached browse page params
   }
   $: changeStyle(style);
 


### PR DESCRIPTION
More noticeable now that we save the query string!

To verify this works, go to `browse.html?disable_remote_schemes` initially, then "load latest scheme data", verify the URL changes. Go to `browse.html` with no params and verify schemes do load. (If you're testing locally, for the remote schemes to show up at all, follow the dev guide instructions for VITE_MIMIC_GCP_LOCALLY)