### PR TITLE
Include more detail about existing OSM cycle routes

### DIFF
--- a/src/lib/browse/layers/lines/CycleRoutes.svelte
+++ b/src/lib/browse/layers/lines/CycleRoutes.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
-  import { ColorLegend, ExternalLink, publicResourceBaseUrl } from "lib/common";
+  import {
+    ColorLegend,
+    ExternalLink,
+    Popup,
+    publicResourceBaseUrl,
+  } from "lib/common";
   import { layerId } from "lib/maplibre";
-  import { LineLayer, VectorTileSource } from "svelte-maplibre";
+  import {
+    hoverStateFilter,
+    LineLayer,
+    VectorTileSource,
+    type LayerClickInfo,
+  } from "svelte-maplibre";
   import { colors } from "../../colors";
   import LayerControl from "../LayerControl.svelte";
   import OsmLicense from "../OsmLicense.svelte";
@@ -11,19 +21,26 @@
   let title = "Cycle routes";
 
   let show = showHideLayer(name);
+
+  function onClick(e: CustomEvent<LayerClickInfo>) {
+    window.open(
+      `http://openstreetmap.org/relation/${e.detail.features[0].properties!.osm_relation}`,
+      "_blank",
+    );
+  }
 </script>
 
 <LayerControl {name} {title} bind:show={$show}>
   <span slot="icon"><ColorLegend color={colors.cycle_route} /></span>
   <span slot="help">
     <p>
-      This shows all roads with at least one cycle route crossing them,
-      according to <ExternalLink
+      This shows all cycle routes, according to <ExternalLink
         href="https://wiki.openstreetmap.org/wiki/Tag:route%3Dbicycle"
       >
         OpenStreetMap
       </ExternalLink> (as of 20 October 2024). The quality of the route or infrastructure
-      along it is not shown here.
+      along it is not shown here. Not all routes are official, named routes -- click
+      one to see more information.
     </p>
     <OsmLicense />
   </span>
@@ -36,11 +53,17 @@
     {...layerId(name)}
     sourceLayer={name}
     paint={{
-      "line-color": colors.cycle_route,
+      "line-color": hoverStateFilter(colors.cycle_route, "red"),
       "line-width": 8,
     }}
     layout={{
       visibility: $show ? "visible" : "none",
     }}
-  />
+    manageHoverState
+    eventsIfTopMost
+    hoverCursor="pointer"
+    on:click={onClick}
+  >
+    <Popup let:props>{props.name || "untitled route"}</Popup>
+  </LineLayer>
 </VectorTileSource>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a635d314-1e61-4692-afec-1194b34872fd)
Needs https://github.com/acteng/atip-data-prep/pull/70 GCS updating there first