### PR TITLE
Upgrade node from 18 to 22

### DIFF
--- a/.github/workflows/deploy_private_dev.yml
+++ b/.github/workflows/deploy_private_dev.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install wasm-pack

--- a/.github/workflows/deploy_private_test.yml
+++ b/.github/workflows/deploy_private_test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install wasm-pack

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: 'npm'
 
     - name: Install wasm-pack

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install wasm-pack
@@ -26,7 +26,7 @@ jobs:
       - name: Build all branches
         run: |
           mkdir deployme
-          for branch in $(git branch -r | sed 's/origin\///' | grep -v nobuild_); do
+          for branch in $(git branch -r | sed 's/origin\///' | grep -v nobuild_ | grep -v 'HEAD -> origin/main'); do
             if [ "$branch" == "gh-pages" ]; then
               continue
             fi

--- a/backend/app_private_dev.yaml
+++ b/backend/app_private_dev.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 env_variables:
   GCS_BUCKET: "dft-rlg-atip-dev"
   PROJECT_NUMBER: "537912455420"

--- a/backend/app_private_test.yaml
+++ b/backend/app_private_test.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 env_variables:
   GCS_BUCKET: "dft-rlg-atip-test"
   PROJECT_NUMBER: "306057427889"

--- a/backend/app_public_dev.yaml
+++ b/backend/app_public_dev.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 env_variables:
   GCS_BUCKET: "dft-rlg-schemes-gis-dev"
   PROJECT_NUMBER: "239567674839"

--- a/backend/app_public_prod.yaml
+++ b/backend/app_public_prod.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 env_variables:
   GCS_BUCKET: "dft-rlg-schemes-gis-prod"
   PROJECT_NUMBER: "1042091002892"


### PR DESCRIPTION
18 is deprecated and end-of-life in a few months of appengine. I've been running 22 on my local development machine for ages, so I don't expect anything to not work, but will let tests + the auto-deploy to test environments reveal any problems.

Also includes the #584 fix to have any hope of building