### PR TITLE
Update to maptiler streets-v2 style

### DIFF
--- a/src/lib/maplibre/styles.ts
+++ b/src/lib/maplibre/styles.ts
@@ -36,8 +36,11 @@ export async function getStyleSpecification(
     style == "uk-openzoomstack-light" ||
     style == "openstreetmap"
   ) {
+    // For backwards compatibility, map the old URL query parameter to the new URL
+    let styleName = style == "streets" ? "streets-v2" : style;
+
     attributionStore.set("&copy; MapTiler &copy; OpenStreetMap contributors");
-    return `https://api.maptiler.com/maps/${style}/style.json?key=${
+    return `https://api.maptiler.com/maps/${styleName}/style.json?key=${
       import.meta.env.VITE_MAPTILER_API_KEY
     }`;
   }


### PR DESCRIPTION
There's been a new version of this style for a while; the old is deprecated. I've preserved the URL query parameters.