### PR TITLE
Add a browse layer for existing OSM cycle routes

### DIFF
--- a/src/lib/browse/LayerControls.svelte
+++ b/src/lib/browse/LayerControls.svelte
@@ -18,6 +18,7 @@
   import WardsLayerControl from "./layers/areas/Wards.svelte";
   import BusRoutesLayerControl from "./layers/lines/BusRoutes.svelte";
   import CyclePathsLayerControl from "./layers/lines/CyclePaths.svelte";
+  import CycleRoutesLayerControl from "./layers/lines/CycleRoutes.svelte";
   import GradientsLayerControl from "./layers/lines/Gradients.svelte";
   import MajorRoadNetworkLayerControl from "./layers/lines/MajorRoadNetwork.svelte";
   import NationalCycleNetworkLayerControl from "./layers/lines/NationalCycleNetwork.svelte";
@@ -111,6 +112,7 @@
   <CollapsibleCard label="Existing infrastructure">
     <CheckboxGroup small>
       <CyclePathsLayerControl />
+      <CycleRoutesLayerControl />
       <NationalCycleNetworkLayerControl />
       <MajorRoadNetworkLayerControl />
       <StrategicRoadNetworkLayerControl />

--- a/src/lib/browse/colors.ts
+++ b/src/lib/browse/colors.ts
@@ -17,6 +17,7 @@ export const colors = {
   combined_authorities: "cyan",
   local_authority_districts: "orange",
   local_planning_authorities: "red",
+  cycle_route: "green",
   bus_route_with_lane: "#9362BA",
   bus_route_without_lane: "#C2A6D8",
   trams: "black",

--- a/src/lib/browse/layers/lines/CycleRoutes.svelte
+++ b/src/lib/browse/layers/lines/CycleRoutes.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { ColorLegend, ExternalLink, publicResourceBaseUrl } from "lib/common";
+  import { layerId } from "lib/maplibre";
+  import { LineLayer, VectorTileSource } from "svelte-maplibre";
+  import { colors } from "../../colors";
+  import LayerControl from "../LayerControl.svelte";
+  import OsmLicense from "../OsmLicense.svelte";
+  import { showHideLayer } from "../url";
+
+  let name = "cycle_routes";
+  let title = "Cycle routes";
+
+  let show = showHideLayer(name);
+</script>
+
+<LayerControl {name} {title} bind:show={$show}>
+  <span slot="icon"><ColorLegend color={colors.cycle_route} /></span>
+  <span slot="help">
+    <p>
+      This shows all roads with at least one cycle route crossing them,
+      according to <ExternalLink
+        href="https://wiki.openstreetmap.org/wiki/Tag:route%3Dbicycle"
+      >
+        OpenStreetMap
+      </ExternalLink> (as of 20 October 2024). The quality of the route or infrastructure
+      along it is not shown here.
+    </p>
+    <OsmLicense />
+  </span>
+</LayerControl>
+
+<VectorTileSource
+  url={`pmtiles://${publicResourceBaseUrl()}/v1/${name}.pmtiles`}
+>
+  <LineLayer
+    {...layerId(name)}
+    sourceLayer={name}
+    paint={{
+      "line-color": colors.cycle_route,
+      "line-width": 8,
+    }}
+    layout={{
+      visibility: $show ? "visible" : "none",
+    }}
+  />
+</VectorTileSource>

--- a/src/lib/maplibre/zorder.ts
+++ b/src/lib/maplibre/zorder.ts
@@ -44,6 +44,7 @@ export let layerZorder = [
   browse("mrn"),
   browse("srn"),
   browse("bus_routes"),
+  browse("cycle_routes"),
   browse("trams"),
   browse("national_cycle_network"),
   browse("cycle_paths"),


### PR DESCRIPTION
Demo: https://acteng.github.io/atip/osm_routes/browse.html?cycle_routes=1#16.16/51.494749/-0.100203

I'm not sure why I never thought to include this. OSM has named cycle routes, modeled as relations. I think it's quite illustrative to look at these alongside the existing "cycle paths" layer, which should maybe be rephrased as "Cycle infrastructure". Compare the more semantic routes:
![image](https://github.com/user-attachments/assets/6350a573-f185-4dc0-80da-b314deb2b52d)
with the actual infrastructure making them:
![image](https://github.com/user-attachments/assets/cd729958-8502-4d0d-9e8f-a9c9d9b19635)

Not sure it's visible easily in the screenshot, but Elliot's Row is an example where it's part of one logical route, but it's just a quiet residential street; there's no physical infrastructure there.

Note I'd love to let people click the routes and open in OSM, like https://www.openstreetmap.org/relation/11739129. But that'd require doing our own work to stitch together the linestring geometry from the relation, and I'm just getting a quick thing started over in data-prep.